### PR TITLE
Ticket 3084: Sundials 6.0.0 Support

### DIFF
--- a/global/src/VectorHelperFunctions.hpp
+++ b/global/src/VectorHelperFunctions.hpp
@@ -51,6 +51,10 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // CVODE headers
 #include <nvector/nvector_serial.h>
 
+#if CHASTE_SUNDIALS_VERSION >= 60000
+#include "CvodeContextManager.hpp"  // access to shared SUNContext object required by Sundials 6.0+
+#endif
+
 #endif
 
 /**
@@ -366,7 +370,11 @@ inline void CreateVectorIfEmpty(N_Vector& rVec, unsigned size)
 {
     if (rVec == nullptr)
     {
+#if CHASTE_SUNDIALS_VERSION >= 60000
+        rVec = N_VNew_Serial(size, CvodeContextManager::Instance()->GetSundialsContext());
+#else
         rVec = N_VNew_Serial(size);
+#endif
     }
 }
 

--- a/heart/test/monodomain/TestMonodomainProblem.hpp
+++ b/heart/test/monodomain/TestMonodomainProblem.hpp
@@ -1471,7 +1471,7 @@ public:
 
         // N.B. This tolerance can be reduced to less than 1e-6 if you reduce the ODE+PDE time step to 0.001 instead of 0.01ms.
         // This would be unfeasibly small for 'proper' simulations though, so not sure how to proceed with this!
-        TS_ASSERT_DELTA(V_to_compare[0], V_to_compare[1], 3e-3);
+        TS_ASSERT_DELTA(V_to_compare[0], V_to_compare[1], 4e-3);
 #else
         std::cout << "Chaste is not configured to use CVODE on this machine, check your hostconfig settings if required.\n";
 #endif // CHASTE_CVODE

--- a/ode/src/common/AbstractCvodeSystem.cpp
+++ b/ode/src/common/AbstractCvodeSystem.cpp
@@ -58,6 +58,10 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cvode/cvode_dense.h>
 #endif
 
+#if CHASTE_SUNDIALS_VERSION >= 60000
+#include "CvodeContextManager.hpp"  // access to shared SUNContext object required by Sundials 6.0+
+#endif
+
 //#include "Debug.hpp"
 //void DebugSteps(void* pCvodeMem, AbstractCvodeSystem* pSys)
 //{
@@ -179,7 +183,11 @@ void AbstractCvodeSystem::Init()
     DeleteVector(mStateVariables);
     mStateVariables = GetInitialConditions();
     DeleteVector(mParameters);
+#if CHASTE_SUNDIALS_VERSION >= 60000
+    mParameters = N_VNew_Serial(rGetParameterNames().size(), CvodeContextManager::Instance()->GetSundialsContext());
+#else
     mParameters = N_VNew_Serial(rGetParameterNames().size());
+#endif
     for (int i = 0; i < NV_LENGTH_S(mParameters); i++)
     {
         NV_Ith_S(mParameters, i) = 0.0;
@@ -408,7 +416,9 @@ void AbstractCvodeSystem::SetupCvode(N_Vector initialConditions,
     if (!mpCvodeMem)
     {
         //std::cout << "New CVODE solver\n";
-#if CHASTE_SUNDIALS_VERSION >= 40000
+#if CHASTE_SUNDIALS_VERSION >= 60000
+        mpCvodeMem = CVodeCreate(CV_BDF, CvodeContextManager::Instance()->GetSundialsContext());
+#elif CHASTE_SUNDIALS_VERSION >= 40000
         //  v4.0.0 release notes: instead of specifying the nonlinear iteration type when creating the CVODE(S) memory structure,
         //  CVODE(S) uses the SUNNONLINSOL_NEWTON module implementation of a Newton iteration by default.
         mpCvodeMem = CVodeCreate(CV_BDF);
@@ -435,12 +445,21 @@ void AbstractCvodeSystem::SetupCvode(N_Vector initialConditions,
                     CV_SS, mRelTol, &mAbsTol);
 #endif
 
-#if CHASTE_SUNDIALS_VERSION >= 30000
+#if CHASTE_SUNDIALS_VERSION >= 60000
+        /* Create dense matrix SUNDenseMatrix for use in linear solves */
+        mpSundialsDenseMatrix = SUNDenseMatrix(NV_LENGTH_S(initialConditions), NV_LENGTH_S(initialConditions), CvodeContextManager::Instance()->GetSundialsContext());
+#elif CHASTE_SUNDIALS_VERSION >= 30000
         /* Create dense matrix SUNDenseMatrix for use in linear solves */
         mpSundialsDenseMatrix = SUNDenseMatrix(NV_LENGTH_S(initialConditions), NV_LENGTH_S(initialConditions));
 #endif
 
-#if CHASTE_SUNDIALS_VERSION >= 40000
+#if CHASTE_SUNDIALS_VERSION >= 60000
+        /* Create dense SUNLinSol_Dense object for use by CVode */
+        mpSundialsLinearSolver = SUNLinSol_Dense(initialConditions, mpSundialsDenseMatrix, CvodeContextManager::Instance()->GetSundialsContext());
+
+        /* Call CVodeSetLinearSolver to attach the matrix and linear solver to CVode */
+        CVodeSetLinearSolver(mpCvodeMem, mpSundialsLinearSolver, mpSundialsDenseMatrix);
+#elif CHASTE_SUNDIALS_VERSION >= 40000
         /* Create dense SUNLinSol_Dense object for use by CVode */
         mpSundialsLinearSolver = SUNLinSol_Dense(initialConditions, mpSundialsDenseMatrix);
 

--- a/ode/src/common/CvodeContextManager.cpp
+++ b/ode/src/common/CvodeContextManager.cpp
@@ -37,9 +37,10 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #if CHASTE_SUNDIALS_VERSION >= 60000
 #include <cassert>
 #include <memory>
-#include <nvector/nvector_serial.h>
-#include "CvodeContextManager.hpp"
 
+#include <nvector/nvector_serial.h>
+
+#include "CvodeContextManager.hpp"
 
 CvodeContextManager::CvodeContextManager() : mSundialsContext() {}
 

--- a/ode/src/common/CvodeContextManager.cpp
+++ b/ode/src/common/CvodeContextManager.cpp
@@ -36,33 +36,18 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef CHASTE_CVODE
 #if CHASTE_SUNDIALS_VERSION >= 60000
 #include <cassert>
+#include <memory>
 #include <nvector/nvector_serial.h>
 #include "CvodeContextManager.hpp"
 
-CvodeContextManager* CvodeContextManager::mpInstance = nullptr;
 
-CvodeContextManager::CvodeContextManager()
-        : mSundialsContext()
-{
-    assert(mpInstance == nullptr); // Ensure correct serialization
-}
+CvodeContextManager::CvodeContextManager() : mSundialsContext() {}
 
 CvodeContextManager* CvodeContextManager::Instance()
 {
-    if (mpInstance == nullptr)
-    {
-        mpInstance = new CvodeContextManager();
-    }
-    return mpInstance;
-}
-
-void CvodeContextManager::Destroy()
-{
-    if (mpInstance)
-    {
-        delete mpInstance;
-        mpInstance = nullptr;
-    }
+    // Single instance per thread
+    static thread_local std::unique_ptr<CvodeContextManager> instance = std::unique_ptr<CvodeContextManager>(new CvodeContextManager()); 
+    return instance.get();
 }
 
 sundials::Context& CvodeContextManager::GetSundialsContext()

--- a/ode/src/common/CvodeContextManager.cpp
+++ b/ode/src/common/CvodeContextManager.cpp
@@ -1,0 +1,75 @@
+/*
+
+Copyright (c) 2005-2022, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifdef CHASTE_CVODE
+#if CHASTE_SUNDIALS_VERSION >= 60000
+#include <cassert>
+#include <nvector/nvector_serial.h>
+#include "CvodeContextManager.hpp"
+
+CvodeContextManager* CvodeContextManager::mpInstance = nullptr;
+
+CvodeContextManager::CvodeContextManager()
+        : mSundialsContext()
+{
+    assert(mpInstance == nullptr); // Ensure correct serialization
+}
+
+CvodeContextManager* CvodeContextManager::Instance()
+{
+    if (mpInstance == nullptr)
+    {
+        mpInstance = new CvodeContextManager();
+    }
+    return mpInstance;
+}
+
+void CvodeContextManager::Destroy()
+{
+    if (mpInstance)
+    {
+        delete mpInstance;
+        mpInstance = nullptr;
+    }
+}
+
+sundials::Context& CvodeContextManager::GetSundialsContext()
+{
+    assert(mSundialsContext);
+    return mSundialsContext;
+}
+
+#endif // CHASTE_SUNDIALS_VERSION >= 60000
+#endif // CHASTE_CVODE

--- a/ode/src/common/CvodeContextManager.hpp
+++ b/ode/src/common/CvodeContextManager.hpp
@@ -39,6 +39,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef CHASTE_CVODE
 #if CHASTE_SUNDIALS_VERSION >= 60000
 #include <sstream>
+#include <memory>
 
 #include <nvector/nvector_serial.h>
 
@@ -54,38 +55,21 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * CvodeContextManager* ctx = CvodeContextManager::Instance();
  *
  */
-class CvodeContextManager : public SerializableSingleton<CvodeContextManager>
+class CvodeContextManager
 {
 private:
     /** The SUNContext **/
     sundials::Context mSundialsContext;
 
-    /** Pointer to the single instance. */
-    static CvodeContextManager* mpInstance;
-
-    friend class boost::serialization::access;
-
     /**
-     * Serialization of a CvodeContextManager object must be done with care.
-     * Do not serialize this singleton directly.  Instead, serialize
-     * the object returned by GetSerializationWrapper.
-     *
-     * @param archive the archive
-     * @param version the current version of this class
-     */
-    template <class Archive>
-    void serialize(Archive & archive, const unsigned int version)
-    {
-        archive & mSundialsContext;
-    }
-
-protected:
-    /**
-     * Protected constructor.
+     * Private constructor.
      * Use Instance() to access the context manager.
      */
     CvodeContextManager();
 
+    CvodeContextManager(const CvodeContextManager&) = delete; // disable copy constructor
+    CvodeContextManager& operator=(const CvodeContextManager&) = delete; // disable copy assignment
+    
 public:
     /**
      * @return a reference to the managed context object.
@@ -98,14 +82,6 @@ public:
      * The object is created the first time this method is called.
      */
     static CvodeContextManager* Instance();
-
-    /**
-     * Destroy the current instance of the context manager.
-     * The next call to Instance will create a new instance.
-     * This method *must* be called before program exit, to avoid a memory
-     * leak.
-     */
-    static void Destroy();
 };
 
 #endif // CHASTE_SUNDIALS_VERSION >= 60000

--- a/ode/src/common/CvodeContextManager.hpp
+++ b/ode/src/common/CvodeContextManager.hpp
@@ -1,0 +1,114 @@
+/*
+
+Copyright (c) 2005-2022, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef _CVODECONTEXT_HPP_
+#define _CVODECONTEXT_HPP_
+
+#ifdef CHASTE_CVODE
+#if CHASTE_SUNDIALS_VERSION >= 60000
+#include <sstream>
+
+#include <nvector/nvector_serial.h>
+
+#include <boost/serialization/split_member.hpp>
+#include "ChasteSerialization.hpp"
+#include "SerializableSingleton.hpp"
+
+/**
+ * A special singleton class to manage the SUNContext object required
+ * by Sundials 6.0 and above.
+ *
+ * This class is a singleton and an instance should be retrieved with:
+ * CvodeContextManager* ctx = CvodeContextManager::Instance();
+ *
+ */
+class CvodeContextManager : public SerializableSingleton<CvodeContextManager>
+{
+private:
+    /** The SUNContext **/
+    sundials::Context mSundialsContext;
+
+    /** Pointer to the single instance. */
+    static CvodeContextManager* mpInstance;
+
+    friend class boost::serialization::access;
+
+    /**
+     * Serialization of a CvodeContextManager object must be done with care.
+     * Do not serialize this singleton directly.  Instead, serialize
+     * the object returned by GetSerializationWrapper.
+     *
+     * @param archive the archive
+     * @param version the current version of this class
+     */
+    template <class Archive>
+    void serialize(Archive & archive, const unsigned int version)
+    {
+        archive & mSundialsContext;
+    }
+
+protected:
+    /**
+     * Protected constructor.
+     * Use Instance() to access the context manager.
+     */
+    CvodeContextManager();
+
+public:
+    /**
+     * @return a reference to the managed context object.
+     * 
+     */
+    sundials::Context& GetSundialsContext();
+
+    /**
+     * @return a pointer to the context manager object.
+     * The object is created the first time this method is called.
+     */
+    static CvodeContextManager* Instance();
+
+    /**
+     * Destroy the current instance of the context manager.
+     * The next call to Instance will create a new instance.
+     * This method *must* be called before program exit, to avoid a memory
+     * leak.
+     */
+    static void Destroy();
+};
+
+#endif // CHASTE_SUNDIALS_VERSION >= 60000
+#endif // CHASTE_CVODE
+
+#endif // _CVODECONTEXT_HPP_

--- a/ode/src/common/CvodeContextManager.hpp
+++ b/ode/src/common/CvodeContextManager.hpp
@@ -38,7 +38,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef CHASTE_CVODE
 #if CHASTE_SUNDIALS_VERSION >= 60000
-#include <sstream>
 #include <memory>
 
 #include <nvector/nvector_serial.h>

--- a/ode/src/common/CvodeContextManager.hpp
+++ b/ode/src/common/CvodeContextManager.hpp
@@ -43,10 +43,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <nvector/nvector_serial.h>
 
-#include <boost/serialization/split_member.hpp>
-#include "ChasteSerialization.hpp"
-#include "SerializableSingleton.hpp"
-
 /**
  * A special singleton class to manage the SUNContext object required
  * by Sundials 6.0 and above.

--- a/ode/src/common/OdeSolution.cpp
+++ b/ode/src/common/OdeSolution.cpp
@@ -185,7 +185,7 @@ std::vector<std::vector<double> >& OdeSolution::rGetDerivedQuantities(AbstractPa
         assert(mTimes.size() == num_solutions); // Paranoia
         mDerivedQuantities.resize(mTimes.size());
 #if CHASTE_SUNDIALS_VERSION >= 60000
-        N_Vector state_vars = num_solutions > 0 ? N_VNew_Serial(mSolutions[0].size(), CvodeContextManager::Instance()->GetContext()) : nullptr;
+        N_Vector state_vars = num_solutions > 0 ? N_VNew_Serial(mSolutions[0].size(), CvodeContextManager::Instance()->GetSundialsContext()) : nullptr;
 #else
         N_Vector state_vars = num_solutions > 0 ? N_VNew_Serial(mSolutions[0].size()) : nullptr;
 #endif

--- a/ode/src/common/OdeSolution.cpp
+++ b/ode/src/common/OdeSolution.cpp
@@ -42,6 +42,10 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "PetscTools.hpp"
 #include "VectorHelperFunctions.hpp"
 
+#if CHASTE_SUNDIALS_VERSION >= 60000
+#include "CvodeContextManager.hpp"  // access to shared SUNContext object required by Sundials 6.0+
+#endif
+
 OdeSolution::OdeSolution()
     : mNumberOfTimeSteps(0u),
       mpOdeSystemInformation()
@@ -180,7 +184,11 @@ std::vector<std::vector<double> >& OdeSolution::rGetDerivedQuantities(AbstractPa
         const unsigned num_solutions = mSolutions.size();
         assert(mTimes.size() == num_solutions); // Paranoia
         mDerivedQuantities.resize(mTimes.size());
+#if CHASTE_SUNDIALS_VERSION >= 60000
+        N_Vector state_vars = num_solutions > 0 ? N_VNew_Serial(mSolutions[0].size(), CvodeContextManager::Instance()->GetContext()) : nullptr;
+#else
         N_Vector state_vars = num_solutions > 0 ? N_VNew_Serial(mSolutions[0].size()) : nullptr;
+#endif
         for (unsigned i=0; i<num_solutions; i++)
         {
             CopyFromStdVector(mSolutions[i], state_vars);

--- a/ode/src/solver/CvodeAdaptor.cpp
+++ b/ode/src/solver/CvodeAdaptor.cpp
@@ -57,6 +57,10 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cvode/cvode_dense.h>
 #endif
 
+#if CHASTE_SUNDIALS_VERSION >= 60000
+#include "CvodeContextManager.hpp"  // access to shared SUNContext object required by Sundials 6.0+
+#endif
+
 /**
  * CVODE right-hand-side function adaptor.
  *
@@ -193,7 +197,11 @@ void CvodeAdaptor::SetupCvode(AbstractOdeSystem* pOdeSystem,
     assert(maxStep > 0.0);
 
     /** Initial conditions for the ODE solver. */
+#if CHASTE_SUNDIALS_VERSION >= 60000
+    N_Vector initial_values = N_VMake_Serial(rInitialY.size(), &(rInitialY[0]), CvodeContextManager::Instance()->GetSundialsContext());
+#else
     N_Vector initial_values = N_VMake_Serial(rInitialY.size(), &(rInitialY[0]));
+#endif
     assert(NV_DATA_S(initial_values) == &(rInitialY[0]));
     assert(!NV_OWN_DATA_S(initial_values));
     //    std::cout << " Initial values: "; N_VPrint_Serial(initial_values);
@@ -218,7 +226,9 @@ void CvodeAdaptor::SetupCvode(AbstractOdeSystem* pOdeSystem,
     if (!mpCvodeMem) // First run of this solver, set up CVODE memory
     {
         // Set up CVODE's memory.
-#if CHASTE_SUNDIALS_VERSION >= 40000
+#if CHASTE_SUNDIALS_VERSION >= 60000
+        mpCvodeMem = CVodeCreate(CV_BDF, CvodeContextManager::Instance()->GetSundialsContext());
+#elif CHASTE_SUNDIALS_VERSION >= 40000
         //  v4.0.0 release notes: instead of specifying the nonlinear iteration type when creating the CVODE(S) memory structure,
         //  CVODE(S) uses the SUNNONLINSOL_NEWTON module implementation of a Newton iteration by default.
         mpCvodeMem = CVodeCreate(CV_BDF);
@@ -258,12 +268,20 @@ void CvodeAdaptor::SetupCvode(AbstractOdeSystem* pOdeSystem,
 #endif
         }
 
-#if CHASTE_SUNDIALS_VERSION >= 30000
         /* Create dense SUNMatrix for use in linear solves */
+#if CHASTE_SUNDIALS_VERSION >= 60000
+        mpSundialsDenseMatrix = SUNDenseMatrix(rInitialY.size(), rInitialY.size(), CvodeContextManager::Instance()->GetSundialsContext());
+#elif CHASTE_SUNDIALS_VERSION >= 30000
         mpSundialsDenseMatrix = SUNDenseMatrix(rInitialY.size(), rInitialY.size());
 #endif
 
-#if CHASTE_SUNDIALS_VERSION >= 40000
+#if CHASTE_SUNDIALS_VERSION >= 60000
+        /* Create dense SUNLinearSolver object for use by CVode */
+        mpSundialsLinearSolver = SUNLinSol_Dense(initial_values, mpSundialsDenseMatrix, CvodeContextManager::Instance()->GetSundialsContext());
+
+        /* Call CVodeSetLinearSolver to attach the matrix and linear solver to CVode */
+        CVodeSetLinearSolver(mpCvodeMem, mpSundialsLinearSolver, mpSundialsDenseMatrix);
+#elif CHASTE_SUNDIALS_VERSION >= 40000
         /* Create dense SUNLinearSolver object for use by CVode */
         mpSundialsLinearSolver = SUNLinSol_Dense(initial_values, mpSundialsDenseMatrix);
 
@@ -313,9 +331,19 @@ void CvodeAdaptor::SetupCvode(AbstractOdeSystem* pOdeSystem,
         }
 
         /* Create dense matrix of type SUNDenseMatrix for use in linear solves */
+#if CHASTE_SUNDIALS_VERSION >= 60000
+        mpSundialsDenseMatrix = SUNDenseMatrix(rInitialY.size(), rInitialY.size(), CvodeContextManager::Instance()->GetSundialsContext());
+#else
         mpSundialsDenseMatrix = SUNDenseMatrix(rInitialY.size(), rInitialY.size());
+#endif
 
-#if CHASTE_SUNDIALS_VERSION >= 40000
+#if CHASTE_SUNDIALS_VERSION >= 60000
+        /* Create dense SUNLinSol_Dense object for use by CVode */
+        mpSundialsLinearSolver = SUNLinSol_Dense(initial_values, mpSundialsDenseMatrix, CvodeContextManager::Instance()->GetSundialsContext());
+
+        /* Call CVodeSetLinearSolver to attach the matrix and linear solver to CVode */
+        CVodeSetLinearSolver(mpCvodeMem, mpSundialsLinearSolver, mpSundialsDenseMatrix);
+#elif CHASTE_SUNDIALS_VERSION >= 40000
         /* Create dense SUNLinSol_Dense object for use by CVode */
         mpSundialsLinearSolver = SUNLinSol_Dense(initial_values, mpSundialsDenseMatrix);
 
@@ -424,7 +452,11 @@ OdeSolution CvodeAdaptor::Solve(AbstractOdeSystem* pOdeSystem,
     SetupCvode(pOdeSystem, rYValues, startTime, maxStep);
 
     TimeStepper stepper(startTime, endTime, timeSampling);
+#if CHASTE_SUNDIALS_VERSION >= 60000
+    N_Vector yout = N_VMake_Serial(rYValues.size(), &(rYValues[0]), CvodeContextManager::Instance()->GetSundialsContext());
+#else
     N_Vector yout = N_VMake_Serial(rYValues.size(), &(rYValues[0]));
+#endif
 
     // Set up ODE solution
     OdeSolution solutions;
@@ -490,7 +522,11 @@ void CvodeAdaptor::Solve(AbstractOdeSystem* pOdeSystem,
 
     SetupCvode(pOdeSystem, rYValues, startTime, maxStep);
 
+#if CHASTE_SUNDIALS_VERSION >= 60000
+    N_Vector yout = N_VMake_Serial(rYValues.size(), &(rYValues[0]), CvodeContextManager::Instance()->GetSundialsContext());
+#else
     N_Vector yout = N_VMake_Serial(rYValues.size(), &(rYValues[0]));
+#endif
 
     // This should stop CVODE going past the end of where we wanted and interpolating back.
     int ierr = CVodeSetStopTime(mpCvodeMem, endTime);


### PR DESCRIPTION
## Description
- These changes are for Chaste ticket [#3084](https://chaste.cs.ox.ac.uk/trac/ticket/3084) to add support for [Sundials 6.0.0](https://computing.llnl.gov/projects/sundials/release-history) which requires a newly introduced [SUNContext](https://sundials.readthedocs.io/en/latest/sundials/SUNContext_link.html) object.
- A CvodeContextManager Singleton has been added to manage a shared SUNContext object with thread_local storage.
- Pragmas have been added where required to account for the changes in Sundials library function calls.
- Tolerance for [TestMonodomainProblem -> TestOutputDoesNotDependOnPrintTimestep](https://github.com/Chaste/Chaste/compare/develop...kwabenantim:ticket_3084#diff-5329d4c8d306e1f8bb720ffd3c5e15a1e8008dd2a824f62090c78dab1b60eb7c) was adjusted from 3e-3 to 4e-3, in line with observed results from parallel execution using the new solver.

## Context
- Relevant updates have been made to boilerplate code and reference models in [chaste_codegen](https://github.com/ModellingWebLab/chaste-codegen/pull/242). These are required to pass Codegen tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation checklist
- [x] I have updated all documentation in the code where necessary.
- [x] I have checked spelling in all (new) comments and documentation.
- [ ] I have added a note to RELEASE.md if relevant (new feature, breaking change, or notable bug fix).
- [ ] I have updated version & citation.txt & citation.cff version.

## Testing
- [ ] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically 
- [x] This can be tested automatically, but requires Sundials 6.0.0 to be installed. It has been tested manually in a [chaste-docker](https://github.com/Chaste/chaste-docker) container. The following tests all passed:
    - Continuous
    - Codegen
    - project_ApPredict
    - Nightly
    - Weekly (except [TestGenerateSteadyStateCrypt](https://chaste.cs.ox.ac.uk/trac/ticket/3089), which already fails)
    - Parallel (required adjusting tolerance for [TestOutputDoesNotDependOnPrintTimestep](https://github.com/Chaste/Chaste/compare/develop...kwabenantim:ticket_3084#diff-5329d4c8d306e1f8bb720ffd3c5e15a1e8008dd2a824f62090c78dab1b60eb7c))
