### PR TITLE
#3084 Upgrading default codegen version for Sundials 6.0 support

### DIFF
--- a/chaste_codegen.txt
+++ b/chaste_codegen.txt
@@ -1,1 +1,1 @@
-chaste_codegen>=0.9.0, <0.10.0
+chaste_codegen>=0.9.10, <0.10.0


### PR DESCRIPTION
## Description
This upgrades the minimum version of chaste_codegen to 0.9.10 for Sundials 6.0 support.

## Context
- This change is related to Chaste ticket [#3084](https://chaste.cs.ox.ac.uk/trac/ticket/3084)
- The [chaste_codegen](https://github.com/ModellingWebLab/chaste-codegen/pull/243) project has been updated to generate Chaste code that supports Sundials 6.0.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Testing
- [ ] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically 
- [x] This can be tested automatically, but requires Sundials 6.0.0 to be installed. It has been tested manually in a [chaste-docker](https://github.com/Chaste/chaste-docker) container. The following tests all passed:
    - Continuous
    - Nightly
    - Codegen
    - project_ApPredict
    - Weekly (except [TestGenerateSteadyStateCrypt](https://chaste.cs.ox.ac.uk/trac/ticket/3089), which already fails)
