### PR TITLE
Update chaste_codegen.txt

### DIFF
--- a/chaste_codegen.txt
+++ b/chaste_codegen.txt
@@ -1,1 +1,1 @@
-chaste_codegen>=0.9.10, <0.10.0
+chaste_codegen>=0.9.11, <0.10.0


### PR DESCRIPTION
this pulls in new codegen release, which oins Pint verion to prevent incomatibilit we were seeing on python 3.10 & Ping 0.20.0