### PR TITLE
#3094: Support boost 1.78

### DIFF
--- a/global/src/FileFinder.cpp
+++ b/global/src/FileFinder.cpp
@@ -35,6 +35,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "FileFinder.hpp"
 
+#include <algorithm>
 #include <cassert>
 
 #include "BoostFilesystem.hpp"

--- a/global/test/TestArchivingHelperClasses.hpp
+++ b/global/test/TestArchivingHelperClasses.hpp
@@ -315,7 +315,7 @@ public:
         //Check testout/archive/specific_secondary.arch
         FileFinder archive_dir("global/test/data", RelativeTo::ChasteSourceRoot);
         std::string archive_file = "future_boost.arch";
-        // future_boost has got archive version 19 in it
+        // future_boost has got archive version 20 in it
         // 1.33 => 3
         // 1.34 => 4
         // 1.36 => 5
@@ -349,6 +349,10 @@ public:
         // 1.72 => 17
         // 1.73 => 18
         // 1.74 => 18
+        // 1.75 => 18
+        // 1.76 => 19
+        // 1.77 => 19
+        // 1.78 => 19
 
 #ifndef BOOST_VERSION
         TS_FAIL("This test needs to know the version of Boost with which it was compiled.");

--- a/global/test/data/future_boost.arch
+++ b/global/test/data/future_boost.arch
@@ -1,1 +1,1 @@
-22 serialization::archive 19 321
+22 serialization::archive 20 321

--- a/global/test/data/future_boost.arch.0
+++ b/global/test/data/future_boost.arch.0
@@ -1,1 +1,1 @@
-22 serialization::archive 19 0
+22 serialization::archive 20 0


### PR DESCRIPTION
## Summary
This adds support for boost 1.78 to Chaste for [ticket 3094](https://chaste.cs.ox.ac.uk/trac/ticket/3094).

### Passing Tests
- [x] Continuous
- [x] Nightly
- [x] Parallel

### Failing Tests
- ~~TestArchivingHelperClasses~~ (Fixed)
- ~~TestArchivingHelperClassesParallel~~ (Fixed)

## Additional Testing
### Boost 1.75
- [x] Continuous
- [x] Nightly
- [x] Parallel

### Boost 1.76
- [x] Continuous
- [x] Nightly
- [x] Parallel

### Boost 1.77
- [x] Continuous
- [x] Nightly
- [x] Parallel

## Notes
- `TestGenerateSteadyStateCrypt` in `Weekly` test pack currently passes for `intel`, but fails for `gcc` regardless of boost version. All other `Weekly` tests pass for `gcc`.
