### PR TITLE
Fix portability workflow

### DIFF
--- a/.github/workflows/portability.yml
+++ b/.github/workflows/portability.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: set runner user privileges
         run: |
-          chown -R runner:runner chaste
+          chown -R runner:runner .
           
       - name: cmake configure
         run: |


### PR DESCRIPTION
- This fixes the path to the checkout directory in the Portability GitHub Actions workflow:
https://github.com/Chaste/dependency-modules/actions/runs/4501485360