### PR TITLE
103 bbr wp 41 barcelona

### DIFF
--- a/cell_based/src/cell/cycle/BiasedBernoulliTrialCellCycleModel.cpp
+++ b/cell_based/src/cell/cycle/BiasedBernoulliTrialCellCycleModel.cpp
@@ -1,0 +1,132 @@
+/*
+
+Copyright (c) 2005-2023, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "BiasedBernoulliTrialCellCycleModel.hpp"
+#include "RandomNumberGenerator.hpp"
+#include "DifferentiatedCellProliferativeType.hpp"
+
+BiasedBernoulliTrialCellCycleModel::BiasedBernoulliTrialCellCycleModel()
+    : AbstractCellCycleModel(),
+      mMaxDivisionProbability(0.1),
+      mMinimumDivisionAge(1.0)
+{
+}
+
+BiasedBernoulliTrialCellCycleModel::BiasedBernoulliTrialCellCycleModel(const BiasedBernoulliTrialCellCycleModel& rModel)
+   : AbstractCellCycleModel(rModel),
+     mMaxDivisionProbability(rModel.mMaxDivisionProbability),
+     mMinimumDivisionAge(rModel.mMinimumDivisionAge)
+{
+    /*
+     * Initialize only those member variables defined in this class.
+     *
+     * The member variables mBirthTime, mReadyToDivide and mDimension
+     * are initialized in the AbstractCellCycleModel constructor.
+     */
+}
+
+bool BiasedBernoulliTrialCellCycleModel::ReadyToDivide()
+{
+    assert(mpCell != nullptr);
+
+    if (!mReadyToDivide)
+    {
+        if (GetAge() > mMinimumDivisionAge)
+        {
+            double dt = SimulationTime::Instance()->GetTimeStep();
+            double p = mpCell->GetCellData()->GetItem("bias");
+            assert(p >= 0.0 && p <= 1.0);
+            if (!(mpCell->GetCellProliferativeType()->IsType<DifferentiatedCellProliferativeType>()))
+            {
+                RandomNumberGenerator* p_gen = RandomNumberGenerator::Instance();
+                if (p_gen->ranf() < p*mMaxDivisionProbability*dt)
+                {
+                    mReadyToDivide = true;
+                }
+            }
+        }
+    }
+    return mReadyToDivide;
+}
+
+AbstractCellCycleModel* BiasedBernoulliTrialCellCycleModel::CreateCellCycleModel()
+{
+    return new BiasedBernoulliTrialCellCycleModel(*this);
+}
+
+void BiasedBernoulliTrialCellCycleModel::SetMaxDivisionProbability(double maxDivisionProbability)
+{
+    assert(maxDivisionProbability >= 0.0 && maxDivisionProbability <= 1.0);
+    mMaxDivisionProbability = maxDivisionProbability;
+}
+
+double BiasedBernoulliTrialCellCycleModel::GetMaxDivisionProbability()
+{
+    return mMaxDivisionProbability;
+}
+
+void BiasedBernoulliTrialCellCycleModel::SetMinimumDivisionAge(double minimumDivisionAge)
+{
+    assert(minimumDivisionAge >= 0.0);
+    mMinimumDivisionAge = minimumDivisionAge;
+}
+
+double BiasedBernoulliTrialCellCycleModel::GetMinimumDivisionAge()
+{
+    return mMinimumDivisionAge;
+}
+
+double BiasedBernoulliTrialCellCycleModel::GetAverageTransitCellCycleTime()
+{
+    return 1.0/mMaxDivisionProbability;
+}
+
+double BiasedBernoulliTrialCellCycleModel::GetAverageStemCellCycleTime()
+{
+    return 1.0/mMaxDivisionProbability;
+}
+
+void BiasedBernoulliTrialCellCycleModel::OutputCellCycleModelParameters(out_stream& rParamsFile)
+{
+    *rParamsFile << "\t\t\t<MaxDivisionProbability>" << mMaxDivisionProbability << "</MaxDivisionProbability>\n";
+    *rParamsFile << "\t\t\t<MinimumDivisionAge>" << mMinimumDivisionAge << "</MinimumDivisionAge>\n";
+
+    // Call method on direct parent class
+    AbstractCellCycleModel::OutputCellCycleModelParameters(rParamsFile);
+}
+
+// Serialization for Boost >= 1.36
+#include "SerializationExportWrapperForCpp.hpp"
+CHASTE_CLASS_EXPORT(BiasedBernoulliTrialCellCycleModel)

--- a/cell_based/src/cell/cycle/BiasedBernoulliTrialCellCycleModel.hpp
+++ b/cell_based/src/cell/cycle/BiasedBernoulliTrialCellCycleModel.hpp
@@ -1,0 +1,184 @@
+/*
+
+Copyright (c) 2005-2023, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef BIASEDBERNOULLITRIALCELLCYCLEMODEL_HPP_
+#define BIASEDBERNOULLITRIALCELLCYCLEMODEL_HPP_
+
+#include "AbstractCellCycleModel.hpp"
+
+/**
+ * Simple cell-cycle model where mature non-differentiated cells have a probability of
+ * dividing per hour that is biased so that it varies linearly across an axis of the 
+ * population through its centre, from zero up to a specified upper value.
+ *
+ * The class includes two parameters: the first, mMaxDivisionProbability, defines the 
+ * maximum probability of dividing per hour; the second, mMinimumDivisionAge, defines a 
+ * minimum age at which cells may divide. The axis along which cell division probability 
+ * is biased must be specified in the separate class DivisionBiasTrackingModifier.
+ */
+class BiasedBernoulliTrialCellCycleModel : public AbstractCellCycleModel
+{
+private:
+
+    friend class boost::serialization::access;
+
+    /**
+     * Boost Serialization method for archiving/checkpointing
+     * @param archive  The boost archive.
+     * @param version  The current version of this class.
+     */
+    template<class Archive>
+    void serialize(Archive & archive, const unsigned int version)
+    {
+        archive & boost::serialization::base_object<AbstractCellCycleModel>(*this);
+        archive & mMaxDivisionProbability;
+        archive & mMinimumDivisionAge;
+    }
+
+protected:
+
+    /**
+     * Maximum probability of dividing per hour.
+     * Defaults to 0.1.
+     */
+    double mMaxDivisionProbability;
+
+    /**
+     * Minimum age of a cell at which it may divide.
+     * Defaults to 1 hour.
+     */
+    double mMinimumDivisionAge;
+
+    /**
+     * Protected copy-constructor for use by CreateCellCycleModel.
+     *
+     * The only way for external code to create a copy of a cell cycle model
+     * is by calling that method, to ensure that a model of the correct subclass
+     * is created. This copy-constructor helps subclasses to ensure that all
+     * member variables are correctly copied when this happens.
+     *
+     * This method is called by child classes to set member variables for a
+     * daughter cell upon cell division. Note that the parent cell cycle model
+     * will have had ResetForDivision() called just before CreateCellCycleModel()
+     * is called, so performing an exact copy of the parent is suitable behaviour.
+     * Any daughter-cell-specific initialisation can be done in InitialiseDaughterCell().
+     *
+     * @param rModel the cell cycle model to copy.
+     */
+    BiasedBernoulliTrialCellCycleModel(const BiasedBernoulliTrialCellCycleModel& rModel);
+
+public:
+
+    /**
+     * Constructor.
+     */
+    BiasedBernoulliTrialCellCycleModel();
+
+    /**
+     * Overridden ReadyToDivide() method.
+     *
+     * If the cell's age is greater than mMinimumDivisionAge, then we draw a uniform
+     * random number r ~ U[0,1]. If r < p*dt, where p varies linearly from zero up to 
+     * mMaxDivisionProbability dependent on the cell's location within the population, 
+     * and dt is the simulation time step, then the cell is ready to divide and we 
+     * return true. Otherwise, the cell is not yet ready to divide and we return false.
+     *
+     * @return whether the cell is ready to divide.
+     */
+    virtual bool ReadyToDivide();
+
+    /**
+     * Overridden builder method to create new instances of
+     * the cell-cycle model.
+     *
+     * @return new cell-cycle model
+     */
+    AbstractCellCycleModel* CreateCellCycleModel();
+
+    /**
+     * Set the value of mMaxDivisionProbability.
+     *
+     * @param maxDivisionProbability the new value of mMaxDivisionProbability
+     */
+    void SetMaxDivisionProbability(double maxDivisionProbability);
+
+    /**
+     * Get mMaxDivisionProbability.
+     *
+     * @return mMaxDivisionProbability
+     */
+    double GetMaxDivisionProbability();
+
+    /**
+     * Set the value of mMinimumDivisionAge.
+     *
+     * @param minimumDivisionAge the new value of mMinimumDivisionAge
+     */
+    void SetMinimumDivisionAge(double minimumDivisionAge);
+
+    /**
+     * Get mMinimumDivisionAge.
+     *
+     * @return mMinimumDivisionAge
+     */
+    double GetMinimumDivisionAge();
+
+    /**
+     * Overridden GetAverageTransitCellCycleTime() method.
+     *
+     * @return the average cell cycle time for cells of transit proliferative type
+     */
+    double GetAverageTransitCellCycleTime();
+
+    /**
+     * Overridden GetAverageStemCellCycleTime() method.
+     *
+     * @return the average cell cycle time for cells of stem proliferative type
+     */
+    double GetAverageStemCellCycleTime();
+
+    /**
+     * Overridden OutputCellCycleModelParameters() method.
+     *
+     * @param rParamsFile the file stream to which the parameters are output
+     */
+    virtual void OutputCellCycleModelParameters(out_stream& rParamsFile);
+};
+
+// Declare identifier for the serializer
+#include "SerializationExportWrapper.hpp"
+CHASTE_CLASS_EXPORT(BiasedBernoulliTrialCellCycleModel)
+
+#endif // BIASEDBERNOULLITRIALCELLCYCLEMODEL_HPP_

--- a/cell_based/src/cell/cycle/LabelDependentBernoulliTrialCellCycleModel.cpp
+++ b/cell_based/src/cell/cycle/LabelDependentBernoulliTrialCellCycleModel.cpp
@@ -1,0 +1,146 @@
+/*
+
+Copyright (c) 2005-2023, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "LabelDependentBernoulliTrialCellCycleModel.hpp"
+#include "RandomNumberGenerator.hpp"
+#include "DifferentiatedCellProliferativeType.hpp"
+#include "CellLabel.hpp"
+
+LabelDependentBernoulliTrialCellCycleModel::LabelDependentBernoulliTrialCellCycleModel()
+    : AbstractCellCycleModel(),
+      mDivisionProbability(0.1),
+      mLabelledDivisionProbability(0.1),
+      mMinimumDivisionAge(1.0)
+{
+}
+
+LabelDependentBernoulliTrialCellCycleModel::LabelDependentBernoulliTrialCellCycleModel(const LabelDependentBernoulliTrialCellCycleModel& rModel)
+   : AbstractCellCycleModel(rModel),
+     mDivisionProbability(rModel.mDivisionProbability),
+     mLabelledDivisionProbability(rModel.mLabelledDivisionProbability),
+     mMinimumDivisionAge(rModel.mMinimumDivisionAge)
+{
+    /*
+     * Initialize only those member variables defined in this class.
+     *
+     * The member variables mBirthTime, mReadyToDivide and mDimension
+     * are initialized in the AbstractCellCycleModel constructor.
+     */
+}
+
+bool LabelDependentBernoulliTrialCellCycleModel::ReadyToDivide()
+{
+    assert(mpCell != nullptr);
+
+    if (!mReadyToDivide)
+    {
+        if (GetAge() > mMinimumDivisionAge)
+        {
+            double dt = SimulationTime::Instance()->GetTimeStep();
+            if (!(mpCell->GetCellProliferativeType()->IsType<DifferentiatedCellProliferativeType>()))
+            {
+                RandomNumberGenerator* p_gen = RandomNumberGenerator::Instance();
+                double division_probability = mDivisionProbability;
+                if (mpCell->HasCellProperty<CellLabel>())
+                {
+                    division_probability = mLabelledDivisionProbability;
+                }
+                if (p_gen->ranf() < division_probability*dt)
+                {
+                    mReadyToDivide = true;
+                }
+            }
+        }
+    }
+    return mReadyToDivide;
+}
+
+AbstractCellCycleModel* LabelDependentBernoulliTrialCellCycleModel::CreateCellCycleModel()
+{
+    return new LabelDependentBernoulliTrialCellCycleModel(*this);
+}
+
+void LabelDependentBernoulliTrialCellCycleModel::SetDivisionProbability(double divisionProbability)
+{
+    mDivisionProbability = divisionProbability;
+}
+
+double LabelDependentBernoulliTrialCellCycleModel::GetDivisionProbability()
+{
+    return mDivisionProbability;
+}
+
+void LabelDependentBernoulliTrialCellCycleModel::SetLabelledDivisionProbability(double labelledDivisionProbability)
+{
+    mLabelledDivisionProbability = labelledDivisionProbability;
+}
+
+double LabelDependentBernoulliTrialCellCycleModel::GetLabelledDivisionProbability()
+{
+    return mLabelledDivisionProbability;
+}
+
+void LabelDependentBernoulliTrialCellCycleModel::SetMinimumDivisionAge(double minimumDivisionAge)
+{
+    mMinimumDivisionAge = minimumDivisionAge;
+}
+
+double LabelDependentBernoulliTrialCellCycleModel::GetMinimumDivisionAge()
+{
+    return mMinimumDivisionAge;
+}
+
+double LabelDependentBernoulliTrialCellCycleModel::GetAverageTransitCellCycleTime()
+{
+    return 1.0/mDivisionProbability;
+}
+
+double LabelDependentBernoulliTrialCellCycleModel::GetAverageStemCellCycleTime()
+{
+    return 1.0/mDivisionProbability;
+}
+
+void LabelDependentBernoulliTrialCellCycleModel::OutputCellCycleModelParameters(out_stream& rParamsFile)
+{
+    *rParamsFile << "\t\t\t<DivisionProbability>" << mDivisionProbability << "</DivisionProbability>\n";
+    *rParamsFile << "\t\t\t<MinimumDivisionAge>" << mMinimumDivisionAge << "</MinimumDivisionAge>\n";
+
+    // Call method on direct parent class
+    AbstractCellCycleModel::OutputCellCycleModelParameters(rParamsFile);
+}
+
+// Serialization for Boost >= 1.36
+#include "SerializationExportWrapperForCpp.hpp"
+CHASTE_CLASS_EXPORT(LabelDependentBernoulliTrialCellCycleModel)

--- a/cell_based/src/cell/cycle/LabelDependentBernoulliTrialCellCycleModel.hpp
+++ b/cell_based/src/cell/cycle/LabelDependentBernoulliTrialCellCycleModel.hpp
@@ -1,0 +1,202 @@
+/*
+
+Copyright (c) 2005-2023, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef LABELDEPENDENTBERNOULLITRIALCELLCYCLEMODEL_HPP_
+#define LABELDEPENDENTBERNOULLITRIALCELLCYCLEMODEL_HPP_
+
+#include "AbstractCellCycleModel.hpp"
+
+/**
+ * Simple cell-cycle model where mature non-differentiated cells have a specified probability of
+ * dividing per hour, which depends on whether they are laballed.
+ *
+ * The class includes three parameters: the first, mDivisionProbability, defines the probability
+ * of dividing per hour for unlabelled cells; the second, mLabelledDivisonProbability, defines the 
+ * probability of dividing per hour for labelled cells; and the third, mMinimumDivisionAge, defines 
+ * a minimum age at which any cells may divide.
+ */
+class LabelDependentBernoulliTrialCellCycleModel : public AbstractCellCycleModel
+{
+private:
+
+    friend class boost::serialization::access;
+
+    /**
+     * Boost Serialization method for archiving/checkpointing
+     * @param archive  The boost archive.
+     * @param version  The current version of this class.
+     */
+    template<class Archive>
+    void serialize(Archive & archive, const unsigned int version)
+    {
+        archive & boost::serialization::base_object<AbstractCellCycleModel>(*this);
+        archive & mDivisionProbability;
+        archive & mLabelledDivisionProbability;
+        archive & mMinimumDivisionAge;
+    }
+
+protected:
+    /**
+     * Probability of dividing per hour for unlabelled cells.
+     * Defaults to 0.1.
+     */
+    double mDivisionProbability;
+
+    /**
+     * Probability of dividing per hour for labelled cells.
+     * Defaults to 0.1.
+     */
+    double mLabelledDivisionProbability;
+
+    /**
+     * Minimum age of a cell at which it may divide.
+     * Defaults to 1 hour.
+     */
+    double mMinimumDivisionAge;
+
+    /**
+     * Protected copy-constructor for use by CreateCellCycleModel.
+     *
+     * The only way for external code to create a copy of a cell cycle model
+     * is by calling that method, to ensure that a model of the correct subclass
+     * is created. This copy-constructor helps subclasses to ensure that all
+     * member variables are correctly copied when this happens.
+     *
+     * This method is called by child classes to set member variables for a
+     * daughter cell upon cell division. Note that the parent cell cycle model
+     * will have had ResetForDivision() called just before CreateCellCycleModel()
+     * is called, so performing an exact copy of the parent is suitable behaviour.
+     * Any daughter-cell-specific initialisation can be done in InitialiseDaughterCell().
+     *
+     * @param rModel the cell cycle model to copy.
+     */
+    LabelDependentBernoulliTrialCellCycleModel(const LabelDependentBernoulliTrialCellCycleModel& rModel);
+
+public:
+
+    /**
+     * Constructor.
+     */
+    LabelDependentBernoulliTrialCellCycleModel();
+
+    /**
+     * Overridden ReadyToDivide() method.
+     *
+     * If the cell's age is greater than mMinimumDivisionAge, then we draw a uniform
+     * random number r ~ U[0,1]. If r < mDivisionProbability*dt, where dt is the
+     * simulation time step, then the cell is ready to divide and we return true.
+     * Otherwise, the cell is not yet ready to divide and we return false.
+     *
+     * @return whether the cell is ready to divide.
+     */
+    virtual bool ReadyToDivide();
+
+    /**
+     * Overridden builder method to create new instances of
+     * the cell-cycle model.
+     *
+     * @return new cell-cycle model
+     */
+    AbstractCellCycleModel* CreateCellCycleModel();
+
+    /**
+     * Set the value of mDivisionProbability.
+     *
+     * @param divisionProbability the new value of mDivisionProbability
+     */
+    void SetDivisionProbability(double divisionProbability);
+
+    /**
+     * Get mLabelledDivisionProbability.
+     *
+     * @return mLabelledDivisionProbability
+     */
+    double GetLabelledDivisionProbability();
+
+    /**
+     * Set the value of mLabelledDivisionProbability.
+     *
+     * @param labelledDivisionProbability the new value of mLabelledDivisionProbability
+     */
+    void SetLabelledDivisionProbability(double labelledDivisionProbability);
+
+    /**
+     * Get mDivisionProbability.
+     *
+     * @return mDivisionProbability
+     */
+    double GetDivisionProbability();
+  
+    /**
+     * Set the value of mMinimumDivisionAge.
+     *
+     * @param minimumDivisionAge the new value of mMinimumDivisionAge
+     */
+    void SetMinimumDivisionAge(double minimumDivisionAge);
+
+    /**
+     * Get mMinimumDivisionAge.
+     *
+     * @return mMinimumDivisionAge
+     */
+    double GetMinimumDivisionAge();
+
+    /**
+     * Overridden GetAverageTransitCellCycleTime() method.
+     *
+     * @return the average cell cycle time for cells of transit proliferative type
+     */
+    double GetAverageTransitCellCycleTime();
+
+    /**
+     * Overridden GetAverageStemCellCycleTime() method.
+     *
+     * @return the average cell cycle time for cells of stem proliferative type
+     */
+    double GetAverageStemCellCycleTime();
+
+    /**
+     * Overridden OutputCellCycleModelParameters() method.
+     *
+     * @param rParamsFile the file stream to which the parameters are output
+     */
+    virtual void OutputCellCycleModelParameters(out_stream& rParamsFile);
+};
+
+// Declare identifier for the serializer
+#include "SerializationExportWrapper.hpp"
+CHASTE_CLASS_EXPORT(LabelDependentBernoulliTrialCellCycleModel)
+
+#endif // LABELDEPENDENTBERNOULLITRIALCELLCYCLEMODEL_HPP_

--- a/cell_based/src/population/boundary_conditions/SlidingBoundaryCondition.cpp
+++ b/cell_based/src/population/boundary_conditions/SlidingBoundaryCondition.cpp
@@ -1,0 +1,108 @@
+/*
+
+Copyright (c) 2005-2023, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "SlidingBoundaryCondition.hpp"
+#include "AbstractCentreBasedCellPopulation.hpp"
+#include "VertexBasedCellPopulation.hpp"
+
+template<unsigned DIM>
+SlidingBoundaryCondition<DIM>::SlidingBoundaryCondition(AbstractCellPopulation<DIM>* pCellPopulation,
+                                                    double threshold)
+        : AbstractCellPopulationBoundaryCondition<DIM>(pCellPopulation),
+          mThreshold(threshold)
+{
+}
+
+template<unsigned DIM>
+double SlidingBoundaryCondition<DIM>::GetThreshold() const
+{
+    return mThreshold;
+}
+
+template<unsigned DIM>
+void SlidingBoundaryCondition<DIM>::ImposeBoundaryCondition(const std::map<Node<DIM>*, c_vector<double, DIM> >& rOldLocations)
+{
+    ///\todo Move this to constructor. If this is in the constructor then Exception always throws.
+    if (dynamic_cast<AbstractOffLatticeCellPopulation<DIM>*>(this->mpCellPopulation) == nullptr)
+    {
+        EXCEPTION("SlidingBoundaryCondition requires a subclass of AbstractOffLatticeCellPopulation.");
+    }
+
+    ChasteCuboid<DIM> bounds = this->mpCellPopulation->rGetMesh().CalculateBoundingBox();
+    double x_min = bounds.rGetLowerCorner()[0];
+
+    // Loop over every node
+    for (unsigned node_index=0; node_index<this->mpCellPopulation->GetNumNodes(); node_index++)
+    {
+        Node<DIM>* p_node = this->mpCellPopulation->GetNode(node_index);
+
+        if (p_node->IsBoundaryNode())
+        {
+            c_vector<double, DIM> old_node_location;
+            old_node_location = rOldLocations.find(p_node)->second;
+
+            // If the node lies on the left, then revert its x coordinate
+            if (p_node->rGetLocation()[0] < x_min + mThreshold)
+            {
+                p_node->rGetModifiableLocation()[0] = old_node_location[0];
+            }
+        }
+    }
+}
+
+template<unsigned DIM>
+bool SlidingBoundaryCondition<DIM>::VerifyBoundaryCondition()
+{
+    // Without further information, it is not possible to directly verify the boundary condition
+    return true;
+}
+
+template<unsigned DIM>
+void SlidingBoundaryCondition<DIM>::OutputCellPopulationBoundaryConditionParameters(out_stream& rParamsFile)
+{
+    *rParamsFile << "\t\t\t<Threshold>" << mThreshold << "</Threshold>\n";
+
+    // Call method on direct parent class
+    AbstractCellPopulationBoundaryCondition<DIM>::OutputCellPopulationBoundaryConditionParameters(rParamsFile);
+}
+
+// Explicit instantiation
+template class SlidingBoundaryCondition<1>;
+template class SlidingBoundaryCondition<2>;
+template class SlidingBoundaryCondition<3>;
+
+// Serialization for Boost >= 1.36
+#include "SerializationExportWrapperForCpp.hpp"
+EXPORT_TEMPLATE_CLASS_SAME_DIMS(SlidingBoundaryCondition)

--- a/cell_based/src/population/boundary_conditions/SlidingBoundaryCondition.hpp
+++ b/cell_based/src/population/boundary_conditions/SlidingBoundaryCondition.hpp
@@ -1,0 +1,162 @@
+/*
+
+Copyright (c) 2005-2023, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef SLIDINGBOUNDARYCONDITION_HPP_
+#define SLIDINGBOUNDARYCONDITION_HPP_
+
+#include "AbstractCellPopulationBoundaryCondition.hpp"
+
+#include "ChasteSerialization.hpp"
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/vector.hpp>
+
+/**
+ * A boundary condition class that prevents nodes lying with a threshold distance from the 
+ * left-hand boundary to move in the x direction, but which allows them to 'slide' along 
+ * this boundary.
+ */
+template<unsigned DIM>
+class SlidingBoundaryCondition : public AbstractCellPopulationBoundaryCondition<DIM>
+{
+private:
+
+    /**
+     * Maximum distance from left-hand boundary at which condition is imposed on nodes. 
+     * Initialised to 0.8 in constructor.
+     */
+    double mThreshold;
+
+    /** Needed for serialization. */
+    friend class boost::serialization::access;
+    /**
+     * Serialize the object and its member variables.
+     *
+     * @param archive the archive
+     * @param version the current version of this class
+     */
+    template<class Archive>
+    void serialize(Archive & archive, const unsigned int version)
+    {
+        archive & boost::serialization::base_object<AbstractCellPopulationBoundaryCondition<DIM> >(*this);
+    }
+
+public:
+
+    /**
+     * Constructor.
+     *
+     * @param pCellPopulation pointer to the cell population
+     * @param threshold maximum distance from left-hand boundary at which condition is imposed on nodes (defaults to 0.8)
+     */
+    SlidingBoundaryCondition(AbstractCellPopulation<DIM>* pCellPopulation,
+                             double threshold=0.8);
+
+    /**
+     * @return #mThreshold.
+     */
+    double GetThreshold() const;
+
+    /**
+     * Overridden ImposeBoundaryCondition() method.
+     *
+     * Apply the cell population boundary condition.
+     *
+     * @param rOldLocations the node locations before the boundary condition are applied
+     */
+    void ImposeBoundaryCondition(const std::map<Node<DIM>*, c_vector<double, DIM> >& rOldLocations);
+
+    /**
+     * Overridden VerifyBoundaryCondition() method.
+     * Verify the boundary condition has been applied.
+     * This is called after ImposeBoundaryCondition() to ensure the condition is still satisfied.
+     *
+     * @return whether the boundary conditions are satisfied.
+     */
+    bool VerifyBoundaryCondition();
+
+    /**
+     * Overridden OutputCellPopulationBoundaryConditionParameters() method.
+     * Output cell population boundary condition parameters to file.
+     *
+     * @param rParamsFile the file stream to which the parameters are output
+     */
+    void OutputCellPopulationBoundaryConditionParameters(out_stream& rParamsFile);
+};
+
+#include "SerializationExportWrapper.hpp"
+EXPORT_TEMPLATE_CLASS_SAME_DIMS(SlidingBoundaryCondition)
+
+namespace boost
+{
+namespace serialization
+{
+/**
+ * Serialize information required to construct a SlidingBoundaryCondition.
+ */
+template<class Archive, unsigned DIM>
+inline void save_construct_data(
+    Archive & ar, const SlidingBoundaryCondition<DIM>* t, const unsigned int file_version)
+{
+    // Save data required to construct instance
+    const AbstractCellPopulation<DIM>* const p_cell_population = t->GetCellPopulation();
+    ar << p_cell_population;
+
+    // Archive member variable
+    double threshold = t->GetThreshold();
+    ar << threshold;
+}
+
+/**
+ * De-serialize constructor parameters and initialize a SphereGeometryBoundaryCondition.
+ */
+template<class Archive, unsigned DIM>
+inline void load_construct_data(
+    Archive & ar, SlidingBoundaryCondition<DIM>* t, const unsigned int file_version)
+{
+    // Retrieve data from archive required to construct new instance
+    AbstractCellPopulation<DIM>* p_cell_population;
+    ar >> p_cell_population;
+
+    // Retrieve member variable
+    double threshold;
+    ar >> threshold;
+
+    // Invoke inplace constructor to initialise instance
+    ::new(t)SlidingBoundaryCondition<DIM>(p_cell_population, threshold);
+}
+}
+} // namespace ...
+
+#endif /*SLIDINGBOUNDARYCONDITION_HPP_*/

--- a/cell_based/src/population/division_rules/RandomDirectionVertexBasedDivisionRule.hpp
+++ b/cell_based/src/population/division_rules/RandomDirectionVertexBasedDivisionRule.hpp
@@ -46,7 +46,7 @@ template<unsigned SPACE_DIM> class VertexBasedCellPopulation;
 template<unsigned SPACE_DIM> class AbstractVertexBasedDivisionRule;
 
 /**
- * A class to generate a division vector of unit length that points in a random direction.
+ * A class to generate a division vector of unit length that points in a uniformly random direction.
  */
 template <unsigned SPACE_DIM>
 class RandomDirectionVertexBasedDivisionRule : public AbstractVertexBasedDivisionRule<SPACE_DIM>

--- a/cell_based/src/population/division_rules/VonMisesVertexBasedDivisionRule.cpp
+++ b/cell_based/src/population/division_rules/VonMisesVertexBasedDivisionRule.cpp
@@ -1,0 +1,121 @@
+/*
+
+Copyright (c) 2005-2023, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "VonMisesVertexBasedDivisionRule.hpp"
+#include "MathsCustomFunctions.hpp"
+
+template<unsigned DIM>
+VonMisesVertexBasedDivisionRule<DIM>::VonMisesVertexBasedDivisionRule()
+   : AbstractVertexBasedDivisionRule<DIM>(),
+     mMeanParameter(0.0),
+     mConcentrationParameter(1.0)
+{
+}
+
+template<unsigned DIM>
+VonMisesVertexBasedDivisionRule<DIM>::~VonMisesVertexBasedDivisionRule()
+{
+}
+
+template<unsigned DIM>
+double VonMisesVertexBasedDivisionRule<DIM>::GetMeanParameter()
+{
+    return mMeanParameter;
+}
+
+template<unsigned DIM>
+double VonMisesVertexBasedDivisionRule<DIM>::GetConcentrationParameter()
+{
+    return mConcentrationParameter;
+}
+
+template<unsigned DIM>
+void VonMisesVertexBasedDivisionRule<DIM>::SetMeanParameter(double meanParameter)
+{
+    mMeanParameter = meanParameter;
+}
+
+template<unsigned DIM>
+void VonMisesVertexBasedDivisionRule<DIM>::SetConcentrationParameter(double concentrationParameter)
+{
+    assert(concentrationParameter > 0);
+    mConcentrationParameter = concentrationParameter;
+}
+
+template <unsigned SPACE_DIM>
+c_vector<double, SPACE_DIM> VonMisesVertexBasedDivisionRule<SPACE_DIM>::CalculateCellDivisionVector(
+    CellPtr pParentCell,
+    VertexBasedCellPopulation<SPACE_DIM>& rCellPopulation)
+{
+    // Algorithm taken from: Fisher, Statistical Analysis of Circular Data, CUP (1993)
+
+    double a = 1.0 + sqrt(1.0 + 4.0*mConcentrationParameter*mConcentrationParameter);
+    double b = (a - sqrt(2.0*a)) / (2.0*mConcentrationParameter);
+    double r = (1.0 + b*b) / (2.0*b);
+
+    unsigned counter = 0;
+    double theta = 0;
+    while (counter != 0)
+    {
+        double u1 = RandomNumberGenerator::Instance()->ranf();
+        double u2 = RandomNumberGenerator::Instance()->ranf();
+        double u3 = RandomNumberGenerator::Instance()->ranf();
+
+        double z = cos(M_PI*u1);
+        double f = (1.0 + r*z) / (r + z);
+        double c = mConcentrationParameter*(r - f);
+
+        if (((c*(2.0 - c) - u2) > 0.0) || ((log(c/u2) + 1.0 - c) > 0.0))
+        {
+            theta = fmod((Signum(u3 - 0.5)*std::acos(f)) + mMeanParameter, 2*M_PI);
+            counter += 1;
+        }
+    }
+
+    c_vector<double, SPACE_DIM> vector;
+    vector(0) = cos(theta);
+    vector(1) = sin(theta);
+
+    return vector;
+}
+
+// Explicit instantiation
+template class VonMisesVertexBasedDivisionRule<1>;
+template class VonMisesVertexBasedDivisionRule<2>;
+template class VonMisesVertexBasedDivisionRule<3>;
+
+// Serialization for Boost >= 1.36
+#include "SerializationExportWrapperForCpp.hpp"
+EXPORT_TEMPLATE_CLASS_SAME_DIMS(VonMisesVertexBasedDivisionRule)

--- a/cell_based/src/population/division_rules/VonMisesVertexBasedDivisionRule.cpp
+++ b/cell_based/src/population/division_rules/VonMisesVertexBasedDivisionRule.cpp
@@ -87,7 +87,7 @@ c_vector<double, SPACE_DIM> VonMisesVertexBasedDivisionRule<SPACE_DIM>::Calculat
 
     unsigned counter = 0;
     double theta = 0;
-    while (counter != 0)
+    while (counter <= 0)
     {
         double u1 = RandomNumberGenerator::Instance()->ranf();
         double u2 = RandomNumberGenerator::Instance()->ranf();

--- a/cell_based/src/population/division_rules/VonMisesVertexBasedDivisionRule.hpp
+++ b/cell_based/src/population/division_rules/VonMisesVertexBasedDivisionRule.hpp
@@ -1,0 +1,130 @@
+/*
+
+Copyright (c) 2005-2023, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef VONMISESVERTEXBASEDDIVISIONRULE_HPP_
+#define VONMISESVERTEXBASEDDIVISIONRULE_HPP_
+
+#include "ChasteSerialization.hpp"
+#include <boost/serialization/base_object.hpp>
+#include "AbstractVertexBasedDivisionRule.hpp"
+#include "VertexBasedCellPopulation.hpp"
+
+// Forward declaration prevents circular include chain
+template<unsigned SPACE_DIM> class VertexBasedCellPopulation;
+template<unsigned SPACE_DIM> class AbstractVertexBasedDivisionRule;
+
+/**
+ * A class to generate a division vector of unit length that points in a direction 
+ * randomly sampled from a von Mises distribution parameterised by mu (mean parameter) 
+ * and kappa (concentration parameter).
+ */
+template <unsigned SPACE_DIM>
+class VonMisesVertexBasedDivisionRule : public AbstractVertexBasedDivisionRule<SPACE_DIM>
+{
+private:
+
+    /** Mean parameter. Initialised to 0 in the constructor. */
+    double mMeanParameter;
+
+    /** Concentration parameter. Must be positive. Initialised to 1 in the constructor.  */
+    double mConcentrationParameter;
+
+    friend class boost::serialization::access;
+    /**
+     * Serialize the object and its member variables.
+     *
+     * @param archive the archive
+     * @param version the current version of this class
+     */
+    template<class Archive>
+    void serialize(Archive & archive, const unsigned int version)
+    {
+        archive & boost::serialization::base_object<AbstractVertexBasedDivisionRule<SPACE_DIM> >(*this);
+        archive & mMeanParameter;
+        archive & mConcentrationParameter;
+    }
+
+public:
+    /**
+     * Default constructor.
+     */
+    VonMisesVertexBasedDivisionRule();
+
+    /**
+     * Empty destructor.
+     */
+    virtual ~VonMisesVertexBasedDivisionRule();
+
+    /**
+     * @return mMeanParameter
+     */
+    double GetMeanParameter();
+
+    /**
+     * @return mConcentrationParameter
+     */
+    double GetConcentrationParameter();
+
+    /**
+     * Set mMeanParameter.
+     *
+     * @param meanParameter the new value of mMeanParameter
+     */
+    void SetMeanParameter(double meanParameter);
+
+    /**
+     * Set mConcentrationParameter.
+     *
+     * @param concentrationParameter the new value of mConcentrationParameter
+     */
+    void SetConcentrationParameter(double concentrationParameter);
+
+    /**
+     * Overridden CalculateCellDivisionVector() method.
+     *
+     * Return a unit vector that points in a direction randomly sampled from a von Mises distribution, i.e the arguments are redundant for this division rule.
+     *
+     * @param pParentCell  The cell to divide
+     * @param rCellPopulation  The vertex-based cell population
+     * @return the division vector.
+     */
+    virtual c_vector<double, SPACE_DIM> CalculateCellDivisionVector(CellPtr pParentCell,
+        VertexBasedCellPopulation<SPACE_DIM>& rCellPopulation);
+};
+
+#include "SerializationExportWrapper.hpp"
+EXPORT_TEMPLATE_CLASS_SAME_DIMS(VonMisesVertexBasedDivisionRule)
+
+#endif // VONMISESVERTEXBASEDDIVISIONRULE_HPP_

--- a/cell_based/src/population/forces/PlanarPolarisedFarhadifarForce.cpp
+++ b/cell_based/src/population/forces/PlanarPolarisedFarhadifarForce.cpp
@@ -1,0 +1,131 @@
+/*
+
+Copyright (c) 2005-2023, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "PlanarPolarisedFarhadifarForce.hpp"
+
+template<unsigned DIM>
+PlanarPolarisedFarhadifarForce<DIM>::PlanarPolarisedFarhadifarForce()
+   : FarhadifarForce<DIM>(),
+     mPlanarPolarisedLineTensionMultiplier(2.0)
+{
+}
+
+template<unsigned DIM>
+PlanarPolarisedFarhadifarForce<DIM>::~PlanarPolarisedFarhadifarForce()
+{
+}
+
+template<unsigned DIM>
+double PlanarPolarisedFarhadifarForce<DIM>::GetPlanarPolarisedLineTensionMultiplier()
+{
+    return mPlanarPolarisedLineTensionMultiplier;
+}
+
+template<unsigned DIM>
+void PlanarPolarisedFarhadifarForce<DIM>::SetPlanarPolarisedLineTensionMultiplier(double planarPolarisedLineTensionMultiplier)
+{
+    mPlanarPolarisedLineTensionMultiplier = planarPolarisedLineTensionMultiplier;
+}
+
+template<unsigned DIM>
+double PlanarPolarisedFarhadifarForce<DIM>::GetLineTensionParameter(Node<DIM>* pNodeA, Node<DIM>* pNodeB, VertexBasedCellPopulation<DIM>& rVertexCellPopulation)
+{
+    // Find the indices of the elements owned by each node
+    std::set<unsigned> elements_containing_nodeA = pNodeA->rGetContainingElementIndices();
+    std::set<unsigned> elements_containing_nodeB = pNodeB->rGetContainingElementIndices();
+
+    // Find common elements
+    std::set<unsigned> shared_elements;
+    std::set_intersection(elements_containing_nodeA.begin(),
+                          elements_containing_nodeA.end(),
+                          elements_containing_nodeB.begin(),
+                          elements_containing_nodeB.end(),
+                          std::inserter(shared_elements, shared_elements.begin()));
+
+    // Check that the nodes have a common edge
+    assert(!shared_elements.empty());
+
+    // Since each internal edge is visited twice in the loop above, we have to use half the line tension parameter
+    // for each visit.
+    double line_tension_parameter_in_calculation = this->mLineTensionParameter/2.0;
+
+    // If the edge corresponds to a single element, then the cell is on the boundary
+    if (shared_elements.size() == 1)
+    {
+        line_tension_parameter_in_calculation = this->mBoundaryLineTensionParameter;
+    }
+
+    // Get the vector between the two vertices
+    c_vector<double, 2> vector = pNodeB->rGetLocation() - pNodeA->rGetLocation();
+    double theta = atan2(fabs(vector(1)), fabs(vector(0)));
+
+    if ((theta > 0.25*M_PI) && (theta < 0.75*M_PI))
+    {
+        line_tension_parameter_in_calculation *= mPlanarPolarisedLineTensionMultiplier;
+    }
+
+    return line_tension_parameter_in_calculation;
+}
+
+template<unsigned DIM>
+double PlanarPolarisedFarhadifarForce<DIM>::GetLineTensionParameter()
+{
+    return this->mLineTensionParameter;
+}
+
+template<unsigned DIM>
+double PlanarPolarisedFarhadifarForce<DIM>::GetBoundaryLineTensionParameter()
+{
+    return this->mBoundaryLineTensionParameter;
+}
+
+
+template<unsigned DIM>
+void PlanarPolarisedFarhadifarForce<DIM>::OutputForceParameters(out_stream& rParamsFile)
+{
+    *rParamsFile << "\t\t\t<PlanarPolarisedLineTensionMultiplier>" << mPlanarPolarisedLineTensionMultiplier << "</PlanarPolarisedLineTensionMultiplier>\n";
+
+    // Call method on direct parent class
+    FarhadifarForce<DIM>::OutputForceParameters(rParamsFile);
+}
+
+// Explicit instantiation
+template class PlanarPolarisedFarhadifarForce<1>;
+template class PlanarPolarisedFarhadifarForce<2>;
+template class PlanarPolarisedFarhadifarForce<3>;
+
+// Serialization for Boost >= 1.36
+#include "SerializationExportWrapperForCpp.hpp"
+EXPORT_TEMPLATE_CLASS_SAME_DIMS(PlanarPolarisedFarhadifarForce)

--- a/cell_based/src/population/forces/PlanarPolarisedFarhadifarForce.hpp
+++ b/cell_based/src/population/forces/PlanarPolarisedFarhadifarForce.hpp
@@ -1,0 +1,140 @@
+/*
+
+Copyright (c) 2005-2023, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef PLANARPOLARISEDFARHADIFARFORCE_HPP_
+#define PLANARPOLARISEDFARHADIFARFORCE_HPP_
+
+#include "ChasteSerialization.hpp"
+#include <boost/serialization/base_object.hpp>
+
+#include "FarhadifarForce.hpp"
+
+
+/**
+ * A force class for use in vertex-based simulations. This force is based on the
+ * energy function proposed by Farhadifar et al in  Curr. Biol., 2007, 17, 2095-2104, 
+ * but with a planar polarised line tension parameter, similar to that proposed by 
+ * Rauzi et al in Nat. Cell Biol., 2008, 10, 1401-1410.
+ */
+template<unsigned DIM>
+class PlanarPolarisedFarhadifarForce : public FarhadifarForce<DIM>
+{
+friend class TestForces;
+
+private:
+
+    friend class boost::serialization::access;
+    /**
+     * Boost Serialization method for archiving/checkpointing.
+     * Archives the object and its member variables.
+     *
+     * @param archive  The boost archive.
+     * @param version  The current version of this class.
+     */
+    template<class Archive>
+    void serialize(Archive & archive, const unsigned int version)
+    {
+        archive & boost::serialization::base_object<FarhadifarForce<DIM> >(*this);
+        archive & mPlanarPolarisedLineTensionMultiplier;
+    }
+
+protected:
+
+    /**
+     * A scalar that multiplies the strength of the line tension term in the model for edges 
+     * whose angle relative to the x axis are between 45 degrees and 135 degrees.
+     */
+    double mPlanarPolarisedLineTensionMultiplier;
+
+
+public:
+
+    /**
+     * Constructor.
+     */
+    PlanarPolarisedFarhadifarForce();
+
+    /**
+     * Destructor.
+     */
+    virtual ~PlanarPolarisedFarhadifarForce();
+
+    /**
+     * Overridden GetLineTensionParameter() method.
+     * 
+     * Get the line tension parameter for the edge between two given nodes.
+     *
+     * @param pNodeA one node
+     * @param pNodeB the other node
+     * @param rVertexCellPopulation reference to the cell population
+     *
+     * @return the line tension parameter for this edge.
+     */
+    virtual double GetLineTensionParameter(Node<DIM>* pNodeA, Node<DIM>* pNodeB, VertexBasedCellPopulation<DIM>& rVertexCellPopulation);
+
+    /**
+     * @return mPlanarPolarisedLineTensionMultiplier
+     */
+    double GetPlanarPolarisedLineTensionMultiplier();
+
+    /**
+     * Set mPlanarPolarisedLineTensionMultiplier.
+     *
+     * @param planarPolarisedLineTensionMultiplier the new value of mPlanarPolarisedLineTensionMultiplier
+     */
+    void SetPlanarPolarisedLineTensionMultiplier(double planarPolarisedLineTensionMultiplier);
+
+    /**
+     * @return mLineTensionParameter
+     */
+    double GetLineTensionParameter();
+
+    /**
+     * @return mBoundaryLineTensionParameter
+     */
+    double GetBoundaryLineTensionParameter();
+
+    /**
+     * Overridden OutputForceParameters() method.
+     *
+     * @param rParamsFile the file stream to which the parameters are output
+     */
+    void OutputForceParameters(out_stream& rParamsFile);
+};
+
+#include "SerializationExportWrapper.hpp"
+EXPORT_TEMPLATE_CLASS_SAME_DIMS(PlanarPolarisedFarhadifarForce)
+
+#endif /*PLANARPOLARISEDFARHADIFARFORCE_HPP_*/

--- a/cell_based/src/simulation/modifiers/ConstantTargetAreaModifier.cpp
+++ b/cell_based/src/simulation/modifiers/ConstantTargetAreaModifier.cpp
@@ -1,0 +1,73 @@
+/*
+
+Copyright (c) 2005-2023, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "ConstantTargetAreaModifier.hpp"
+
+template<unsigned DIM>
+ConstantTargetAreaModifier<DIM>::ConstantTargetAreaModifier()
+    : AbstractTargetAreaModifier<DIM>()
+{
+}
+
+template<unsigned DIM>
+ConstantTargetAreaModifier<DIM>::~ConstantTargetAreaModifier()
+{
+}
+
+template<unsigned DIM>
+void ConstantTargetAreaModifier<DIM>::UpdateTargetAreaOfCell(CellPtr pCell)
+{
+    // Get target area A of a healthy cell in S, G2 or M phase
+    double cell_target_area = this->mReferenceTargetArea;
+
+    // Set cell data
+    pCell->GetCellData()->SetItem("target area", cell_target_area);
+}
+
+template<unsigned DIM>
+void ConstantTargetAreaModifier<DIM>::OutputSimulationModifierParameters(out_stream& rParamsFile)
+{
+    // No parameters to output, so just call method on direct parent class
+    AbstractTargetAreaModifier<DIM>::OutputSimulationModifierParameters(rParamsFile);
+}
+
+// Explicit instantiation
+template class ConstantTargetAreaModifier<1>;
+template class ConstantTargetAreaModifier<2>;
+template class ConstantTargetAreaModifier<3>;
+
+// Serialization for Boost >= 1.36
+#include "SerializationExportWrapperForCpp.hpp"
+EXPORT_TEMPLATE_CLASS_SAME_DIMS(ConstantTargetAreaModifier)

--- a/cell_based/src/simulation/modifiers/ConstantTargetAreaModifier.hpp
+++ b/cell_based/src/simulation/modifiers/ConstantTargetAreaModifier.hpp
@@ -1,0 +1,95 @@
+/*
+
+Copyright (c) 2005-2023, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef CONSTANTTARGETAREAMODIFIER_HPP_
+#define CONSTANTTARGETAREAMODIFIER_HPP_
+
+#include "ChasteSerialization.hpp"
+#include <boost/serialization/base_object.hpp>
+#include "AbstractTargetAreaModifier.hpp"
+
+/**
+ * A modifier class in which the target area property of each cell is held constant over time.
+ */
+template<unsigned DIM>
+class ConstantTargetAreaModifier : public AbstractTargetAreaModifier<DIM>
+{
+    /** Needed for serialization. */
+    friend class boost::serialization::access;
+    /**
+     * Boost Serialization method for archiving/checkpointing.
+     * Archives the object and its member variables.
+     *
+     * @param archive  The boost archive.
+     * @param version  The current version of this class.
+     */
+    template<class Archive>
+    void serialize(Archive & archive, const unsigned int version)
+    {
+        archive & boost::serialization::base_object<AbstractTargetAreaModifier<DIM> >(*this);
+    }
+
+public:
+
+    /**
+     * Default constructor.
+     */
+    ConstantTargetAreaModifier();
+
+    /**
+     * Destructor.
+     */
+    virtual ~ConstantTargetAreaModifier();
+
+    /**
+     * Overridden UpdateTargetAreaOfCell() method.
+     *
+     * @param pCell pointer to the cell
+     */
+    virtual void UpdateTargetAreaOfCell(const CellPtr pCell);
+
+    /**
+     * Overridden OutputSimulationModifierParameters() method.
+     * Output any simulation modifier parameters to file.
+     *
+     * @param rParamsFile the file stream to which the parameters are output
+     */
+    void OutputSimulationModifierParameters(out_stream& rParamsFile);
+};
+
+#include "SerializationExportWrapper.hpp"
+EXPORT_TEMPLATE_CLASS_SAME_DIMS(ConstantTargetAreaModifier)
+
+#endif /*CONSTANTTARGETAREAMODIFIER_HPP_*/

--- a/cell_based/src/simulation/modifiers/DivisionBiasTrackingModifier.cpp
+++ b/cell_based/src/simulation/modifiers/DivisionBiasTrackingModifier.cpp
@@ -1,0 +1,154 @@
+/*
+
+Copyright (c) 2005-2023, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "DivisionBiasTrackingModifier.hpp"
+#include "MeshBasedCellPopulation.hpp"
+
+template<unsigned DIM>
+DivisionBiasTrackingModifier<DIM>::DivisionBiasTrackingModifier(c_vector<double, DIM> divisionBiasVector)
+    : AbstractCellBasedSimulationModifier<DIM>(),
+      mDivisionBiasVector(divisionBiasVector)
+{
+    // mDivisionBiasVector must be a unit vector
+    assert(fabs(norm_2(mDivisionBiasVector) - 1.0) < 1e-6);
+}
+
+template<unsigned DIM>
+DivisionBiasTrackingModifier<DIM>::~DivisionBiasTrackingModifier()
+{
+}
+
+template<unsigned DIM>
+const c_vector<double, DIM>& DivisionBiasTrackingModifier<DIM>::rGetDivisionBiasVector() const
+{
+    return mDivisionBiasVector;
+}
+
+template<unsigned DIM>
+void DivisionBiasTrackingModifier<DIM>::UpdateAtEndOfTimeStep(AbstractCellPopulation<DIM,DIM>& rCellPopulation)
+{
+    UpdateCellData(rCellPopulation);
+}
+
+template<unsigned DIM>
+void DivisionBiasTrackingModifier<DIM>::SetupSolve(AbstractCellPopulation<DIM,DIM>& rCellPopulation, std::string outputDirectory)
+{
+    /*
+     * We must update CellData in SetupSolve(), otherwise it will not have been
+     * fully initialised by the time we enter the main time loop.
+     */
+    UpdateCellData(rCellPopulation);
+}
+
+template<unsigned DIM>
+void DivisionBiasTrackingModifier<DIM>::UpdateCellData(AbstractCellPopulation<DIM,DIM>& rCellPopulation)
+{
+    // Make sure the cell population is updated
+    rCellPopulation.Update();
+
+    /**
+     * This hack is needed because in the case of a MeshBasedCellPopulation in which
+     * multiple cell divisions have occurred over one time step, the Voronoi tessellation
+     * (while existing) is out-of-date. Thus, if we did not regenerate the Voronoi
+     * tessellation here, an assertion may trip as we try to access a Voronoi element
+     * whose index exceeds the number of elements in the out-of-date tessellation.
+     *
+     * \todo work out how to properly fix this (#1986)
+     */
+    if (bool(dynamic_cast<MeshBasedCellPopulation<DIM>*>(&rCellPopulation)))
+    {
+        static_cast<MeshBasedCellPopulation<DIM>*>(&(rCellPopulation))->CreateVoronoiTessellation();
+    }
+
+    // Find centroid of cell population
+    c_vector<double, DIM> centroid = rCellPopulation.GetCentroidOfCellPopulation();
+
+    /**
+     * Iterate over cell population and store each cell's signed distance along mDivisionBiasVector
+     * through the centroid of the cell population, where zero corresponds to a cell located at the 
+     * centroid of the cell population.
+     */
+    std::vector<double> biases;
+    for (typename AbstractCellPopulation<DIM>::Iterator cell_iter = rCellPopulation.Begin();
+         cell_iter != rCellPopulation.End();
+         ++cell_iter)
+    {
+        double distance = inner_prod(rCellPopulation.GetLocationOfCellCentre(*cell_iter) - centroid, mDivisionBiasVector);
+        biases.push_back(distance);
+    }
+
+    // Map signed distances into [0,1]
+    double min_distance = *std::min_element(biases.begin(), biases.end());
+    double max_distance = *std::max_element(biases.begin(), biases.end());
+    for (unsigned i = 0; i < biases.size(); i++)
+    {
+        biases[i] = (biases[i] - min_distance) / (max_distance - min_distance);
+    }
+
+    // Iterate over cell population
+    unsigned i = 0;
+    for (typename AbstractCellPopulation<DIM>::Iterator cell_iter = rCellPopulation.Begin();
+         cell_iter != rCellPopulation.End();
+         ++cell_iter)
+    {
+        // Store the cell's volume in CellData
+        cell_iter->GetCellData()->SetItem("bias", biases[i]);
+        i++;
+    }
+}
+
+template<unsigned DIM>
+void DivisionBiasTrackingModifier<DIM>::OutputSimulationModifierParameters(out_stream& rParamsFile)
+{
+    *rParamsFile << "\t\t\t<DivisionBiasVector>";
+    for (unsigned index=0; index != DIM-1U; index++) // Note: inequality avoids testing index < 0U when DIM=1
+    {
+        *rParamsFile << mDivisionBiasVector[index] << ",";
+    }
+    *rParamsFile << mDivisionBiasVector[DIM-1] << "</DivisionBiasVector>\n";
+
+    // Call method on direct parent class
+    AbstractCellBasedSimulationModifier<DIM>::OutputSimulationModifierParameters(rParamsFile);
+}
+
+// Explicit instantiation
+template class DivisionBiasTrackingModifier<1>;
+template class DivisionBiasTrackingModifier<2>;
+template class DivisionBiasTrackingModifier<3>;
+
+// Serialization for Boost >= 1.36
+#include "SerializationExportWrapperForCpp.hpp"
+EXPORT_TEMPLATE_CLASS_SAME_DIMS(DivisionBiasTrackingModifier)
+

--- a/cell_based/src/simulation/modifiers/DivisionBiasTrackingModifier.hpp
+++ b/cell_based/src/simulation/modifiers/DivisionBiasTrackingModifier.hpp
@@ -1,0 +1,174 @@
+/*
+
+Copyright (c) 2005-2023, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef DIVISIONBIASTRACKINGMODIFIER_HPP_
+#define DIVISIONBIASTRACKINGMODIFIER_HPP_
+
+#include "ChasteSerialization.hpp"
+#include <boost/serialization/base_object.hpp>
+
+#include "AbstractCellBasedSimulationModifier.hpp"
+
+/**
+ * A modifier class which at each simulation time step calculates a real number between 
+ * zero and 1 for each cell, which represents the normalised distance of the cell along 
+ * a given axis of the cell population through its centroid, and stores this number in 
+ * the CellData property as "bias". To be used in conjunction with the 
+ * BiasedBernoulliTrialCellCycleModel class.
+ */
+template<unsigned DIM>
+class DivisionBiasTrackingModifier : public AbstractCellBasedSimulationModifier<DIM,DIM>
+{
+private:
+
+    /**
+     * The specified axis along which division probability is biased.
+     * Initialized in the constructor.
+     */
+    c_vector<double, DIM> mDivisionBiasVector;
+
+    /** Needed for serialization. */
+    friend class boost::serialization::access;
+    /**
+     * Boost Serialization method for archiving/checkpointing.
+     * Archives the object and its member variables.
+     *
+     * @param archive  The boost archive.
+     * @param version  The current version of this class.
+     */
+    template<class Archive>
+    void serialize(Archive & archive, const unsigned int version)
+    {
+        archive & boost::serialization::base_object<AbstractCellBasedSimulationModifier<DIM,DIM> >(*this);
+    }
+
+public:
+
+    /**
+     * Constructor.
+     * 
+     * @param centre the specified axis along which division probability is biased
+     */
+    DivisionBiasTrackingModifier(c_vector<double, DIM> divisionBiasVector);
+
+    /**
+     * Destructor.
+     */
+    virtual ~DivisionBiasTrackingModifier();
+  
+    /**
+     * @return #mDivisionBiasVector.
+     */
+    const c_vector<double, DIM>& rGetDivisionBiasVector() const;
+    
+    /**
+     * Overridden UpdateAtEndOfTimeStep() method.
+     *
+     * Specify what to do in the simulation at the end of each time step.
+     *
+     * @param rCellPopulation reference to the cell population
+     */
+    virtual void UpdateAtEndOfTimeStep(AbstractCellPopulation<DIM,DIM>& rCellPopulation);
+
+    /**
+     * Overridden SetupSolve() method.
+     *
+     * Specify what to do in the simulation before the start of the time loop.
+     *
+     * @param rCellPopulation reference to the cell population
+     * @param outputDirectory the output directory, relative to where Chaste output is stored
+     */
+    virtual void SetupSolve(AbstractCellPopulation<DIM,DIM>& rCellPopulation, std::string outputDirectory);
+
+    /**
+     * Helper method to calculate the normalised distance of each cell in the population 
+     * along the division bias axis and store these in the CellData.
+     *
+     * @param rCellPopulation reference to the cell population
+     */
+    void UpdateCellData(AbstractCellPopulation<DIM,DIM>& rCellPopulation);
+
+    /**
+     * Overridden OutputSimulationModifierParameters() method.
+     * Output any simulation modifier parameters to file.
+     *
+     * @param rParamsFile the file stream to which the parameters are output
+     */
+    void OutputSimulationModifierParameters(out_stream& rParamsFile);
+};
+
+#include "SerializationExportWrapper.hpp"
+EXPORT_TEMPLATE_CLASS_SAME_DIMS(DivisionBiasTrackingModifier)
+
+namespace boost
+{
+namespace serialization
+{
+/**
+ * Serialize information required to construct a DivisionBiasTrackingModifier.
+ */
+template<class Archive, unsigned DIM>
+inline void save_construct_data(
+    Archive & ar, const DivisionBiasTrackingModifier<DIM>* t, const unsigned int file_version)
+{
+    // Archive c_vector one component at a time
+    c_vector<double, DIM> point = t->rGetDivisionBiasVector();
+    for (unsigned i=0; i<DIM; i++)
+    {
+        ar << point[i];
+    }
+}
+
+/**
+ * De-serialize constructor parameters and initialize a DivisionBiasTrackingModifier.
+ */
+template<class Archive, unsigned DIM>
+inline void load_construct_data(
+    Archive & ar, DivisionBiasTrackingModifier<DIM>* t, const unsigned int file_version)
+{
+    // Retrieve c_vector one component at a time
+    c_vector<double, DIM> point;
+    for (unsigned i=0; i<DIM; i++)
+    {
+        ar >> point[i];
+    }
+
+    // Invoke inplace constructor to initialise instance
+    ::new(t)DivisionBiasTrackingModifier<DIM>(point);
+}
+}
+} // namespace ...
+
+#endif /*DIVISIONBIASTRACKINGMODIFIER_HPP_*/

--- a/cell_based/src/simulation/modifiers/ExtrinsicPullModifier.cpp
+++ b/cell_based/src/simulation/modifiers/ExtrinsicPullModifier.cpp
@@ -1,0 +1,137 @@
+/*
+
+Copyright (c) 2005-2023, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "ExtrinsicPullModifier.hpp"
+
+template<unsigned DIM>
+ExtrinsicPullModifier<DIM>::ExtrinsicPullModifier()
+    : AbstractCellBasedSimulationModifier<DIM>(),
+      mApplyExtrinsicPullToAllNodes(true),
+      mSpeed(1.0)
+{
+}
+
+template<unsigned DIM>
+ExtrinsicPullModifier<DIM>::~ExtrinsicPullModifier()
+{
+}
+
+template<unsigned DIM>
+void ExtrinsicPullModifier<DIM>::UpdateAtEndOfTimeStep(AbstractCellPopulation<DIM,DIM>& rCellPopulation)
+{
+    double epsilon = 0.8;
+
+    double dt = SimulationTime::Instance()->GetTimeStep();
+    unsigned num_nodes = rCellPopulation.GetNumNodes();
+    ChasteCuboid<DIM> bounds = rCellPopulation.rGetMesh().CalculateBoundingBox();
+    double x_min = bounds.rGetLowerCorner()[0];
+    double x_max = bounds.rGetUpperCorner()[0];
+
+    if (mApplyExtrinsicPullToAllNodes)
+    {
+        // Pull on all nodes, with a constant strain rate
+        double width = x_max - x_min;
+        for (unsigned node_index=0; node_index<num_nodes; node_index++)
+        {
+            Node<DIM>* p_node = rCellPopulation.GetNode(node_index);
+            double speed = mSpeed * (p_node->rGetLocation()[0] - x_min) / width;
+
+            if (p_node->rGetLocation()[0] > x_min + epsilon)
+            {
+                    p_node->rGetModifiableLocation()[0] += speed*dt;
+            }
+        }
+    }
+    else
+    {
+        // Pull on the right-most nodes only, with a constant speed
+        for (unsigned node_index=0; node_index<num_nodes; node_index++)
+        {
+            Node<DIM>* p_node = rCellPopulation.GetNode(node_index);
+            if (fabs(p_node->rGetLocation()[0] - x_max) < 0.1)
+            {
+                p_node->rGetModifiableLocation()[0] += mSpeed*dt;
+            }
+        }
+    }
+}
+
+template<unsigned DIM>
+void ExtrinsicPullModifier<DIM>::SetupSolve(AbstractCellPopulation<DIM,DIM>& rCellPopulation, std::string outputDirectory)
+{
+}
+
+template<unsigned DIM>
+void ExtrinsicPullModifier<DIM>::SetApplyExtrinsicPullToAllNodes(bool applyExtrinsicPullToAllNodes)
+{
+    mApplyExtrinsicPullToAllNodes = applyExtrinsicPullToAllNodes;
+}
+
+template<unsigned DIM>
+void ExtrinsicPullModifier<DIM>::SetSpeed(double speed)
+{
+    mSpeed = speed;
+}
+
+template<unsigned DIM>
+bool ExtrinsicPullModifier<DIM>::GetApplyExtrinsicPullToAllNodes()
+{
+    return mApplyExtrinsicPullToAllNodes;
+}
+
+template<unsigned DIM>
+double ExtrinsicPullModifier<DIM>::GetSpeed()
+{
+    return mSpeed;
+}
+
+template<unsigned DIM>
+void ExtrinsicPullModifier<DIM>::OutputSimulationModifierParameters(out_stream& rParamsFile)
+{
+    *rParamsFile << "\t\t\t<ApplyExtrinsicPullToAllNodes>" << mApplyExtrinsicPullToAllNodes << "</ApplyExtrinsicPullToAllNodes>\n";
+    *rParamsFile << "\t\t\t<Speed>" << mSpeed << "</Speed>\n";
+
+    // Next, call method on direct parent class
+    AbstractCellBasedSimulationModifier<DIM>::OutputSimulationModifierParameters(rParamsFile);
+}
+
+// Explicit instantiation
+template class ExtrinsicPullModifier<1>;
+template class ExtrinsicPullModifier<2>;
+template class ExtrinsicPullModifier<3>;
+
+// Serialization for Boost >= 1.36
+#include "SerializationExportWrapperForCpp.hpp"
+EXPORT_TEMPLATE_CLASS_SAME_DIMS(ExtrinsicPullModifier)

--- a/cell_based/src/simulation/modifiers/ExtrinsicPullModifier.hpp
+++ b/cell_based/src/simulation/modifiers/ExtrinsicPullModifier.hpp
@@ -1,0 +1,144 @@
+/*
+
+Copyright (c) 2005-2023, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef EXTRINSICPULLMODIFIER_HPP_
+#define EXTRINSICPULLMODIFIER_HPP_
+
+#include "ChasteSerialization.hpp"
+#include <boost/serialization/base_object.hpp>
+
+#include "AbstractCellBasedSimulationModifier.hpp"
+
+/**
+ * A modifier class which at each simulation time step applies an extrinsic 
+ * pull to the right at a specified speed, optionally applying this to all 
+ * nodes or else just the right-most nodes.
+ */
+template<unsigned DIM>
+class ExtrinsicPullModifier : public AbstractCellBasedSimulationModifier<DIM,DIM>
+{
+private:
+
+    /** Needed for serialization. */
+    friend class boost::serialization::access;
+    /**
+     * Boost Serialization method for archiving/checkpointing.
+     * Archives the object and its member variables.
+     *
+     * @param archive  The boost archive.
+     * @param version  The current version of this class.
+     */
+    template<class Archive>
+    void serialize(Archive & archive, const unsigned int version)
+    {
+        archive & boost::serialization::base_object<AbstractCellBasedSimulationModifier<DIM,DIM> >(*this);
+        archive & mApplyExtrinsicPullToAllNodes;
+        archive & mSpeed;
+    }
+
+    /**
+     * Whether to apply extrinsic pull on all nodes (or just the right-most nodes).
+     */
+    bool mApplyExtrinsicPullToAllNodes;
+
+    /**
+     * The speed of the extrinsic pull.
+     */
+    double mSpeed;
+
+public:
+
+    /**
+     * Default constructor.
+     */
+    ExtrinsicPullModifier();
+
+    /**
+     * Destructor.
+     */
+    virtual ~ExtrinsicPullModifier();
+
+    /**
+     * Overridden UpdateAtEndOfTimeStep() method.
+     *
+     * Specifies what to do in the simulation at the end of each time step.
+     *
+     * @param rCellPopulation reference to the cell population
+     */
+    virtual void UpdateAtEndOfTimeStep(AbstractCellPopulation<DIM,DIM>& rCellPopulation);
+
+    /**
+     * Overridden SetupSolve() method.
+     *
+     * Specifies what to do in the simulation before the start of the time loop.
+     *
+     * @param rCellPopulation reference to the cell population
+     * @param outputDirectory the output directory, relative to where Chaste output is stored
+     */
+    virtual void SetupSolve(AbstractCellPopulation<DIM,DIM>& rCellPopulation, std::string outputDirectory);
+
+    /**
+     * @param applyExtrinsicPullToAllNodes whether to apply the extrinsic pull to all nodes in the tissue
+     */
+    void SetApplyExtrinsicPullToAllNodes(bool applyExtrinsicPullToAllNodes);
+
+    /**
+     * @param speed the speed of the extrinsic pull
+     */
+    void SetSpeed(double speed);
+    
+    /**
+     * @return #mApplyExtrinsicPullToAllNodes
+     */
+    bool GetApplyExtrinsicPullToAllNodes();
+
+    /**
+     * @return #mSpeed
+     */
+    double GetSpeed();
+
+    /**
+     * Overridden OutputSimulationModifierParameters() method.
+     * Output any simulation modifier parameters to file.
+     *
+     * @param rParamsFile the file stream to which the parameters are output
+     */
+    void OutputSimulationModifierParameters(out_stream& rParamsFile);
+};
+
+#include "SerializationExportWrapper.hpp"
+EXPORT_TEMPLATE_CLASS_SAME_DIMS(ExtrinsicPullModifier)
+
+#endif /*EXTRINSICPULLMODIFIER_HPP_*/

--- a/cell_based/test/ContinuousTestPack.txt
+++ b/cell_based/test/ContinuousTestPack.txt
@@ -63,6 +63,7 @@ population/TestVertexBasedCellPopulation.hpp
 population/TestVertexBasedDivisionRules.hpp
 simulation/TestConstantTargetAreaModifier.hpp
 simulation/TestDeltaNotchModifier.hpp
+simulation/TestExtrinsicPullModifier.hpp
 simulation/TestNumericalMethods.hpp
 simulation/TestDivisionBiasTrackingModifier.hpp
 simulation/TestOffLatticeSimulation.hpp

--- a/cell_based/test/ContinuousTestPack.txt
+++ b/cell_based/test/ContinuousTestPack.txt
@@ -63,6 +63,7 @@ population/TestVertexBasedCellPopulation.hpp
 population/TestVertexBasedDivisionRules.hpp
 simulation/TestDeltaNotchModifier.hpp
 simulation/TestNumericalMethods.hpp
+simulation/TestDivisionBiasTrackingModifier.hpp
 simulation/TestOffLatticeSimulation.hpp
 simulation/TestOffLatticeSimulation3d.hpp
 simulation/TestOffLatticeSimulationWithBuskeForces.hpp

--- a/cell_based/test/ContinuousTestPack.txt
+++ b/cell_based/test/ContinuousTestPack.txt
@@ -61,6 +61,7 @@ population/TestPottsUpdateRules.hpp
 population/TestT2SwapCellKiller.hpp
 population/TestVertexBasedCellPopulation.hpp
 population/TestVertexBasedDivisionRules.hpp
+simulation/TestConstantTargetAreaModifier.hpp
 simulation/TestDeltaNotchModifier.hpp
 simulation/TestNumericalMethods.hpp
 simulation/TestDivisionBiasTrackingModifier.hpp

--- a/cell_based/test/cell/TestSimpleCellCycleModels.hpp
+++ b/cell_based/test/cell/TestSimpleCellCycleModels.hpp
@@ -69,6 +69,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "UniformCellCycleModel.hpp"
 #include "UniformG1GenerationalCellCycleModel.hpp"
 #include "WildTypeCellMutationState.hpp"
+#include "BiasedBernoulliTrialCellCycleModel.hpp"
 
 //This test is always run sequentially (never in parallel)
 #include "FakePetscSetup.hpp"
@@ -1051,6 +1052,72 @@ public:
         TS_ASSERT_EQUALS(p_hepa_one_model2->GetCurrentCellCyclePhase(), M_PHASE);
     }
 
+    void TestBiasedBernoulliTrialCellCycleModel()
+    {
+        BiasedBernoulliTrialCellCycleModel* p_diff_model = new BiasedBernoulliTrialCellCycleModel;
+        p_diff_model->SetDimension(2);
+        p_diff_model->SetBirthTime(0.0);
+        BiasedBernoulliTrialCellCycleModel* p_transit_model = new BiasedBernoulliTrialCellCycleModel;
+        p_transit_model->SetDimension(2);
+        p_transit_model->SetBirthTime(0.0);
+
+        TS_ASSERT_DELTA(p_transit_model->GetMaxDivisionProbability(), 0.1, 1e-9);
+        TS_ASSERT_DELTA(p_transit_model->GetMinimumDivisionAge(), 1.0, 1e-9);
+
+        // Change parameters for this model
+        p_transit_model->SetMaxDivisionProbability(1.0);
+        p_transit_model->SetMinimumDivisionAge(0.1);
+        TS_ASSERT_DELTA(p_transit_model->GetMaxDivisionProbability(), 1.0, 1e-9);
+        TS_ASSERT_DELTA(p_transit_model->GetMinimumDivisionAge(), 0.1, 1e-9);
+
+        MAKE_PTR(WildTypeCellMutationState, p_healthy_state);
+        MAKE_PTR(TransitCellProliferativeType, p_transit_type);
+        MAKE_PTR(DifferentiatedCellProliferativeType, p_diff_type);
+
+        CellPtr p_transit_cell(new Cell(p_healthy_state, p_transit_model));
+        p_transit_cell->SetCellProliferativeType(p_transit_type);
+        p_transit_cell->GetCellData()->SetItem("bias", 0.9);
+        p_transit_cell->InitialiseCellCycleModel();
+
+        CellPtr p_diff_cell(new Cell(p_healthy_state, p_diff_model));
+        p_diff_cell->SetCellProliferativeType(p_diff_type);
+        p_diff_cell->GetCellData()->SetItem("bias", 0.2);
+        p_diff_cell->InitialiseCellCycleModel();
+
+        SimulationTime* p_simulation_time = SimulationTime::Instance();
+        unsigned num_steps = 100;
+        p_simulation_time->SetEndTimeAndNumberOfTimeSteps(10.0, num_steps);
+
+        for (unsigned i = 0; i < num_steps; i++)
+        {
+            p_simulation_time->IncrementTimeOneStep();
+            
+            // The division time below is taken from the first random number generated
+            if (i < 16)
+            {
+                TS_ASSERT_EQUALS(p_transit_cell->ReadyToDivide(), false);
+            }
+            else
+            {
+                TS_ASSERT_EQUALS(p_transit_cell->ReadyToDivide(), true);
+            }
+            TS_ASSERT_EQUALS(p_diff_cell->ReadyToDivide(), false);
+        }
+        TS_ASSERT_DELTA(p_transit_model->GetAge(), p_simulation_time->GetTime(), 1e-9);
+        TS_ASSERT_DELTA(p_diff_model->GetAge(), p_simulation_time->GetTime(), 1e-9);
+
+        // Check that cell division correctly resets the cell cycle phase
+        CellPtr p_transit_cell2 = p_transit_cell->Divide();
+        BiasedBernoulliTrialCellCycleModel* p_transit_model2 = static_cast<BiasedBernoulliTrialCellCycleModel*>(p_transit_cell2->GetCellCycleModel());
+
+        TS_ASSERT_EQUALS(p_transit_model2->ReadyToDivide(), false);
+        TS_ASSERT_DELTA(p_transit_model2->GetMaxDivisionProbability(), 1.0, 1e-9);
+        TS_ASSERT_DELTA(p_transit_model2->GetMinimumDivisionAge(), 0.1, 1e-9);
+
+        TS_ASSERT_DELTA(p_transit_model2->GetAverageTransitCellCycleTime(), 1.0, 1e-9);
+        TS_ASSERT_DELTA(p_transit_model2->GetAverageStemCellCycleTime(), 1.0, 1e-9);
+    }
+
     void TestStochasticOxygenBasedCellCycleModel()
     {
         // Check that mCurrentHypoxiaOnsetTime and mCurrentHypoxicDuration are updated correctly
@@ -1302,6 +1369,55 @@ public:
             TS_ASSERT_EQUALS(p_model2->GetDimension(), 2u);
             TS_ASSERT_DELTA(static_cast<BernoulliTrialCellCycleModel*>(p_model2)->GetDivisionProbability(), 0.5, 1e-9);
             TS_ASSERT_DELTA(static_cast<BernoulliTrialCellCycleModel*>(p_model2)->GetMinimumDivisionAge(), 0.1, 1e-9);
+
+            // Avoid memory leaks
+            delete p_model2;
+        }
+    }
+
+    void TestArchiveBiasedBernoulliTrialCellCycleModel()
+    {
+        OutputFileHandler handler("archive", false);
+        std::string archive_filename = handler.GetOutputDirectoryFullPath() + "BiasedBernoulliTrialCellCycleModel.arch";
+
+        {
+            // We must set up SimulationTime to avoid memory leaks
+            SimulationTime::Instance()->SetEndTimeAndNumberOfTimeSteps(1.0, 1);
+
+            // As usual, we archive via a pointer to the most abstract class possible
+            AbstractCellCycleModel* const p_model = new BiasedBernoulliTrialCellCycleModel;
+
+            p_model->SetDimension(2);
+            p_model->SetBirthTime(-1.0);
+            static_cast<BiasedBernoulliTrialCellCycleModel*>(p_model)->SetMaxDivisionProbability(0.4);
+            static_cast<BiasedBernoulliTrialCellCycleModel*>(p_model)->SetMinimumDivisionAge(0.7);
+
+            std::ofstream ofs(archive_filename.c_str());
+            boost::archive::text_oarchive output_arch(ofs);
+
+            output_arch << p_model;
+
+            delete p_model;
+            SimulationTime::Destroy();
+        }
+
+        {
+            // We must set SimulationTime::mStartTime here to avoid tripping an assertion
+            SimulationTime::Instance()->SetStartTime(0.0);
+
+            AbstractCellCycleModel* p_model2;
+
+            std::ifstream ifs(archive_filename.c_str(), std::ios::binary);
+            boost::archive::text_iarchive input_arch(ifs);
+
+            input_arch >> p_model2;
+
+            // Check private data has been restored correctly
+            TS_ASSERT_DELTA(p_model2->GetBirthTime(), -1.0, 1e-12);
+            TS_ASSERT_DELTA(p_model2->GetAge(), 1.0, 1e-12);
+            TS_ASSERT_EQUALS(p_model2->GetDimension(), 2u);
+            TS_ASSERT_DELTA(static_cast<BiasedBernoulliTrialCellCycleModel*>(p_model2)->GetMaxDivisionProbability(), 0.4, 1e-9);
+            TS_ASSERT_DELTA(static_cast<BiasedBernoulliTrialCellCycleModel*>(p_model2)->GetMinimumDivisionAge(), 0.7, 1e-9);
 
             // Avoid memory leaks
             delete p_model2;
@@ -1749,6 +1865,22 @@ public:
             TS_ASSERT(comparer.CompareFiles());
         }
 
+        // Test with BiasedBernoulliTrialCellCycleModel
+        BiasedBernoulliTrialCellCycleModel biased_random_division_cell_cycle_model;
+        TS_ASSERT_EQUALS(biased_random_division_cell_cycle_model.GetIdentifier(), "BiasedBernoulliTrialCellCycleModel");
+
+        out_stream biased_random_division_parameter_file = output_file_handler.OpenOutputFile("biased_random_division_results.parameters");
+        biased_random_division_cell_cycle_model.OutputCellCycleModelParameters(biased_random_division_parameter_file);
+        biased_random_division_parameter_file->close();
+
+        {
+            FileFinder generated_file = output_file_handler.FindFile("biased_random_division_results.parameters");
+            FileFinder reference_file("cell_based/test/data/TestCellCycleModels/biased_random_division_results.parameters",
+                                      RelativeTo::ChasteSourceRoot);
+            FileComparison comparer(generated_file, reference_file);
+            TS_ASSERT(comparer.CompareFiles());
+        }
+    
         // Test with FixedG1GenerationalCellCycleModel
         FixedG1GenerationalCellCycleModel fixed_duration_generation_based_cell_cycle_model;
         TS_ASSERT_EQUALS(fixed_duration_generation_based_cell_cycle_model.GetIdentifier(), "FixedG1GenerationalCellCycleModel");

--- a/cell_based/test/data/TestCellBoundaryConditionsOutputParameters/sliding_results.parameters
+++ b/cell_based/test/data/TestCellBoundaryConditionsOutputParameters/sliding_results.parameters
@@ -1,0 +1,1 @@
+			<Threshold>0.56</Threshold>

--- a/cell_based/test/data/TestCellCycleModels/biased_random_division_results.parameters
+++ b/cell_based/test/data/TestCellCycleModels/biased_random_division_results.parameters
@@ -1,0 +1,2 @@
+			<MaxDivisionProbability>0.1</MaxDivisionProbability>
+			<MinimumDivisionAge>1</MinimumDivisionAge>

--- a/cell_based/test/data/TestCellCycleModels/label_random_division_results.parameters
+++ b/cell_based/test/data/TestCellCycleModels/label_random_division_results.parameters
@@ -1,0 +1,2 @@
+			<DivisionProbability>0.1</DivisionProbability>
+			<MinimumDivisionAge>1</MinimumDivisionAge>

--- a/cell_based/test/data/TestExtrinsicPullModifierOutputParameters/ExtrinsicPullModifier.parameters
+++ b/cell_based/test/data/TestExtrinsicPullModifierOutputParameters/ExtrinsicPullModifier.parameters
@@ -1,0 +1,2 @@
+			<ApplyExtrinsicPullToAllNodes>1</ApplyExtrinsicPullToAllNodes>
+			<Speed>1</Speed>

--- a/cell_based/test/data/TestForces/planar_results.parameters
+++ b/cell_based/test/data/TestForces/planar_results.parameters
@@ -1,0 +1,5 @@
+			<PlanarPolarisedLineTensionMultiplier>2</PlanarPolarisedLineTensionMultiplier>
+			<AreaElasticityParameter>1</AreaElasticityParameter>
+			<PerimeterContractilityParameter>0.04</PerimeterContractilityParameter>
+			<LineTensionParameter>0.12</LineTensionParameter>
+			<BoundaryLineTensionParameter>0.12</BoundaryLineTensionParameter>

--- a/cell_based/test/data/TestSimulationModifierOutputParameters/ConstantTargetAreaModifier.parameters
+++ b/cell_based/test/data/TestSimulationModifierOutputParameters/ConstantTargetAreaModifier.parameters
@@ -1,0 +1,1 @@
+			<ReferenceTargetArea>6.2</ReferenceTargetArea>

--- a/cell_based/test/data/TestSimulationModifierOutputParameters/DivisionBiasTrackingModifier.parameters
+++ b/cell_based/test/data/TestSimulationModifierOutputParameters/DivisionBiasTrackingModifier.parameters
@@ -1,0 +1,1 @@
+			<DivisionBiasVector>1,0</DivisionBiasVector>

--- a/cell_based/test/population/TestCellPopulationBoundaryConditions.hpp
+++ b/cell_based/test/population/TestCellPopulationBoundaryConditions.hpp
@@ -445,20 +445,16 @@ public:
     void TestSlidingBoundaryCondition()
     {
         // Create mesh
-        HoneycombMeshGenerator generator(2, 2, 0);
-        MutableMesh<2,2>* p_generating_mesh = generator.GetMesh();
-
-        // Convert this to a NodesOnlyMesh
-        NodesOnlyMesh<2> mesh;
-        mesh.ConstructNodesWithoutMesh(*p_generating_mesh, 1.5);
+        HoneycombVertexMeshGenerator generator(2, 2);
+        MutableVertexMesh<2,2>* p_mesh = generator.GetMesh();
 
         // Create cells
         std::vector<CellPtr> cells;
         CellsGenerator<FixedG1GenerationalCellCycleModel, 2> cells_generator;
-        cells_generator.GenerateBasic(cells, mesh.GetNumNodes());
+        cells_generator.GenerateBasic(cells, p_mesh->GetNumElements());
 
         // Create cell population
-        NodeBasedCellPopulation<2> cell_population(mesh, cells);
+        VertexBasedCellPopulation<2> cell_population(*p_mesh, cells);
 
         double threshold = 0.2;
         SlidingBoundaryCondition<2> boundary_condition(&cell_population, threshold);

--- a/cell_based/test/population/TestCellPopulationBoundaryConditions.hpp
+++ b/cell_based/test/population/TestCellPopulationBoundaryConditions.hpp
@@ -49,6 +49,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "PottsMeshGenerator.hpp"
 #include "PlaneBoundaryCondition.hpp"
 #include "SphereGeometryBoundaryCondition.hpp"
+#include "SlidingBoundaryCondition.hpp"
 #include "MeshBasedCellPopulation.hpp"
 #include "TrianglesMeshReader.hpp"
 #include "WildTypeCellMutationState.hpp"
@@ -441,6 +442,88 @@ public:
         TS_ASSERT_EQUALS(bc_3d.VerifyBoundaryCondition(), true);
     }
 
+    void TestSlidingBoundaryCondition()
+    {
+        // Create mesh
+        HoneycombMeshGenerator generator(2, 2, 0);
+        MutableMesh<2,2>* p_generating_mesh = generator.GetMesh();
+
+        // Convert this to a NodesOnlyMesh
+        NodesOnlyMesh<2> mesh;
+        mesh.ConstructNodesWithoutMesh(*p_generating_mesh, 1.5);
+
+        // Create cells
+        std::vector<CellPtr> cells;
+        CellsGenerator<FixedG1GenerationalCellCycleModel, 2> cells_generator;
+        cells_generator.GenerateBasic(cells, mesh.GetNumNodes());
+
+        // Create cell population
+        NodeBasedCellPopulation<2> cell_population(mesh, cells);
+
+        double threshold = 0.2;
+        SlidingBoundaryCondition<2> boundary_condition(&cell_population, threshold);
+
+        // Test GetThreshold() method
+        TS_ASSERT_DELTA(boundary_condition.GetThreshold(), threshold, 1e-6);
+
+        // Impose boundary condition
+        std::map<Node<2>*, c_vector<double,2> > old_locations;
+        for (MutableVertexMesh<2,2>::NodeIterator node_iter = cell_population.rGetMesh().GetNodeIteratorBegin();
+             node_iter != cell_population.rGetMesh().GetNodeIteratorEnd();
+             ++node_iter)
+        {
+            old_locations[&(*node_iter)] = node_iter->rGetLocation();
+        }
+        boundary_condition.ImposeBoundaryCondition(old_locations);
+
+        // Test that all nodes satisfy the boundary condition
+        for (MutableVertexMesh<2,2>::NodeIterator node_iter = cell_population.rGetMesh().GetNodeIteratorBegin();
+             node_iter != cell_population.rGetMesh().GetNodeIteratorEnd();
+             ++node_iter)
+        {
+            c_vector<double, 2> location;
+            location = node_iter->rGetLocation();
+            if (old_locations[&(*node_iter)][0] < threshold)
+            {
+                TS_ASSERT_DELTA(0.0, location[0], 1e-6);
+                TS_ASSERT_DELTA(location[1], old_locations[&(*node_iter)][1], 1e-6);
+            }
+            else
+            {
+                TS_ASSERT_DELTA(location[0], old_locations[&(*node_iter)][0], 1e-6);
+                TS_ASSERT_DELTA(location[1], old_locations[&(*node_iter)][1], 1e-6);
+            }
+        }
+
+        // Test VerifyBoundaryCondition() method
+        TS_ASSERT_EQUALS(boundary_condition.VerifyBoundaryCondition(), true);
+    }
+
+    void TestSlidingBoundaryConditionException()
+    {
+        // Create a simple 2D PottsMesh
+        PottsMeshGenerator<2> generator(6, 2, 2, 6, 2, 2);
+        PottsMesh<2>* p_mesh = generator.GetMesh();
+
+        // Create cells
+        std::vector<CellPtr> cells;
+        MAKE_PTR(DifferentiatedCellProliferativeType, p_diff_type);
+        CellsGenerator<FixedG1GenerationalCellCycleModel, 2> cells_generator;
+        cells_generator.GenerateBasicRandom(cells, p_mesh->GetNumElements(), p_diff_type);
+
+        // Create cell population
+        PottsBasedCellPopulation<2> potts_cell_population(*p_mesh, cells);
+
+        // Attempt to set up cell population boundary condition
+        double threshold = 0.4;
+        SlidingBoundaryCondition<2> sliding_boundary_condition(&potts_cell_population, threshold);
+        std::map<Node<2>*, c_vector<double, 2> > old_locations;
+
+        // Test the correct exception is thrown
+        TS_ASSERT_THROWS_THIS(sliding_boundary_condition.ImposeBoundaryCondition(old_locations),
+            "SlidingBoundaryCondition requires a subclass of AbstractOffLatticeCellPopulation.");
+    }
+
     void TestArchivingOfPlaneBoundaryCondition()
     {
         EXIT_IF_PARALLEL;    // We cannot archive parallel cell based simulations yet.
@@ -563,6 +646,61 @@ public:
         }
     }
 
+    void TestArchivingOfSlidingBoundaryCondition()
+    {
+        EXIT_IF_PARALLEL;    // We cannot archive parallel cell based simulations yet.
+
+        TrianglesMeshReader<2,2> mesh_reader("mesh/test/data/square_4_elements");
+        TetrahedralMesh<2,2> generating_mesh;
+        generating_mesh.ConstructFromMeshReader(mesh_reader);
+
+        NodesOnlyMesh<2> mesh;
+        mesh.ConstructNodesWithoutMesh(generating_mesh, 1.5);
+
+        std::vector<CellPtr> cells;
+        CellsGenerator<FixedG1GenerationalCellCycleModel, 2> cells_generator;
+        cells_generator.GenerateBasic(cells, mesh.GetNumNodes());
+
+        NodeBasedCellPopulation<2> population(mesh, cells);
+
+        FileFinder archive_dir("archive", RelativeTo::ChasteTestOutput);
+        std::string archive_file = "SlidingBoundaryCondition.arch";
+        ArchiveLocationInfo::SetMeshFilename("SlidingBoundaryCondition");
+
+        {
+            // Create an output archive
+            SlidingBoundaryCondition<2> boundary_condition(&population, 0.56);
+
+            TS_ASSERT_DELTA(boundary_condition.GetThreshold(), 0.56, 1e-6);
+
+            // Create an output archive
+            ArchiveOpener<boost::archive::text_oarchive, std::ofstream> arch_opener(archive_dir, archive_file);
+            boost::archive::text_oarchive* p_arch = arch_opener.GetCommonArchive();
+
+            // Serialize via pointer
+            AbstractCellPopulationBoundaryCondition<2>* const p_boundary_condition = &boundary_condition;
+            (*p_arch) << p_boundary_condition;
+        }
+
+        {
+            // Create an input archive
+            ArchiveOpener<boost::archive::text_iarchive, std::ifstream> arch_opener(archive_dir, archive_file);
+            boost::archive::text_iarchive* p_arch = arch_opener.GetCommonArchive();
+
+            AbstractCellPopulationBoundaryCondition<2,2>* p_boundary_condition;
+
+            // Restore from the archive
+            (*p_arch) >> p_boundary_condition;
+
+            // Test we have restored the plane geometry correctly
+            TS_ASSERT_DELTA(static_cast<SlidingBoundaryCondition<2>*>(p_boundary_condition)->GetThreshold(), 0.56, 1e-6);
+
+            // Tidy up
+            delete p_boundary_condition->mpCellPopulation;
+            delete p_boundary_condition;
+       }
+    }
+
     void TestCellBoundaryConditionsOutputParameters()
     {
         EXIT_IF_PARALLEL;
@@ -612,6 +750,23 @@ public:
             // Compare the generated file in test output with a reference copy in the source code.
             FileFinder generated = output_file_handler.FindFile("sphere_results.parameters");
             FileFinder reference("cell_based/test/data/TestCellBoundaryConditionsOutputParameters/sphere_results.parameters",
+                    RelativeTo::ChasteSourceRoot);
+            FileComparison comparer(generated, reference);
+            TS_ASSERT(comparer.CompareFiles());
+        }
+
+        // Test with SlidingBoundaryCondition
+        SlidingBoundaryCondition<2> sliding_boundary_condition(&population, 0.56);
+        TS_ASSERT_EQUALS(sliding_boundary_condition.GetIdentifier(), "SlidingBoundaryCondition-2");
+
+        out_stream sliding_boundary_condition_parameter_file = output_file_handler.OpenOutputFile("sliding_results.parameters");
+        sliding_boundary_condition.OutputCellPopulationBoundaryConditionParameters(sliding_boundary_condition_parameter_file);
+        sliding_boundary_condition_parameter_file->close();
+
+        {
+            // Compare the generated file in test output with a reference copy in the source code.
+            FileFinder generated = output_file_handler.FindFile("sliding_results.parameters");
+            FileFinder reference("cell_based/test/data/TestCellBoundaryConditionsOutputParameters/sliding_results.parameters",
                     RelativeTo::ChasteSourceRoot);
             FileComparison comparer(generated, reference);
             TS_ASSERT(comparer.CompareFiles());

--- a/cell_based/test/population/TestForces.hpp
+++ b/cell_based/test/population/TestForces.hpp
@@ -54,6 +54,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "NagaiHondaDifferentialAdhesionForce.hpp"
 #include "WelikyOsterForce.hpp"
 #include "FarhadifarForce.hpp"
+#include "PlanarPolarisedFarhadifarForce.hpp"
 #include "DiffusionForce.hpp"
 #include "AbstractCellBasedTestSuite.hpp"
 #include "ApcOneHitCellMutationState.hpp"
@@ -641,16 +642,33 @@ public:
             TS_ASSERT(comparer.CompareFiles());
         }
 
-        FarhadifarForce<2> force;
-        TS_ASSERT_EQUALS(force.GetIdentifier(), "FarhadifarForce-2");
+        // Test with FarhadifarForce
+        FarhadifarForce<2> farhadifar_force;
+        TS_ASSERT_EQUALS(farhadifar_force.GetIdentifier(), "FarhadifarForce-2");
 
         out_stream farhadifar_force_parameter_file = output_file_handler.OpenOutputFile("farhadifar_results.parameters");
-        force.OutputForceParameters(farhadifar_force_parameter_file);
+        farhadifar_force.OutputForceParameters(farhadifar_force_parameter_file);
         farhadifar_force_parameter_file->close();
 
         {
             FileFinder generated_file = output_file_handler.FindFile("farhadifar_results.parameters");
             FileFinder reference_file("cell_based/test/data/TestForces/farhadifar_results.parameters",
+                    RelativeTo::ChasteSourceRoot);
+            FileComparison comparer(generated_file,reference_file);
+            TS_ASSERT(comparer.CompareFiles());
+        }
+
+        // Test with PlanarPolarisedFarhadifarForce
+        PlanarPolarisedFarhadifarForce<2> planar_force;
+        TS_ASSERT_EQUALS(planar_force.GetIdentifier(), "PlanarPolarisedFarhadifarForce-2");
+
+        out_stream planar_force_parameter_file = output_file_handler.OpenOutputFile("planar_results.parameters");
+        planar_force.OutputForceParameters(planar_force_parameter_file);
+        planar_force_parameter_file->close();
+
+        {
+            FileFinder generated_file = output_file_handler.FindFile("planar_results.parameters");
+            FileFinder reference_file("cell_based/test/data/TestForces/planar_results.parameters",
                     RelativeTo::ChasteSourceRoot);
             FileComparison comparer(generated_file,reference_file);
             TS_ASSERT(comparer.CompareFiles());
@@ -1542,8 +1560,83 @@ public:
         }
     }
 
+
+    void TestPlanarPolarisedFarhadifarForce()
+    {
+        // Construct a 2D vertex mesh consisting of a single element
+        std::vector<Node<2>*> nodes;
+        unsigned num_nodes = 9;
+        std::vector<double> angles = std::vector<double>(num_nodes);
+        for (unsigned i=0; i<num_nodes; i++)
+        {
+            angles[i] = M_PI+2.0*M_PI*(double)(i)/(double)(num_nodes);
+            nodes.push_back(new Node<2>(i, true, cos(angles[i]), sin(angles[i])));
+        }
+
+        std::vector<VertexElement<2,2>*> elements;
+        elements.push_back(new VertexElement<2,2>(0, nodes));
+
+        double cell_swap_threshold = 0.01;
+        double edge_division_threshold = 2.0;
+        MutableVertexMesh<2,2> mesh(nodes, elements, cell_swap_threshold, edge_division_threshold);
+
+        // Set up the cell
+        std::vector<CellPtr> cells;
+        MAKE_PTR(WildTypeCellMutationState, p_state);
+        MAKE_PTR(DifferentiatedCellProliferativeType, p_diff_type);
+        FixedG1GenerationalCellCycleModel* p_model = new FixedG1GenerationalCellCycleModel();
+        CellPtr p_cell(new Cell(p_state, p_model));
+        p_cell->SetCellProliferativeType(p_diff_type);
+        p_cell->SetBirthTime(-1.0);
+        cells.push_back(p_cell);
+
+        // Create cell population
+        VertexBasedCellPopulation<2> cell_population(mesh, cells);
+        cell_population.InitialiseCells();
+
+        // Create force
+        PlanarPolarisedFarhadifarForce<2> force;
+
+        // Test get/set methods
+        TS_ASSERT_DELTA(force.GetAreaElasticityParameter(), 1.0, 1e-12);
+        TS_ASSERT_DELTA(force.GetPerimeterContractilityParameter(), 0.04, 1e-12);
+        TS_ASSERT_DELTA(force.GetLineTensionParameter(), 0.12, 1e-12);
+        TS_ASSERT_DELTA(force.GetBoundaryLineTensionParameter(), 0.12, 1e-12);
+        TS_ASSERT_DELTA(force.GetPlanarPolarisedLineTensionMultiplier(), 2.0, 1e-12);
+
+        force.SetPlanarPolarisedLineTensionMultiplier(4.0);
+        TS_ASSERT_DELTA(force.GetPlanarPolarisedLineTensionMultiplier(), 4.0, 1e-12);
+
+        for (unsigned i=0; i<cell_population.GetNumNodes(); i++)
+        {
+            cell_population.GetNode(i)->ClearAppliedForce();
+        }
+        
+        // Test GetLineTensionParameter()
+        c_vector<double, 2> applied_force_0;
+        applied_force_0 = cell_population.rGetMesh().GetNode(0)->rGetAppliedForce();
+        c_vector<double, 2> applied_force_1;
+        applied_force_1 = cell_population.rGetMesh().GetNode(1)->rGetAppliedForce();
+
+        for (unsigned node_idx = 0; node_idx < cell_population.GetNumNodes(); node_idx++)
+        {
+            Node<2>* p_node_A = cell_population.GetNode(node_idx);
+            Node<2>* p_node_B = cell_population.GetNode((node_idx + 1) % cell_population.GetNumNodes());
+            
+            double line_tension = force.GetLineTensionParameter(p_node_A, p_node_B, cell_population);
+            if ((node_idx == 1) || (node_idx == 2) || (node_idx == 6) || (node_idx == 7))
+            {
+                TS_ASSERT_DELTA(0.12, line_tension, 1e-12);
+            }
+            else
+            {
+                TS_ASSERT_DELTA(0.48, line_tension, 1e-12);
+            }
+        }
+    }
+
     void TestFarhadifarForceTerms()
-       {
+    {
         /**
          * Here we test that the forces are applied correctly to individual nodes.
          * We apply the force to something like this:
@@ -1749,6 +1842,54 @@ public:
             TS_ASSERT_DELTA(p_farhadifar_force->GetPerimeterContractilityParameter(), 17.9, 1e-12);
             TS_ASSERT_DELTA(p_farhadifar_force->GetLineTensionParameter(), 0.5, 1e-12);
             TS_ASSERT_DELTA(p_farhadifar_force->GetBoundaryLineTensionParameter(), 0.6, 1e-12);
+
+            // Tidy up
+            delete p_abstract_force;
+        }
+    }
+
+    void TestPlanarPolarisedFarhadifarForceArchiving()
+    {
+        EXIT_IF_PARALLEL; // Beware of processes overwriting the identical archives of other processes
+        OutputFileHandler handler("archive", false);
+        std::string archive_filename = handler.GetOutputDirectoryFullPath() + "PlanarPolarisedFarhadifarForce.arch";
+
+        {
+            PlanarPolarisedFarhadifarForce<2> force;
+
+            std::ofstream ofs(archive_filename.c_str());
+            boost::archive::text_oarchive output_arch(ofs);
+
+            // Set member variables
+            force.SetAreaElasticityParameter(5.8);
+            force.SetPerimeterContractilityParameter(17.9);
+            force.SetLineTensionParameter(0.5);
+            force.SetBoundaryLineTensionParameter(0.6);
+            force.SetPlanarPolarisedLineTensionMultiplier(5.2);
+
+            // Serialize via pointer to most abstract class possible
+            AbstractForce<2>* const p_force = &force;
+            output_arch << p_force;
+        }
+
+        {
+            AbstractForce<2>* p_abstract_force;
+
+            // Create an input archive
+            std::ifstream ifs(archive_filename.c_str(), std::ios::binary);
+            boost::archive::text_iarchive input_arch(ifs);
+
+            // Restore from the archive
+            input_arch >> p_abstract_force;
+
+            PlanarPolarisedFarhadifarForce<2>* p_planar_force = static_cast<PlanarPolarisedFarhadifarForce<2>*>(p_abstract_force);
+
+            // Check member variables have been correctly archived
+            TS_ASSERT_DELTA(p_planar_force->GetAreaElasticityParameter(), 5.8, 1e-12);
+            TS_ASSERT_DELTA(p_planar_force->GetPerimeterContractilityParameter(), 17.9, 1e-12);
+            TS_ASSERT_DELTA(p_planar_force->GetLineTensionParameter(), 0.5, 1e-12);
+            TS_ASSERT_DELTA(p_planar_force->GetBoundaryLineTensionParameter(), 0.6, 1e-12);
+            TS_ASSERT_DELTA(p_planar_force->GetPlanarPolarisedLineTensionMultiplier(), 5.2, 1e-12);
 
             // Tidy up
             delete p_abstract_force;

--- a/cell_based/test/population/TestVertexBasedDivisionRules.hpp
+++ b/cell_based/test/population/TestVertexBasedDivisionRules.hpp
@@ -52,7 +52,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "VonMisesVertexBasedDivisionRule.hpp"
 #include "HoneycombVertexMeshGenerator.hpp"
 #include "SmartPointers.hpp"
-#include "Debug.hpp"
 
 // This test is always run sequentially (never in parallel)
 #include "FakePetscSetup.hpp"

--- a/cell_based/test/simulation/TestConstantTargetAreaModifier.hpp
+++ b/cell_based/test/simulation/TestConstantTargetAreaModifier.hpp
@@ -1,0 +1,199 @@
+/*
+
+Copyright (c) 2005-2023, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef TESTCONSTANTTARGETAREAMODIFIER_HPP_
+#define TESTCONSTANTTARGETAREAMODIFIER_HPP_
+
+#include <cxxtest/TestSuite.h>
+
+// Must be included before other cell_based headers
+#include "CellBasedSimulationArchiver.hpp"
+
+#include "AbstractCellBasedTestSuite.hpp"
+#include "SmartPointers.hpp"
+
+#include "ConstantTargetAreaModifier.hpp"
+#include "AbstractCellBasedSimulationModifier.hpp"
+#include "HoneycombVertexMeshGenerator.hpp"
+#include "HoneycombMeshGenerator.hpp"
+#include "CellsGenerator.hpp"
+#include "FixedG1GenerationalCellCycleModel.hpp"
+#include "UniformCellCycleModel.hpp"
+#include "DifferentiatedCellProliferativeType.hpp"
+#include "VertexBasedCellPopulation.hpp"
+#include "MeshBasedCellPopulation.hpp"
+#include "OffLatticeSimulation.hpp"
+#include "NagaiHondaForce.hpp"
+#include "CellBasedEventHandler.hpp"
+#include "FileComparison.hpp"
+
+// This test is only run sequentially (never in parallel)
+#include "FakePetscSetup.hpp"
+
+class TestConstantTargetAreaModifier : public AbstractCellBasedTestSuite
+{
+public:
+
+    void TestTargetAreaOfDaughterCellsConstant()
+    {
+        // Create a simple 2D MutableVertexMesh with only one cell
+        HoneycombVertexMeshGenerator generator(1, 1);
+        MutableVertexMesh<2,2>* p_mesh = generator.GetMesh();
+
+        // Set up cell
+        std::vector<CellPtr> cells;
+        MAKE_PTR(WildTypeCellMutationState, p_state);
+        MAKE_PTR(TransitCellProliferativeType, p_transit_type);
+
+        FixedG1GenerationalCellCycleModel* p_model = new FixedG1GenerationalCellCycleModel();
+
+        CellPtr p_cell(new Cell(p_state, p_model));
+        p_cell->SetCellProliferativeType(p_transit_type);
+        double birth_time = -11.0; // The cell cycle duration is 12
+        p_cell->SetBirthTime(birth_time);
+        cells.push_back(p_cell);
+
+        // Create cell population
+        VertexBasedCellPopulation<2> cell_population(*p_mesh, cells);
+
+        // Set up cell-based simulation
+        OffLatticeSimulation<2> simulator(cell_population);
+        simulator.SetOutputDirectory("TestTargetAreaOfDaughterCellsSimple");
+        simulator.SetEndTime(0.997);
+
+        // Create a force law and pass it to the simulation
+        MAKE_PTR(NagaiHondaForce<2>, p_nagai_honda_force);
+        simulator.AddForce(p_nagai_honda_force);
+
+        // Create a ConstantTargetAreaModifier
+        MAKE_PTR(ConstantTargetAreaModifier<2>, p_growth_modifier);
+        simulator.AddSimulationModifier(p_growth_modifier);
+        p_growth_modifier->SetReferenceTargetArea(2.3);
+
+        // Run simulation
+        simulator.Solve();
+
+        // We should only have one cell now
+        unsigned num_cells_before_division = simulator.rGetCellPopulation().GetNumRealCells();
+        TS_ASSERT_EQUALS(num_cells_before_division, 1u);
+
+        // This is the cell from before; let's see what its target area is
+        double target_area_before_division = p_cell->GetCellData()->GetItem("target area");
+        TS_ASSERT_DELTA(target_area_before_division, 2.3, 1e-9);
+
+        // We now adjust the end time and run the simulation a bit further
+        simulator.SetEndTime(1.001);
+        simulator.Solve();
+
+        // We should now have two cells
+        unsigned num_cells_at_division = simulator.rGetCellPopulation().GetNumRealCells();
+        TS_ASSERT_EQUALS(num_cells_at_division, 2u);
+
+        // Iterate over the cells, checking their target areas
+        for (VertexBasedCellPopulation<2>::Iterator cell_iter = cell_population.Begin();
+             cell_iter != cell_population.End();
+             ++cell_iter)
+        {
+            double target_area_at_division = cell_iter->GetCellData()->GetItem("target area");
+            TS_ASSERT_DELTA(target_area_at_division, 2.3, 1e-9);
+        }
+    }
+
+    void TestConstantTargetAreaModifierArchiving()
+    {
+        // Create a file for archiving
+        OutputFileHandler handler("archive", false);
+        std::string archive_filename = handler.GetOutputDirectoryFullPath() + "ConstantTargetAreaModifier.arch";
+
+        // Separate scope to write the archive
+        {
+            // Initialise a growth modifier and set a non-standard mature target area
+            AbstractCellBasedSimulationModifier<2,2>* const p_modifier = new ConstantTargetAreaModifier<2>();
+            (static_cast<ConstantTargetAreaModifier<2>*>(p_modifier))->SetReferenceTargetArea(14.3);
+
+            // Create an output archive
+            std::ofstream ofs(archive_filename.c_str());
+            boost::archive::text_oarchive output_arch(ofs);
+
+            // Serialize via pointer
+            output_arch << p_modifier;
+            delete p_modifier;
+        }
+
+        // Separate scope to read the archive
+        {
+            AbstractCellBasedSimulationModifier<2,2>* p_modifier2;
+
+            // Restore the modifier
+            std::ifstream ifs(archive_filename.c_str());
+            boost::archive::text_iarchive input_arch(ifs);
+
+            input_arch >> p_modifier2;
+
+            // See whether we read out the correct member variables
+            double reference_target_area = (static_cast<ConstantTargetAreaModifier<2>*>(p_modifier2))->GetReferenceTargetArea();
+            TS_ASSERT_DELTA(reference_target_area, 14.3, 1e-9);
+
+            delete p_modifier2;
+        }
+    }
+
+    void TestConstantTargetAreaModifierOutputParameters()
+    {
+        EXIT_IF_PARALLEL;
+        std::string output_directory = "TestConstantTargetAreaModifierOutputParameters";
+        OutputFileHandler output_file_handler(output_directory, false);
+
+        MAKE_PTR(ConstantTargetAreaModifier<2>, p_modifier);
+        TS_ASSERT_EQUALS(p_modifier->GetIdentifier(), "ConstantTargetAreaModifier-2");
+
+        p_modifier->SetReferenceTargetArea(6.2);
+
+        out_stream modifier_parameter_file = output_file_handler.OpenOutputFile("ConstantTargetAreaModifier.parameters");
+        p_modifier->OutputSimulationModifierParameters(modifier_parameter_file);
+        modifier_parameter_file->close();
+
+        {
+            // Compare the generated file in test output with a reference copy in the source code
+            FileFinder generated = output_file_handler.FindFile("ConstantTargetAreaModifier.parameters");
+            FileFinder reference("cell_based/test/data/TestSimulationModifierOutputParameters/ConstantTargetAreaModifier.parameters",
+                    RelativeTo::ChasteSourceRoot);
+            FileComparison comparer(generated, reference);
+            TS_ASSERT(comparer.CompareFiles());
+        }
+    }
+};
+
+#endif /*TESTCONSTANTTARGETAREAMODIFIER_HPP_*/

--- a/cell_based/test/simulation/TestDivisionBiasTrackingModifier.hpp
+++ b/cell_based/test/simulation/TestDivisionBiasTrackingModifier.hpp
@@ -1,0 +1,430 @@
+/*
+
+Copyright (c) 2005-2023, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef TESTDIVISIONBIASTRACKINGMODIFIER_HPP_
+#define TESTDIVISIONBIASTRACKINGMODIFIER_HPP_
+
+#include <cxxtest/TestSuite.h>
+
+// Must be included before other cell_based headers
+#include "CellBasedSimulationArchiver.hpp"
+
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
+
+#include <fstream>
+
+#include "AbstractCellBasedTestSuite.hpp"
+#include "SmartPointers.hpp"
+#include "OffLatticeSimulation.hpp"
+#include "DivisionBiasTrackingModifier.hpp"
+#include "BiasedBernoulliTrialCellCycleModel.hpp"
+#include "FixedG1GenerationalCellCycleModel.hpp"
+#include "WildTypeCellMutationState.hpp"
+#include "CellLabel.hpp"
+#include "GeneralisedLinearSpringForce.hpp"
+#include "NagaiHondaForce.hpp"
+#include "HoneycombVertexMeshGenerator.hpp"
+#include "HoneycombMeshGenerator.hpp"
+#include "MeshBasedCellPopulationWithGhostNodes.hpp"
+#include "VertexBasedCellPopulation.hpp"
+#include "NodeBasedCellPopulation.hpp"
+#include "SimpleTargetAreaModifier.hpp"
+#include "CellsGenerator.hpp"
+#include "Warnings.hpp"
+#include "CellVolumesWriter.hpp"
+#include "FileComparison.hpp"
+
+// Cell population writers
+#include "CellMutationStatesCountWriter.hpp"
+#include "NodeVelocityWriter.hpp"
+
+#include "PetscSetupAndFinalize.hpp"
+
+class TestDivisionBiasTrackingModifier : public AbstractCellBasedTestSuite
+{
+public:
+
+    void TestNodeBasedSimulationWithDivisionBias()
+    {
+        EXIT_IF_PARALLEL;    // HoneycombMeshGenerator does not work in parallel
+
+        // Create a simple 2D NodeBasedCellPopulation
+        HoneycombMeshGenerator generator(5, 5, 0);
+        TetrahedralMesh<2,2>* p_generating_mesh = generator.GetMesh();
+        NodesOnlyMesh<2> mesh;
+        mesh.ConstructNodesWithoutMesh(*p_generating_mesh, 1.5);
+
+        MAKE_PTR(WildTypeCellMutationState, p_state);
+        MAKE_PTR(TransitCellProliferativeType, p_transit_type);
+        std::vector<CellPtr> cells;
+        for (unsigned i=0; i<mesh.GetNumNodes(); i++)
+        {
+            BiasedBernoulliTrialCellCycleModel* p_cycle_model = new BiasedBernoulliTrialCellCycleModel();
+            p_cycle_model->SetDimension(2);
+            p_cycle_model->SetBirthTime(-10.0);
+            p_cycle_model->SetMaxDivisionProbability(0.1);
+
+            CellPtr p_cell(new Cell(p_state, p_cycle_model));
+            p_cell->SetCellProliferativeType(p_transit_type);
+            cells.push_back(p_cell);
+        }
+
+        NodeBasedCellPopulation<2> cell_population(mesh, cells);
+
+        // Create a simulation
+        OffLatticeSimulation<2> simulator(cell_population);
+        simulator.SetOutputDirectory("TestNodeBasedSimulationWithDivisionBias");
+
+        // Create a division bias tracking modifier and pass it to the simulation
+        c_vector<double, 2> bias_vector;
+        bias_vector(0) = 1.0;
+        bias_vector(1) = 0.0;
+        MAKE_PTR_ARGS(DivisionBiasTrackingModifier<2>, p_modifier, (bias_vector));
+        simulator.AddSimulationModifier(p_modifier);
+
+        // Create a force law and pass it to the simulation
+        MAKE_PTR(GeneralisedLinearSpringForce<2>, p_force);
+        p_force->SetCutOffLength(1.5);
+        simulator.AddForce(p_force);
+
+        // Run simulation
+        simulator.Solve();
+
+        // Test that the cell data are correct in CellData at the first timestep
+        for (AbstractCellPopulation<2>::Iterator cell_iter = cell_population.Begin();
+             cell_iter != cell_population.End();
+             ++cell_iter)
+        {
+            TS_ASSERT_LESS_THAN_EQUALS(0.0, cell_iter->GetCellData()->GetItem("bias"));
+            TS_ASSERT_LESS_THAN_EQUALS(cell_iter->GetCellData()->GetItem("bias"), 1.0);
+        }
+    
+        // Run simulation
+        simulator.Solve();
+
+        // Test that the cell data are correct in CellData at the end time
+        for (AbstractCellPopulation<2>::Iterator cell_iter = cell_population.Begin();
+          cell_iter != cell_population.End();
+          ++cell_iter)
+        {
+            TS_ASSERT_LESS_THAN_EQUALS(0.0, cell_iter->GetCellData()->GetItem("bias"));
+            TS_ASSERT_LESS_THAN_EQUALS(cell_iter->GetCellData()->GetItem("bias"), 1.0);
+        }
+    }
+
+    void TestMeshBasedSimulationWithDivisionBias()
+    {
+        EXIT_IF_PARALLEL;    // HoneycombMeshGenerator does not work in parallel
+
+        // Create a simple 2D MeshBasedCellPopulation
+        HoneycombMeshGenerator generator(3, 3);
+        MutableMesh<2,2>* p_mesh = generator.GetMesh();
+
+        MAKE_PTR(WildTypeCellMutationState, p_state);
+        MAKE_PTR(TransitCellProliferativeType, p_transit_type);
+        std::vector<CellPtr> cells;
+        for (unsigned i=0; i<p_mesh->GetNumNodes(); i++)
+        {
+            BiasedBernoulliTrialCellCycleModel* p_cycle_model = new BiasedBernoulliTrialCellCycleModel();
+            p_cycle_model->SetDimension(2);
+            p_cycle_model->SetBirthTime(-10.0);
+            p_cycle_model->SetMaxDivisionProbability(0.1);
+
+            CellPtr p_cell(new Cell(p_state, p_cycle_model));
+            p_cell->SetCellProliferativeType(p_transit_type);
+            cells.push_back(p_cell);
+        }
+
+        MeshBasedCellPopulation<2> cell_population(*p_mesh, cells);
+        cell_population.AddCellPopulationCountWriter<CellMutationStatesCountWriter>();
+        cell_population.AddCellWriter<CellVolumesWriter>();
+
+        // Create a simulation
+        OffLatticeSimulation<2> simulator(cell_population);
+        simulator.SetOutputDirectory("TestMeshBasedSimulationWithDivisionBias");
+        simulator.SetEndTime(simulator.GetDt()/2.0);
+
+        // Create a division bias tracking modifier and pass it to the simulation
+        c_vector<double, 2> bias_vector;
+        bias_vector(0) = 1.0;
+        bias_vector(1) = 0.0;
+        MAKE_PTR_ARGS(DivisionBiasTrackingModifier<2>, p_modifier, (bias_vector));
+        simulator.AddSimulationModifier(p_modifier);
+
+        // Create a force law and pass it to the simulation
+        MAKE_PTR(GeneralisedLinearSpringForce<2>, p_force);
+        p_force->SetCutOffLength(1.5);
+        simulator.AddForce(p_force);
+
+        // Run simulation
+        simulator.Solve();
+
+        // Test that the volumes of the cells are correct in CellData at the first timestep
+        for (AbstractCellPopulation<2>::Iterator cell_iter = cell_population.Begin();
+             cell_iter != cell_population.End();
+             ++cell_iter)
+        {
+            TS_ASSERT_DELTA(cell_population.GetVolumeOfCell(*cell_iter), (*cell_iter)->GetCellData()->GetItem("volume"), 1e-4);
+        }
+    }
+
+    void TestMeshBasedSimulationWithGhostNodesAndContactInhibition()
+    {
+        EXIT_IF_PARALLEL;    // HoneycombMeshGenerator does not work in parallel.
+
+        // Create a simple 2D MeshBasedCellPopulationWithGhostNodes
+        HoneycombMeshGenerator generator(3, 3, 3);
+        MutableMesh<2,2>* p_mesh = generator.GetMesh();
+        std::vector<unsigned> location_indices = generator.GetCellLocationIndices();
+
+        MAKE_PTR(WildTypeCellMutationState, p_state);
+        MAKE_PTR(TransitCellProliferativeType, p_transit_type);
+        std::vector<CellPtr> cells;
+        for (unsigned i=0; i<location_indices.size(); i++)
+        {
+            BiasedBernoulliTrialCellCycleModel* p_cycle_model = new BiasedBernoulliTrialCellCycleModel();
+            p_cycle_model->SetDimension(2);
+            p_cycle_model->SetBirthTime(-10.0);
+            p_cycle_model->SetMaxDivisionProbability(0.1);
+
+            CellPtr p_cell(new Cell(p_state, p_cycle_model));
+            p_cell->SetCellProliferativeType(p_transit_type);
+            cells.push_back(p_cell);
+        }
+
+        MeshBasedCellPopulationWithGhostNodes<2> cell_population(*p_mesh, cells,location_indices);
+        cell_population.AddCellPopulationCountWriter<CellMutationStatesCountWriter>();
+        cell_population.AddCellWriter<CellVolumesWriter>();
+
+        // Create a simulation
+        OffLatticeSimulation<2> simulator(cell_population);
+        simulator.SetOutputDirectory("TestMeshBasedSimulationWithGhostNodesAndVolumeTracked");
+        simulator.SetEndTime(simulator.GetDt()/2.0);
+
+        // Create a division bias tracking modifier and pass it to the simulation
+        c_vector<double, 2> bias_vector;
+        bias_vector(0) = 1.0;
+        bias_vector(1) = 0.0;
+        MAKE_PTR_ARGS(DivisionBiasTrackingModifier<2>, p_modifier, (bias_vector));
+        simulator.AddSimulationModifier(p_modifier);
+
+        // Create a force law and pass it to the simulation
+        MAKE_PTR(GeneralisedLinearSpringForce<2>, p_force);
+        p_force->SetCutOffLength(1.5);
+        simulator.AddForce(p_force);
+
+        // Run simulation
+        simulator.Solve();
+
+        // Test that the volumes of the cells are correct in CellData at the first timestep
+        for (AbstractCellPopulation<2>::Iterator cell_iter = cell_population.Begin();
+             cell_iter != cell_population.End();
+             ++cell_iter)
+        {
+            TS_ASSERT_DELTA(cell_population.GetVolumeOfCell(*cell_iter), (*cell_iter)->GetCellData()->GetItem("volume"), 1e-4);
+        }
+    }
+
+    void TestVertexBasedSimulationWithDivisionBias()
+    {
+        EXIT_IF_PARALLEL;    // Output in cell-based simulations doesn't work in parallel ///\todo #2356
+
+        // Create a simple 2D VertexBasedCellPopulation
+        HoneycombVertexMeshGenerator generator(2, 2);
+        MutableVertexMesh<2,2>* p_mesh = generator.GetMesh();
+
+        MAKE_PTR(WildTypeCellMutationState, p_state);
+        MAKE_PTR(TransitCellProliferativeType, p_transit_type);
+        std::vector<CellPtr> cells;
+
+        for (unsigned i=0; i<p_mesh->GetNumElements(); i++)
+        {
+            BiasedBernoulliTrialCellCycleModel* p_cycle_model = new BiasedBernoulliTrialCellCycleModel();
+            p_cycle_model->SetDimension(2);
+            p_cycle_model->SetBirthTime(-10.0);
+            p_cycle_model->SetMaxDivisionProbability(0.1);
+
+            CellPtr p_cell(new Cell(p_state, p_cycle_model));
+            p_cell->SetCellProliferativeType(p_transit_type);
+            cells.push_back(p_cell);
+        }
+
+        VertexBasedCellPopulation<2> cell_population(*p_mesh, cells);
+        cell_population.AddCellPopulationCountWriter<CellMutationStatesCountWriter>();
+        cell_population.AddCellWriter<CellVolumesWriter>();
+
+        // Create a simulation
+        OffLatticeSimulation<2> simulator(cell_population);
+        simulator.SetOutputDirectory("TestVertexBasedSimulationWithDivisionBias");
+        simulator.SetEndTime(simulator.GetDt()/2.0);
+
+        // Create a division bias tracking modifier and pass it to the simulation
+        c_vector<double, 2> bias_vector;
+        bias_vector(0) = 1.0;
+        bias_vector(1) = 0.0;
+        MAKE_PTR_ARGS(DivisionBiasTrackingModifier<2>, p_modifier, (bias_vector));
+        simulator.AddSimulationModifier(p_modifier);
+
+        // Create a force law and pass it to the simulation
+        MAKE_PTR(NagaiHondaForce<2>, p_nagai_honda_force);
+        simulator.AddForce(p_nagai_honda_force);
+
+        // A NagaiHondaForce has to be used together with an AbstractTargetAreaModifier #2488
+        MAKE_PTR(SimpleTargetAreaModifier<2>, p_growth_modifier);
+        simulator.AddSimulationModifier(p_growth_modifier);
+
+        // Run simulation
+        simulator.Solve();
+
+        // Test that the volumes of the cells are correct in CellData at the first timestep
+        for (AbstractCellPopulation<2>::Iterator cell_iter = cell_population.Begin();
+          cell_iter != cell_population.End();
+          ++cell_iter)
+        {
+            TS_ASSERT_DELTA(cell_population.GetVolumeOfCell(*cell_iter), (*cell_iter)->GetCellData()->GetItem("volume"), 1e-4);
+        }
+    }
+
+    void TestVolumeTrackedOffLatticeSimulationArchiving()
+    {
+        EXIT_IF_PARALLEL;
+
+        // Create a simple 2D MeshBasedCellPopulation
+        HoneycombMeshGenerator generator(2, 2, 0);
+        MutableMesh<2,2>* p_mesh = generator.GetMesh();
+
+        MAKE_PTR(WildTypeCellMutationState, p_state);
+        MAKE_PTR(StemCellProliferativeType, p_stem_type);
+        std::vector<CellPtr> cells;
+        for (unsigned i=0; i<p_mesh->GetNumNodes(); i++)
+        {
+            BiasedBernoulliTrialCellCycleModel* p_cycle_model = new BiasedBernoulliTrialCellCycleModel();
+            p_cycle_model->SetDimension(2);
+            p_cycle_model->SetBirthTime(-10.0);
+            p_cycle_model->SetMaxDivisionProbability(0.1);
+
+            CellPtr p_cell(new Cell(p_state, p_cycle_model));
+            p_cell->SetCellProliferativeType(p_stem_type);
+            cells.push_back(p_cell);
+        }
+
+        MeshBasedCellPopulation<2> cell_population(*p_mesh, cells);
+
+        // Create a contact inhibition simulator
+        OffLatticeSimulation<2> simulator(cell_population);
+        simulator.SetOutputDirectory("TestDivisionBiasTrackedOffLatticeSimulationSaveAndLoad");
+        double end_time = 0.01;
+        simulator.SetEndTime(end_time);
+
+        // Create a division bias tracking modifier and pass it to the simulation
+        c_vector<double, 2> bias_vector;
+        bias_vector(0) = 1.0;
+        bias_vector(1) = 0.0;
+        MAKE_PTR_ARGS(DivisionBiasTrackingModifier<2>, p_modifier, (bias_vector));
+        simulator.AddSimulationModifier(p_modifier);
+
+        // Create a force law and pass it to the simulation
+        MAKE_PTR(GeneralisedLinearSpringForce<2>, p_force);
+        p_force->SetCutOffLength(1.5);
+        simulator.AddForce(p_force);
+
+        // Run simulation
+        simulator.Solve();
+
+        CellBasedSimulationArchiver<2, OffLatticeSimulation<2> >::Save(&simulator);
+
+        TS_ASSERT_EQUALS(simulator.rGetCellPopulation().GetNumRealCells(), 4u);
+        TS_ASSERT_EQUALS((static_cast<MeshBasedCellPopulation<2>*>(&(simulator.rGetCellPopulation())))->GetNumRealCells(), 4u);
+
+        TS_ASSERT_DELTA(SimulationTime::Instance()->GetTime(), 0.01, 1e-9);
+        CellPtr p_cell = simulator.rGetCellPopulation().GetCellUsingLocationIndex(3);
+        TS_ASSERT_DELTA(p_cell->GetAge(), 1.01, 1e-4);
+
+        SimulationTime::Destroy();
+        SimulationTime::Instance()->SetStartTime(0.0);
+
+        // Load simulation
+        OffLatticeSimulation<2>* p_simulator
+            = CellBasedSimulationArchiver<2, OffLatticeSimulation<2> >::Load("TestDivisionBiasTrackedOffLatticeSimulationSaveAndLoad", end_time);
+
+        p_simulator->SetEndTime(0.2);
+
+        TS_ASSERT_EQUALS(p_simulator->rGetCellPopulation().GetNumRealCells(), 4u);
+        TS_ASSERT_EQUALS((static_cast<MeshBasedCellPopulation<2>*>(&(p_simulator->rGetCellPopulation())))->GetNumRealCells(), 4u);
+
+        TS_ASSERT_DELTA(SimulationTime::Instance()->GetTime(), 0.01, 1e-9);
+        CellPtr p_cell2 = p_simulator->rGetCellPopulation().GetCellUsingLocationIndex(3);
+        TS_ASSERT_DELTA(p_cell2->GetAge(), 1.01, 1e-4);
+
+        // Run simulation
+        p_simulator->Solve();
+
+        // Tidy up
+        delete p_simulator;
+
+        // Test Warnings
+        TS_ASSERT_EQUALS(Warnings::Instance()->GetNumWarnings(), 1u);
+        Warnings::QuietDestroy();
+    }
+
+    void TestDivisionBiasTrackingModifierOutputParameters()
+    {
+        EXIT_IF_PARALLEL;
+        std::string output_directory = "TestDivisionBiasTrackingModifierOutputParameters";
+        OutputFileHandler output_file_handler(output_directory, false);
+
+        c_vector<double, 2> bias_vector;
+        bias_vector(0) = 1.0;
+        bias_vector(1) = 0.0;
+        MAKE_PTR_ARGS(DivisionBiasTrackingModifier<2>, p_modifier, (bias_vector));
+        TS_ASSERT_EQUALS(p_modifier->GetIdentifier(), "DivisionBiasTrackingModifier-2");
+
+        out_stream modifier_parameter_file = output_file_handler.OpenOutputFile("DivisionBiasTrackingModifier.parameters");
+        p_modifier->OutputSimulationModifierParameters(modifier_parameter_file);
+        modifier_parameter_file->close();
+
+        {
+            // Compare the generated file in test output with a reference copy in the source code
+            FileFinder generated = output_file_handler.FindFile("DivisionBiasTrackingModifier.parameters");
+            FileFinder reference("cell_based/test/data/TestSimulationModifierOutputParameters/DivisionBiasTrackingModifier.parameters",
+                    RelativeTo::ChasteSourceRoot);
+            FileComparison comparer(generated, reference);
+            TS_ASSERT(comparer.CompareFiles());
+        }
+    }
+};
+
+#endif /*TESTDIVISIONBIASTRACKINGMODIFIER_HPP_*/

--- a/cell_based/test/simulation/TestExtrinsicPullModifier.hpp
+++ b/cell_based/test/simulation/TestExtrinsicPullModifier.hpp
@@ -135,6 +135,7 @@ public:
         std::vector<boost::shared_ptr<AbstractCellBasedSimulationModifier<2> > >::iterator iter = simulator.GetSimulationModifiers()->begin();
         TS_ASSERT(boost::static_pointer_cast<ExtrinsicPullModifier<2> >(*iter));        
         boost::static_pointer_cast<ExtrinsicPullModifier<2> >(*iter)->SetApplyExtrinsicPullToAllNodes(true);
+        boost::static_pointer_cast<ExtrinsicPullModifier<2> >(*iter)->SetSpeed(2.0);
 
         simulator.SetEndTime(4.0*simulator.GetDt());
 
@@ -143,9 +144,9 @@ public:
 
         // Test that some of the nodes have the correct locations
         TS_ASSERT_DELTA(simulator.rGetCellPopulation().GetNode(0)->rGetLocation()[0], 0.5, 1e-3);
-        TS_ASSERT_DELTA(simulator.rGetCellPopulation().GetNode(1)->rGetLocation()[0], 1.611, 1e-3);
+        TS_ASSERT_DELTA(simulator.rGetCellPopulation().GetNode(1)->rGetLocation()[0], 1.7222, 1e-3);
         TS_ASSERT_DELTA(simulator.rGetCellPopulation().GetNode(5)->rGetLocation()[0], 0.0, 1e-3);
-        TS_ASSERT_DELTA(simulator.rGetCellPopulation().GetNode(6)->rGetLocation()[0], 1.0740, 1e-3);
+        TS_ASSERT_DELTA(simulator.rGetCellPopulation().GetNode(6)->rGetLocation()[0], 1.1481, 1e-3);
     }
 
     void TestSimulationArchivingWithExtrinsicPull()

--- a/cell_based/test/simulation/TestExtrinsicPullModifier.hpp
+++ b/cell_based/test/simulation/TestExtrinsicPullModifier.hpp
@@ -1,0 +1,247 @@
+/*
+
+Copyright (c) 2005-2023, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef TESTEXTRINSICPULLMODIFIER_HPP_
+#define TESTEXTRINSICPULLMODIFIER_HPP_
+
+#include <cxxtest/TestSuite.h>
+
+// Must be included before other cell_based headers
+#include "CellBasedSimulationArchiver.hpp"
+
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
+
+#include <fstream>
+
+#include "AbstractCellBasedTestSuite.hpp"
+#include "SmartPointers.hpp"
+#include "OffLatticeSimulation.hpp"
+#include "ExtrinsicPullModifier.hpp"
+#include "NoCellCycleModel.hpp"
+#include "WildTypeCellMutationState.hpp"
+#include "DifferentiatedCellProliferativeType.hpp"
+#include "FarhadifarForce.hpp"
+#include "HoneycombVertexMeshGenerator.hpp"
+#include "VertexBasedCellPopulation.hpp"
+#include "SimpleTargetAreaModifier.hpp"
+#include "CellsGenerator.hpp"
+#include "Warnings.hpp"
+#include "FileComparison.hpp"
+#include "PetscSetupAndFinalize.hpp"
+
+class TestExtrinsicPullModifier : public AbstractCellBasedTestSuite
+{
+public:
+
+    void TestVertexBasedSimulationWithExtrinsicPull()
+    {
+        EXIT_IF_PARALLEL;    // Output in cell-based simulations doesn't work in parallel ///\todo #2356
+
+        // Create a simple 2D VertexBasedCellPopulation
+        HoneycombVertexMeshGenerator generator(2, 2);
+        MutableVertexMesh<2,2>* p_mesh = generator.GetMesh();
+
+        std::vector<CellPtr> cells;
+        MAKE_PTR(DifferentiatedCellProliferativeType, p_differentiated_type);
+        CellsGenerator<NoCellCycleModel, 2> cells_generator;
+        cells_generator.GenerateBasicRandom(cells, p_mesh->GetNumElements(), p_differentiated_type);
+
+        VertexBasedCellPopulation<2> cell_population(*p_mesh, cells);
+
+        // Create a simulation
+        OffLatticeSimulation<2> simulator(cell_population);
+        simulator.SetOutputDirectory("TestVertexBasedSimulationWithExtrinsicPull");
+        simulator.SetDt(0.1);
+        simulator.SetEndTime(2.0*simulator.GetDt());
+
+        // Create an extrinsic pull modifier
+        MAKE_PTR(ExtrinsicPullModifier<2>, p_modifier);
+
+        // Test get methods
+        p_modifier->SetApplyExtrinsicPullToAllNodes(false);
+        TS_ASSERT_EQUALS(p_modifier->GetApplyExtrinsicPullToAllNodes(), false);
+        TS_ASSERT_DELTA(p_modifier->GetSpeed(), 1.0, 1e-12);
+
+        // Pass the modifier to the simulation
+        simulator.AddSimulationModifier(p_modifier);
+
+        // Run simulation
+        simulator.Solve();
+
+        // Test only the right-most nodes (indices 10 and 13) have moved
+        unsigned node_idx = 0;
+        for (unsigned i=0; i<2; i++)
+        {
+            TS_ASSERT_DELTA(simulator.rGetCellPopulation().GetNode(node_idx)->rGetLocation()[0], i + 0.5, 1e-6);
+            node_idx++;
+        }
+        for (unsigned j=1; j<5; j++)
+        {
+            for (unsigned i=0; i<=2; i++)
+            {
+                double x_coord = ((j%4 == 0)||(j%4 == 3)) ? i+0.5 : i;
+                if ((node_idx == 10) || (node_idx == 13))
+                {
+                    TS_ASSERT_DELTA(simulator.rGetCellPopulation().GetNode(node_idx)->rGetLocation()[0], 2.7, 1e-6);
+                }
+                else
+                {
+                    TS_ASSERT_DELTA(simulator.rGetCellPopulation().GetNode(node_idx)->rGetLocation()[0], x_coord, 1e-6);
+                }
+                node_idx++;
+            }
+        }
+        for (unsigned i=1; i<2; i++)
+        {
+            TS_ASSERT_DELTA(simulator.rGetCellPopulation().GetNode(node_idx)->rGetLocation()[0], i, 1e-6);
+            node_idx++;
+        }
+        TS_ASSERT_DELTA(simulator.rGetCellPopulation().GetNode(node_idx)->rGetLocation()[0], 2, 1e-6);
+
+        // Test set/get methods
+        std::vector<boost::shared_ptr<AbstractCellBasedSimulationModifier<2> > >::iterator iter = simulator.GetSimulationModifiers()->begin();
+        TS_ASSERT(boost::static_pointer_cast<ExtrinsicPullModifier<2> >(*iter));        
+        boost::static_pointer_cast<ExtrinsicPullModifier<2> >(*iter)->SetApplyExtrinsicPullToAllNodes(true);
+
+        simulator.SetEndTime(4.0*simulator.GetDt());
+
+        // Run simulation
+        simulator.Solve();
+
+        // Test that some of the nodes have the correct locations
+        TS_ASSERT_DELTA(simulator.rGetCellPopulation().GetNode(0)->rGetLocation()[0], 0.5, 1e-3);
+        TS_ASSERT_DELTA(simulator.rGetCellPopulation().GetNode(1)->rGetLocation()[0], 1.611, 1e-3);
+        TS_ASSERT_DELTA(simulator.rGetCellPopulation().GetNode(5)->rGetLocation()[0], 0.0, 1e-3);
+        TS_ASSERT_DELTA(simulator.rGetCellPopulation().GetNode(6)->rGetLocation()[0], 1.0740, 1e-3);
+    }
+
+    void TestSimulationArchivingWithExtrinsicPull()
+    {
+        EXIT_IF_PARALLEL;
+
+        // Create a simple 2D VertexBasedCellPopulation
+        HoneycombVertexMeshGenerator generator(2, 2);
+        MutableVertexMesh<2,2>* p_mesh = generator.GetMesh();
+
+        // Create some cells, each with a cell-cycle model and srn that incorporates a delta-notch ODE system
+        std::vector<CellPtr> cells;
+        MAKE_PTR(WildTypeCellMutationState, p_state);
+        MAKE_PTR(DifferentiatedCellProliferativeType, p_diff_type);
+        for (unsigned elem_index=0; elem_index<p_mesh->GetNumElements(); elem_index++)
+        {
+            NoCellCycleModel* p_cc_model = new NoCellCycleModel();
+            p_cc_model->SetDimension(2);
+            CellPtr p_cell(new Cell(p_state, p_cc_model));
+            p_cell->SetCellProliferativeType(p_diff_type);
+            p_cell->SetBirthTime(-1.0);
+            cells.push_back(p_cell);
+        }
+        VertexBasedCellPopulation<2> cell_population(*p_mesh, cells);
+
+        // Create a simulation
+        OffLatticeSimulation<2> simulator(cell_population);
+        simulator.SetOutputDirectory("TestSimulationArchivingWithExtrinsicPullSaveAndLoad");
+        double end_time = 0.01;
+        simulator.SetEndTime(end_time);
+
+        // Create an extrinsic pull modifier and pass it to the simulation
+        MAKE_PTR(ExtrinsicPullModifier<2>, p_modifier);
+        simulator.AddSimulationModifier(p_modifier);
+
+        // Run simulation
+        simulator.Solve();
+
+        CellBasedSimulationArchiver<2, OffLatticeSimulation<2> >::Save(&simulator);
+
+        TS_ASSERT_EQUALS(simulator.rGetCellPopulation().GetNumRealCells(), 4u);
+        TS_ASSERT_EQUALS((static_cast<VertexBasedCellPopulation<2>*>(&(simulator.rGetCellPopulation())))->GetNumRealCells(), 4u);
+
+        TS_ASSERT_DELTA(SimulationTime::Instance()->GetTime(), 0.01, 1e-9);
+        CellPtr p_cell = simulator.rGetCellPopulation().GetCellUsingLocationIndex(3);
+        TS_ASSERT_DELTA(p_cell->GetAge(), 1.01, 1e-4);
+
+        SimulationTime::Destroy();
+        SimulationTime::Instance()->SetStartTime(0.0);
+
+        // Load simulation
+        OffLatticeSimulation<2>* p_simulator
+            = CellBasedSimulationArchiver<2, OffLatticeSimulation<2> >::Load("TestSimulationArchivingWithExtrinsicPullSaveAndLoad", end_time);
+
+        p_simulator->SetEndTime(0.2);
+
+        TS_ASSERT_EQUALS(p_simulator->rGetCellPopulation().GetNumRealCells(), 4u);
+        TS_ASSERT_EQUALS((static_cast<VertexBasedCellPopulation<2>*>(&(p_simulator->rGetCellPopulation())))->GetNumRealCells(), 4u);
+
+        TS_ASSERT_DELTA(SimulationTime::Instance()->GetTime(), 0.01, 1e-9);
+        CellPtr p_cell2 = p_simulator->rGetCellPopulation().GetCellUsingLocationIndex(3);
+        TS_ASSERT_DELTA(p_cell2->GetAge(), 1.01, 1e-4);
+
+        // Run simulation
+        p_simulator->Solve();
+
+        // Tidy up
+        delete p_simulator;
+
+        // Test Warnings
+        TS_ASSERT_EQUALS(Warnings::Instance()->GetNumWarnings(), 0u);
+        Warnings::QuietDestroy();
+    }
+
+    void TestExtrinsicPullModifierOutputParameters()
+    {
+        EXIT_IF_PARALLEL;
+        std::string output_directory = "TestExtrinsicPullModifierOutputParameters";
+        OutputFileHandler output_file_handler(output_directory, false);
+
+        MAKE_PTR(ExtrinsicPullModifier<2>, p_modifier);
+        TS_ASSERT_EQUALS(p_modifier->GetIdentifier(), "ExtrinsicPullModifier-2");
+
+        out_stream modifier_parameter_file = output_file_handler.OpenOutputFile("ExtrinsicPullModifier.parameters");
+        p_modifier->OutputSimulationModifierParameters(modifier_parameter_file);
+        modifier_parameter_file->close();
+
+        {
+            // Compare the generated file in test output with a reference copy in the source code
+            FileFinder generated = output_file_handler.FindFile("ExtrinsicPullModifier.parameters");
+            FileFinder reference("cell_based/test/data/TestExtrinsicPullModifierOutputParameters/ExtrinsicPullModifier.parameters",
+                    RelativeTo::ChasteSourceRoot);
+            FileComparison comparer(generated, reference);
+            TS_ASSERT(comparer.CompareFiles());
+        }
+    }
+};
+
+#endif /*TESTEXTRINSICPULLMODIFIER_HPP_*/


### PR DESCRIPTION
This pull request relates to issue [103 ](https://github.com/Chaste/Chaste/issues/103) and introduces the following new functionality into the cell-based code, for the Barcelona workshop:

- VonMisesVertexBasedDivisionRule, a new class that allows the user to specify the parameters of a von Mises (circular) distribution for the angle of cell division in vertex models - here, cells divide with random orientations but with some preferred mean and some measure of variation about this mean;
- BiasedBernoulliTrialCellCycleModel, a new class that is similar to the existing class BernoulliTrialCellCycleModel but which allows the division probability per unit time to vary linearly across a specified axis of the tissue - this is implemented by storing the bias in division probability in CellData;
- DivisionBiasTrackingModifer, a new class that is similar to the existing class VolumeTrackingModifier but which instead store's each cell's bias in division probability based on its location parallelt to a specified axis of the tissue - this is a helper class for BiasedBernoulliTrialCellCycleModel, similar to how VolumeTrackingModifier is a helper class for ContactInhibitionCellCycleModel;
- ConstantTargetAreaModifier, a new class that is similar to the existing class SimpleTargetAreaModifier but allows *no* growth in cell areas over time (force classes such as FarhadifarForce require the user to provide a target area modifier, hence the need for this in the case where the user doesn't actually want to model cell growth);
- SlidingBoundaryCondition, a new class that forces boundary nodes on the left-hand boundary of a tissue to stay at their initial x-coordinate, but allows them to 'slide' up and down in the y direction;
- additional tests and test suites associated with these new classes.