### PR TITLE
#118 make RNG archiving consistent across CCMs

### DIFF
--- a/cell_based/src/cell/cycle/BernoulliTrialCellCycleModel.cpp
+++ b/cell_based/src/cell/cycle/BernoulliTrialCellCycleModel.cpp
@@ -34,7 +34,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "BernoulliTrialCellCycleModel.hpp"
-#include "RandomNumberGenerator.hpp"
 #include "DifferentiatedCellProliferativeType.hpp"
 
 BernoulliTrialCellCycleModel::BernoulliTrialCellCycleModel()

--- a/cell_based/src/cell/cycle/BernoulliTrialCellCycleModel.hpp
+++ b/cell_based/src/cell/cycle/BernoulliTrialCellCycleModel.hpp
@@ -37,6 +37,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define BERNOULLITRIALCELLCYCLEMODEL_HPP_
 
 #include "AbstractCellCycleModel.hpp"
+#include "RandomNumberGenerator.hpp"
 
 /**
  * Simple cell-cycle model where mature non-differentiated cells have a specified probability of
@@ -61,6 +62,11 @@ private:
     void serialize(Archive & archive, const unsigned int version)
     {
         archive & boost::serialization::base_object<AbstractCellCycleModel>(*this);
+
+        // Make sure the RandomNumberGenerator singleton gets saved too
+        SerializableSingleton<RandomNumberGenerator>* p_wrapper = RandomNumberGenerator::Instance()->GetSerializationWrapper();
+        archive & p_wrapper;
+
         archive & mDivisionProbability;
         archive & mMinimumDivisionAge;
     }

--- a/cell_based/src/cell/cycle/BiasedBernoulliTrialCellCycleModel.cpp
+++ b/cell_based/src/cell/cycle/BiasedBernoulliTrialCellCycleModel.cpp
@@ -34,7 +34,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "BiasedBernoulliTrialCellCycleModel.hpp"
-#include "RandomNumberGenerator.hpp"
 #include "DifferentiatedCellProliferativeType.hpp"
 
 BiasedBernoulliTrialCellCycleModel::BiasedBernoulliTrialCellCycleModel()

--- a/cell_based/src/cell/cycle/BiasedBernoulliTrialCellCycleModel.hpp
+++ b/cell_based/src/cell/cycle/BiasedBernoulliTrialCellCycleModel.hpp
@@ -37,6 +37,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define BIASEDBERNOULLITRIALCELLCYCLEMODEL_HPP_
 
 #include "AbstractCellCycleModel.hpp"
+#include "RandomNumberGenerator.hpp"
 
 /**
  * Simple cell-cycle model where mature non-differentiated cells have a probability of
@@ -63,6 +64,11 @@ private:
     void serialize(Archive & archive, const unsigned int version)
     {
         archive & boost::serialization::base_object<AbstractCellCycleModel>(*this);
+
+        // Make sure the RandomNumberGenerator singleton gets saved too
+        SerializableSingleton<RandomNumberGenerator>* p_wrapper = RandomNumberGenerator::Instance()->GetSerializationWrapper();
+        archive & p_wrapper;
+
         archive & mMaxDivisionProbability;
         archive & mMinimumDivisionAge;
     }

--- a/cell_based/src/cell/cycle/LabelDependentBernoulliTrialCellCycleModel.cpp
+++ b/cell_based/src/cell/cycle/LabelDependentBernoulliTrialCellCycleModel.cpp
@@ -34,7 +34,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "LabelDependentBernoulliTrialCellCycleModel.hpp"
-#include "RandomNumberGenerator.hpp"
 #include "DifferentiatedCellProliferativeType.hpp"
 #include "CellLabel.hpp"
 

--- a/cell_based/src/cell/cycle/LabelDependentBernoulliTrialCellCycleModel.hpp
+++ b/cell_based/src/cell/cycle/LabelDependentBernoulliTrialCellCycleModel.hpp
@@ -37,6 +37,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define LABELDEPENDENTBERNOULLITRIALCELLCYCLEMODEL_HPP_
 
 #include "AbstractCellCycleModel.hpp"
+#include "RandomNumberGenerator.hpp"
 
 /**
  * Simple cell-cycle model where mature non-differentiated cells have a specified probability of
@@ -62,6 +63,11 @@ private:
     void serialize(Archive & archive, const unsigned int version)
     {
         archive & boost::serialization::base_object<AbstractCellCycleModel>(*this);
+
+        // Make sure the RandomNumberGenerator singleton gets saved too
+        SerializableSingleton<RandomNumberGenerator>* p_wrapper = RandomNumberGenerator::Instance()->GetSerializationWrapper();
+        archive & p_wrapper;
+
         archive & mDivisionProbability;
         archive & mLabelledDivisionProbability;
         archive & mMinimumDivisionAge;

--- a/cell_based/test/cell/TestSimpleCellCycleModels.hpp
+++ b/cell_based/test/cell/TestSimpleCellCycleModels.hpp
@@ -1476,6 +1476,9 @@ public:
         OutputFileHandler handler("archive", false);
         std::string archive_filename = handler.GetOutputDirectoryFullPath() + "BernoulliTrialCellCycleModel.arch";
 
+        // We will also test that the random number generator is archived correctly
+        double random_number_test = 0.0;
+
         {
             // We must set up SimulationTime to avoid memory leaks
             SimulationTime::Instance()->SetEndTimeAndNumberOfTimeSteps(1.0, 1);
@@ -1495,6 +1498,9 @@ public:
 
             delete p_model;
             SimulationTime::Destroy();
+
+            random_number_test = RandomNumberGenerator::Instance()->ranf();
+            RandomNumberGenerator::Destroy();
         }
 
         {
@@ -1515,6 +1521,8 @@ public:
             TS_ASSERT_DELTA(static_cast<BernoulliTrialCellCycleModel*>(p_model2)->GetDivisionProbability(), 0.5, 1e-9);
             TS_ASSERT_DELTA(static_cast<BernoulliTrialCellCycleModel*>(p_model2)->GetMinimumDivisionAge(), 0.1, 1e-9);
 
+            TS_ASSERT_DELTA(RandomNumberGenerator::Instance()->ranf(), random_number_test, 1e-6);
+
             // Avoid memory leaks
             delete p_model2;
         }
@@ -1524,6 +1532,9 @@ public:
     {
         OutputFileHandler handler("archive", false);
         std::string archive_filename = handler.GetOutputDirectoryFullPath() + "BiasedBernoulliTrialCellCycleModel.arch";
+
+        // We will also test that the random number generator is archived correctly
+        double random_number_test = 0.0;
 
         {
             // We must set up SimulationTime to avoid memory leaks
@@ -1544,6 +1555,9 @@ public:
 
             delete p_model;
             SimulationTime::Destroy();
+
+            random_number_test = RandomNumberGenerator::Instance()->ranf();
+            RandomNumberGenerator::Destroy();
         }
 
         {
@@ -1564,6 +1578,8 @@ public:
             TS_ASSERT_DELTA(static_cast<BiasedBernoulliTrialCellCycleModel*>(p_model2)->GetMaxDivisionProbability(), 0.4, 1e-9);
             TS_ASSERT_DELTA(static_cast<BiasedBernoulliTrialCellCycleModel*>(p_model2)->GetMinimumDivisionAge(), 0.7, 1e-9);
 
+            TS_ASSERT_DELTA(RandomNumberGenerator::Instance()->ranf(), random_number_test, 1e-6);
+
             // Avoid memory leaks
             delete p_model2;
         }
@@ -1573,6 +1589,9 @@ public:
     {
         OutputFileHandler handler("archive", false);
         std::string archive_filename = handler.GetOutputDirectoryFullPath() + "LabelDependentBernoulliTrialCellCycleModel.arch";
+
+        // We will also test that the random number generator is archived correctly
+        double random_number_test = 0.0;
 
         {
             // We must set up SimulationTime to avoid memory leaks
@@ -1594,6 +1613,9 @@ public:
 
             delete p_model;
             SimulationTime::Destroy();
+
+            random_number_test = RandomNumberGenerator::Instance()->ranf();
+            RandomNumberGenerator::Destroy();
         }
 
         {
@@ -1614,6 +1636,8 @@ public:
             TS_ASSERT_DELTA(static_cast<LabelDependentBernoulliTrialCellCycleModel*>(p_model2)->GetDivisionProbability(), 0.4, 1e-9);
             TS_ASSERT_DELTA(static_cast<LabelDependentBernoulliTrialCellCycleModel*>(p_model2)->GetLabelledDivisionProbability(), 0.5, 1e-9);
             TS_ASSERT_DELTA(static_cast<LabelDependentBernoulliTrialCellCycleModel*>(p_model2)->GetMinimumDivisionAge(), 0.7, 1e-9);
+
+            TS_ASSERT_DELTA(RandomNumberGenerator::Instance()->ranf(), random_number_test, 1e-6);
 
             // Avoid memory leaks
             delete p_model2;


### PR DESCRIPTION
This pull request introduces archiving of the `RandomNumberGenerator` singleton in the `serialize()` functions of the `*BernoulliTrialCellCycleModel` classes, completing the task associated with issue #118.