### PR TITLE
Make small changes to Cell.hpp

### DIFF
--- a/cell_based/src/cell/Cell.hpp
+++ b/cell_based/src/cell/Cell.hpp
@@ -92,9 +92,6 @@ class Cell : private boost::noncopyable, public boost::enable_shared_from_this<C
 {
 private:
 
-    /** Caches the result of ReadyToDivide() so Divide() can look at it. */
-    bool mCanDivide;
-
     /** Needed for serialization. */
     friend class boost::serialization::access;
     /**
@@ -120,6 +117,9 @@ private:
     }
 
 protected:
+
+    /** Caches the result of ReadyToDivide() so Divide() can look at it. */
+    bool mCanDivide;
 
     /** The cell's property collection. */
     CellPropertyCollection mCellPropertyCollection;
@@ -176,7 +176,7 @@ public:
     /**
      * Destructor, which frees the memory allocated for our cell-cycle model.
      */
-    ~Cell();
+    virtual ~Cell();
 
     /**
      * @return the cell's proliferative type.
@@ -370,7 +370,7 @@ public:
      *
      * @return the new daughter cell
      */
-    CellPtr Divide();
+    virtual CellPtr Divide();
 
     /**
      * Make the cell enter apoptosis and sets #mDeathTime using the apoptosis


### PR DESCRIPTION
This pull request closes issue [#130](https://github.com/Chaste/Chaste/issues/130) by making the following small changes to `Cell.hpp`:

- move `mCanDivide` from `private` to `protected`;
- make the destructor virtual;
- make `Divide()` virtual.