### PR TITLE
Replace depreacted since CMake 3.12 FindPythonInterp with FindPython3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,9 +273,9 @@ endif ()
 ################################
 ####  Find Python
 ################################
-find_package(PythonInterp 3.5)
-if (PYTHON_VERSION_STRING VERSION_LESS 3.5.0)
-    message(FATAL_ERROR "Python 3.5 or higher is required; found v${PYTHON_VERSION_STRING} instead. Specify interpreter with -DPYTHON_EXECUTABLE=/path/to/python3")
+find_package(Python3 3.5)
+if (Python3_VERSION VERSION_LESS 3.5.0)
+    message(FATAL_ERROR "Python 3.5 or higher is required; found v${Python3_VERSION} instead. Specify interpreter with -DPython_EXECUTABLE=/path/to/python3")
 endif ()
 
 # Install chaste_codegen in virtual environment
@@ -284,14 +284,14 @@ set(codegen_python3_venv ${PROJECT_BINARY_DIR}/codegen_python3_venv/bin)
 if (NOT EXISTS ${codegen_python3_venv})
     message (STATUS "Creating virtual environment for chaste_codegen in ${PROJECT_BINARY_DIR}/codegen_python3_venv")
     execute_process(
-        COMMAND ${PYTHON_EXECUTABLE} -m venv codegen_python3_venv
+        COMMAND ${Python3_EXECUTABLE} -m venv codegen_python3_venv
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
     )
 endif ()
 
 # Update pip setuptools and wheel
 message (STATUS "Updating pip setuptools and wheel")
-if (${PYTHON_VERSION_STRING} VERSION_LESS 3.6.0)
+if (${Python3_VERSION} VERSION_LESS 3.6.0)
     execute_process(COMMAND ${codegen_python3_venv}/pip install --no-cache-dir "pip>=20.0, <21.0")
     execute_process(COMMAND ${codegen_python3_venv}/pip install --no-cache-dir --upgrade setuptools wheel)
 else()
@@ -879,7 +879,7 @@ if (Chaste_COVERAGE)
                        set (_page_title "\"Chaste Coverage Results for commit ${Chaste_REVISION}\"")
                        COMMAND ${GENHTML_PATH} --title "${_page_title}" --config-file ${Chaste_SOURCE_DIR}/cmake/Config/lcovrc --no-function-coverage -o ${_outputname} ${_outputname}.info.cleaned
                        COMMAND ${CMAKE_COMMAND} -E remove ${_outputname}.info ${_outputname}.info.cleaned
-                       COMMAND ${PYTHON_EXECUTABLE} "${Chaste_SOURCE_DIR}/cmake/process_coverage_output.py" "${_outputname}"
+                       COMMAND ${Python3_EXECUTABLE} "${Chaste_SOURCE_DIR}/cmake/process_coverage_output.py" "${_outputname}"
 
                        DEPENDS Continuous Parallel
                        WORKING_DIRECTORY ${Chaste_BINARY_DIR}
@@ -955,14 +955,14 @@ endif ()
 ####################
 
 add_custom_target (doxygen
-                   COMMAND ${PYTHON_EXECUTABLE} "${Chaste_SOURCE_DIR}/cmake/run-doxygen.py" "${Chaste_SOURCE_DIR}"
+                   COMMAND ${Python3_EXECUTABLE} "${Chaste_SOURCE_DIR}/cmake/run-doxygen.py" "${Chaste_SOURCE_DIR}"
                    "${Chaste_BINARY_DIR}/doxygen" "${Chaste_REVISION}"
                    WORKING_DIRECTORY ${Chaste_BINARY_DIR}
                    COMMENT "Generating Doxygen documentation"
                    VERBATIM)
 
 add_custom_target (doxygen_coverage
-                   COMMAND ${PYTHON_EXECUTABLE} "${Chaste_SOURCE_DIR}/cmake/run-doxygen.py" "${Chaste_SOURCE_DIR}"
+                   COMMAND ${Python3_EXECUTABLE} "${Chaste_SOURCE_DIR}/cmake/run-doxygen.py" "${Chaste_SOURCE_DIR}"
                    "${Chaste_BINARY_DIR}/doxygen_coverage" "${Chaste_REVISION}" "True"
                    WORKING_DIRECTORY ${Chaste_BINARY_DIR}
                    COMMENT "Checking Doxygen coverage"
@@ -979,7 +979,7 @@ if (Chaste_MEMORY_TESTING)
     set (CTEST_COMMAND ctest)
     add_custom_target (memtest
                        COMMAND ${NICE_COMMAND} ${NICENESS} ${CTEST_COMMAND} "-j${Chaste_MEMORY_TESTING_CPUS}" "-L" Continuous "--output-on-failure"
-                       COMMAND ${PYTHON_EXECUTABLE} "${Chaste_SOURCE_DIR}/cmake/process_valgrind_output.py" "${Chaste_MEMORY_TESTING_OUTPUT_DIR}"
+                       COMMAND ${Python3_EXECUTABLE} "${Chaste_SOURCE_DIR}/cmake/process_valgrind_output.py" "${Chaste_MEMORY_TESTING_OUTPUT_DIR}"
                        DEPENDS Continuous
                        WORKING_DIRECTORY ${Chaste_BINARY_DIR}
                        VERBATIM)
@@ -1004,7 +1004,7 @@ if (Chaste_PROFILE_GPROF OR Chaste_PROFILE_GPERFTOOLS)
     set (CTEST_COMMAND ctest)
     add_custom_target (profile
                        COMMAND ${NICE_COMMAND} ${NICENESS} ${CTEST_COMMAND} "-j${NUM_CPUS}" "-L" "^Profile_" "--output-on-failure"
-                       COMMAND ${PYTHON_EXECUTABLE} "${Chaste_SOURCE_DIR}/cmake/process_profile.py" "${Chaste_PROFILE_OUTPUT_DIR}" ${extension}
+                       COMMAND ${Python3_EXECUTABLE} "${Chaste_SOURCE_DIR}/cmake/process_profile.py" "${Chaste_PROFILE_OUTPUT_DIR}" ${extension}
                        DEPENDS Profile
                        WORKING_DIRECTORY ${Chaste_BINARY_DIR}
                        VERBATIM)
@@ -1016,10 +1016,10 @@ endif ()
 
 
 add_custom_target (infrastructure
-                   COMMAND ${PYTHON_EXECUTABLE} ${Chaste_SOURCE_DIR}/python/infra/CheckForCopyrights.py
-                   COMMAND ${PYTHON_EXECUTABLE} ${Chaste_SOURCE_DIR}/python/infra/CheckForDuplicateFileNames.py
-                   COMMAND ${PYTHON_EXECUTABLE} ${Chaste_SOURCE_DIR}/python/infra/CheckForOrphanedTests.py
-                   COMMAND ${PYTHON_EXECUTABLE} ${Chaste_SOURCE_DIR}/python/infra/CheckSchemas.py
+                   COMMAND ${Python3_EXECUTABLE} ${Chaste_SOURCE_DIR}/python/infra/CheckForCopyrights.py
+                   COMMAND ${Python3_EXECUTABLE} ${Chaste_SOURCE_DIR}/python/infra/CheckForDuplicateFileNames.py
+                   COMMAND ${Python3_EXECUTABLE} ${Chaste_SOURCE_DIR}/python/infra/CheckForOrphanedTests.py
+                   COMMAND ${Python3_EXECUTABLE} ${Chaste_SOURCE_DIR}/python/infra/CheckSchemas.py
 
                    WORKING_DIRECTORY ${Chaste_SOURCE_DIR}
                    VERBATIM)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -31,7 +31,7 @@
 
 
 #This CMake build file automatically builds Chaste and its third party library dependencies as external projects.
-cmake_minimum_required (VERSION 2.8.10)
+cmake_minimum_required (VERSION 3.16.3)
 
 include(${CMAKE_CURRENT_LIST_DIR}/overrides.cmake)
 

--- a/cmake/Config/ChasteConfig.cmake.in
+++ b/cmake/Config/ChasteConfig.cmake.in
@@ -5,7 +5,7 @@
  
 # Compute paths
 
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required (VERSION 3.16.3)
 if(COMMAND cmake_policy)
     cmake_policy(SET CMP0003 NEW)
 endif(COMMAND cmake_policy) 
@@ -37,7 +37,7 @@ if(NOT TARGET global AND NOT Chaste_BINARY_DIR)
         add_definitions(-DCHASTE_XERCES)
     endif()
 
-    find_package(PythonInterp REQUIRED)
+    find_package(Python3 REQUIRED)
     set(Chaste_PYTHON_DIR @EXPORT_Chaste_PYTHON_DIR@)
 
     option(BUILD_SHARED_LIBS

--- a/cmake/Modules/ChasteGenerateVersionAndBuildInfo.cmake
+++ b/cmake/Modules/ChasteGenerateVersionAndBuildInfo.cmake
@@ -86,8 +86,8 @@ foreach(project ${Chaste_PROJECTS})
     set(projects_modified "${projects_modified} modified[\"${project}\"] = \"${this_project_modified}\";\n")
 endforeach()
 
-find_package(PythonInterp QUIET)
-execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c" "from CheckForCopyrights import current_notice; print(current_notice)"
+find_package(Python3 QUIET)
+execute_process(COMMAND "${Python3_EXECUTABLE}" "-c" "from CheckForCopyrights import current_notice; print(current_notice)"
  WORKING_DIRECTORY "${Chaste_SOURCE_DIR}/python/infra"
  OUTPUT_VARIABLE licence)
 string(REPLACE "\nThis file is part of Chaste.\n" "" licence "${licence}")

--- a/cmake/Modules/ChasteHostOperatingSystem.cmake
+++ b/cmake/Modules/ChasteHostOperatingSystem.cmake
@@ -1,7 +1,7 @@
 # Determine the OS infomration and print it
 
 execute_process(
-        COMMAND ${PYTHON_EXECUTABLE} "${Chaste_SOURCE_DIR}/cmake/Modules/ChasteHostOperatingSystem.py"
+        COMMAND ${Python3_EXECUTABLE} "${Chaste_SOURCE_DIR}/cmake/Modules/ChasteHostOperatingSystem.py"
         OUTPUT_VARIABLE DIST_NAME
 )
 

--- a/cmake/Modules/ChasteMacros.cmake
+++ b/cmake/Modules/ChasteMacros.cmake
@@ -132,7 +132,7 @@ macro(Chaste_ADD_TEST _testTargetName _filename)
 
 
     if (python)
-        set(test_exe ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/python/infra/TestPythonCode.py ${_filename})
+        set(test_exe ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/python/infra/TestPythonCode.py ${_filename})
     else()
         set(_exeTargetName ${_testname})
 
@@ -141,7 +141,7 @@ macro(Chaste_ADD_TEST _testTargetName _filename)
             add_custom_command(
                 OUTPUT "${_test_real_output_filename}"
                 DEPENDS ${_filename} ${ARGN}
-                COMMAND ${PYTHON_EXECUTABLE} ${CXXTEST_PYTHON_TESTGEN_EXECUTABLE} --error-printer -o "${_test_real_output_filename}" ${_filename} ${ARGN}
+                COMMAND ${Python3_EXECUTABLE} ${CXXTEST_PYTHON_TESTGEN_EXECUTABLE} --error-printer -o "${_test_real_output_filename}" ${_filename} ${ARGN}
                 )
 
             set_source_files_properties("${_test_real_output_filename}" PROPERTIES GENERATED true)
@@ -463,9 +463,9 @@ macro(Chaste_DO_APPS_COMMON component)
                 file(REMOVE_RECURSE ${texttest_output_dir})
                 file(MAKE_DIRECTORY ${texttest_report_dir})
                 file(MAKE_DIRECTORY ${texttest_output_dir})
-                execute_process(COMMAND  ${PYTHON_EXECUTABLE} ${TEXTTEST_PY} -d ${tests_dir} -b default -c ${CMAKE_BINARY_DIR} 
+                execute_process(COMMAND  ${Python3_EXECUTABLE} ${TEXTTEST_PY} -d ${tests_dir} -b default -c ${CMAKE_BINARY_DIR} 
                     RESULT_VARIABLE result)
-                execute_process(COMMAND  ${PYTHON_EXECUTABLE} ${TEXTTEST_PY} -d ${tests_dir} -b default -c ${CMAKE_BINARY_DIR} -coll web)
+                execute_process(COMMAND  ${Python3_EXECUTABLE} ${TEXTTEST_PY} -d ${tests_dir} -b default -c ${CMAKE_BINARY_DIR} -coll web)
                 if (result)
                     message(SEND_ERROR \"Error running acceptance test\")
                 endif()
@@ -619,7 +619,7 @@ macro(Chaste_DO_TEST_COMMON component)
                         endif()
                         set(out_filename  ${CMAKE_BINARY_DIR}/tutorials/UserTutorials/${CMAKE_MATCH_1}.md)
                         add_custom_command(OUTPUT ${out_filename}
-                            COMMAND ${PYTHON_EXECUTABLE} ARGS ${Chaste_BINARY_DIR}/python/utils/CreateTutorial.py ${CMAKE_CURRENT_SOURCE_DIR}/${filename} ${out_filename} ${revision_string}
+                            COMMAND ${Python3_EXECUTABLE} ARGS ${Chaste_BINARY_DIR}/python/utils/CreateTutorial.py ${CMAKE_CURRENT_SOURCE_DIR}/${filename} ${out_filename} ${revision_string}
                             DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${filename}
                             COMMENT "Generating user tutorial ${out_filename}" VERBATIM)
                         add_custom_target(${CMAKE_MATCH_1} DEPENDS ${out_filename})
@@ -630,7 +630,7 @@ macro(Chaste_DO_TEST_COMMON component)
                     if(filename MATCHES "Test(.*)LiteratePaper.(hpp|py)") 
                         set(out_filename  ${CMAKE_BINARY_DIR}/tutorials/PaperTutorials/${CMAKE_MATCH_1}.md)
                         add_custom_command(OUTPUT ${out_filename}
-                            COMMAND ${PYTHON_EXECUTABLE} ARGS ${Chaste_BINARY_DIR}/python/utils/CreateTutorial.py ${CMAKE_CURRENT_SOURCE_DIR}/${filename} ${out_filename} 
+                            COMMAND ${Python3_EXECUTABLE} ARGS ${Chaste_BINARY_DIR}/python/utils/CreateTutorial.py ${CMAKE_CURRENT_SOURCE_DIR}/${filename} ${out_filename} 
                             DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${filename}
                             COMMENT "Generating paper tutorial ${out_filename}" VERBATIM)
                         add_custom_target(${CMAKE_MATCH_1} DEPENDS ${out_filename})

--- a/heart/src/odes/CellMLToSharedLibraryConverter.cpp
+++ b/heart/src/odes/CellMLToSharedLibraryConverter.cpp
@@ -203,7 +203,7 @@ void CellMLToSharedLibraryConverter::ConvertCellmlToSo(const std::string& rCellm
                                       "set(CMAKE_CXX_STANDARD_REQUIRED ON)\n" <<
                                       "set(CMAKE_CXX_EXTENSIONS OFF)\n" <<
                                       "project (ChasteCellMLToSharedLibraryConverter)\n" <<
-                                      "find_package(PythonInterp 3.5 REQUIRED)\n" <<
+                                      "find_package(Python3 3.5 REQUIRED)\n" <<
                                       "set(codegen_python3_venv " + chaste_root.GetAbsolutePath() + "/codegen_python3_venv/bin)\n" <<
                                       "find_package(Chaste COMPONENTS " << mComponentName << ")\n" <<
                                       "chaste_do_cellml(sources " << cellml_file.GetAbsolutePath() << " " << "ON " << codegen_args << ")\n" <<


### PR DESCRIPTION
Replace depreacted since CMake 3.12 `FindPythonInterp` with `FindPython3`, which emits author warnings from CMake 3.27 and will be removed from a future CMake release.

Also updates cmake_minimum_required to be consistent to ensure FindPython3 is avialable, excluding 3rd party deps

Closes #236