### PR TITLE
Boost 1.73 & 1.74 deprecation fixes and suppressions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,7 +395,10 @@ endif ()
 find_package (Boost COMPONENTS filesystem system serialization program_options REQUIRED)
 list (APPEND Chaste_INCLUDES "${Boost_INCLUDE_DIR}")
 list (APPEND Chaste_LINK_LIBRARIES "${Boost_LIBRARIES}")
-
+# Suppress boost deprecation notices in Boost 1.74.0 (shipped with Ubuntu 22.04), fixed in 1.75
+if (Boost_VERSION VERSION_GREATER_EQUAL 1.74.0 AND Boost_VERSION VERSION_LESS 1.75.0)
+    add_definitions(-DBOOST_ALLOW_DEPRECATED_HEADERS)
+endif ()
 
 
 ################################

--- a/cell_based/src/population/AbstractCellPopulation.cpp
+++ b/cell_based/src/population/AbstractCellPopulation.cpp
@@ -33,8 +33,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
-#include <boost/bind.hpp>
-
 #include <algorithm>
 #include <functional>
 

--- a/lung/src/ventilation/odes/HiornsAirwayWall.cpp
+++ b/lung/src/ventilation/odes/HiornsAirwayWall.cpp
@@ -36,7 +36,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cmath>
 #include <iostream>
 #include <boost/math/tools/roots.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include "BoostTolerance.hpp"
 #include "HiornsAirwayWall.hpp"
@@ -130,7 +130,7 @@ void HiornsAirwayWall::SolveAndUpdateState(double tStart, double tEnd)
     Tolerance tol = 0.000001;
     boost::uintmax_t maxIterations = 500u;
 
-    std::pair<double, double> found = boost::math::tools::bracket_and_solve_root(boost::bind(&HiornsAirwayWall::CalculatePressureRadiusResidual, this, _1), guess, factor, false, tol, maxIterations);
+    std::pair<double, double> found = boost::math::tools::bracket_and_solve_root(boost::bind(&HiornsAirwayWall::CalculatePressureRadiusResidual, this, boost::placeholders::_1), guess, factor, false, tol, maxIterations);
     mDeformedAirwayRadius = found.first;
 }
 

--- a/lung/src/ventilation/odes/LaPradAirwayWall.cpp
+++ b/lung/src/ventilation/odes/LaPradAirwayWall.cpp
@@ -36,7 +36,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cmath>
 #include <iostream>
 #include <boost/math/tools/roots.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include "BoostTolerance.hpp"
 #include "LaPradAirwayWall.hpp"
@@ -100,7 +100,7 @@ void LaPradAirwayWall::SolveAndUpdateState(double tStart, double tEnd)
     Tolerance tol = 0.000001;
     boost::uintmax_t maxIterations = 500u;
 
-    std::pair<double, double> found = boost::math::tools::bracket_and_solve_root(boost::bind(&LaPradAirwayWall::CalculatePressureRadiusResidual, this, _1), guess, factor, false, tol, maxIterations);
+    std::pair<double, double> found = boost::math::tools::bracket_and_solve_root(boost::bind(&LaPradAirwayWall::CalculatePressureRadiusResidual, this, boost::placeholders::_1), guess, factor, false, tol, maxIterations);
     mDeformedAirwayRadius = found.first;
 }
 

--- a/lung/test/ventilation/TestAcinarUnitModels.hpp
+++ b/lung/test/ventilation/TestAcinarUnitModels.hpp
@@ -50,7 +50,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "BackwardEulerIvpOdeSolver.hpp"
 
 #include <boost/math/tools/roots.hpp>
-#include <boost/bind.hpp>
 #include <iomanip>
 
 //#include "PetscSetupAndFinalize.hpp"


### PR DESCRIPTION
+ Suppresses boost internal deprecation warnings in Boost 1.74.0 (Ubuntu 22.04) (closes #235)
+ Replaces use of `<boost/bind.hpp>` deprecated in Boost 1.73.0 with the suggested alternative of `<boost/bind/bind.hpp>` and scoped `using namespace` statements. (closes #241)
  + 2 occurences of the offending header were removed as unused in those compilation units