### PR TITLE
CI `libexpat1` downgrade

### DIFF
--- a/.github/workflows/memory-testing.yml
+++ b/.github/workflows/memory-testing.yml
@@ -54,6 +54,13 @@ jobs:
           sudo apt update
           sudo apt install chaste-dependencies
 
+      - name: Downgrade libexpat1 (native ubuntu-22.04 only)
+        # if: ${{ matrix.os == 'ubuntu-22.04' }}
+        run: |
+          if dpkg -l | grep libexpat1-dev | grep 2.4.7-1ubuntu0.3; then
+            sudo apt-get install -y --allow-downgrades libexpat1=2.4.7-1 libexpat1-dev=2.4.7-1
+          fi
+
       - name: make build and test directories
         run: |
           mkdir -p ${CHASTE_BUILD_DIR}

--- a/.github/workflows/ubuntu-libexpat1-monitoring.yml
+++ b/.github/workflows/ubuntu-libexpat1-monitoring.yml
@@ -1,0 +1,124 @@
+# Workflow to monitor the state of ubuntu 22.04 post libexpat1 upgrade which causes .vtu parsing errors.
+# See https://github.com/Chaste/Chaste/issues/249
+# This is a reduced version of ubuntu-tests.yml (smaller matrix, Continuous only), on a schedule with notification of success
+name: Ubuntu libexpat1 monitoring
+
+on:
+  workflow_dispatch:
+  # Run nightly (03:23 UTC) until workflow is disabled
+  schedule:
+    - cron: '23 3 * * *'
+
+jobs:
+  
+  build-and-test:
+
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:off') }}
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: "ubuntu-22.04"
+            codename: "jammy"
+            cc: "gcc"
+            cxx: "g++"
+
+    env:
+      CHASTE_TEST_OUTPUT: ${{ github.workspace }}/chaste-test-dir
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
+
+    steps:
+    - name: checkout repository
+      uses: actions/checkout@v3
+
+    - name: install dependencies
+      run: |
+        echo 'deb [signed-by=/usr/share/keyrings/chaste.asc] https://chaste.github.io/ubuntu ${{ matrix.codename }}/' | sudo tee -a /etc/apt/sources.list.d/chaste.list
+        sudo wget -O /usr/share/keyrings/chaste.asc https://chaste.github.io/chaste.asc
+        sudo apt update
+        sudo apt install chaste-dependencies
+
+    - name: install and set up Intel LLVM compiler
+      run: |
+        echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+        sudo apt update
+        sudo apt install intel-oneapi-compiler-dpcpp-cpp
+        source /opt/intel/oneapi/setvars.sh
+        printenv >> $GITHUB_ENV
+      if: ${{ matrix.cc == 'icx' }}
+
+    - name: compiler version
+      run: |
+        ${CXX} --version
+
+    - name: make build and test directories
+      run: |
+        mkdir -p chaste-build-dir
+        mkdir -p ${CHASTE_TEST_OUTPUT}
+
+    - name: cmake configure
+      run: cmake -DCMAKE_BUILD_TYPE=Release ..
+      working-directory: chaste-build-dir
+
+    - name: build core libraries
+      run: cmake --build . --parallel 4 --target chaste_core
+      working-directory: chaste-build-dir
+
+    - name: build cell_based
+      run: cmake --build . --parallel 4 --target chaste_cell_based
+      working-directory: chaste-build-dir
+
+    - name: build crypt
+      run: cmake --build . --parallel 4 --target chaste_crypt
+      working-directory: chaste-build-dir
+
+    - name: build heart
+      run: cmake --build . --parallel 4 --target chaste_heart
+      working-directory: chaste-build-dir
+
+    - name: build lung
+      run: cmake --build . --parallel 4 --target chaste_lung
+      working-directory: chaste-build-dir
+
+    - name: build continuous test pack
+      run: cmake --build . --parallel 4 --target Continuous
+      working-directory: chaste-build-dir
+
+    # - name: build nightly test pack
+    #   run: cmake --build . --parallel 4 --target Nightly
+    #   working-directory: chaste-build-dir
+
+    - name: run Continuous test pack
+      run: ctest -j4 -L Continuous --output-on-failure
+      working-directory: chaste-build-dir
+
+    # - name: run Nightly test pack
+    #   run: ctest -j4 -L Nightly --output-on-failure
+    #   working-directory: chaste-build-dir
+
+    - name: Leave comment when errors no longer occur
+      if: success()
+      run: gh issue comment "$NUMBER" --body "$BODY"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        NUMBER: 249
+        BODY: |
+          ${{ github.workflow }} passed.
+          See [${{ github.repository }}/actions/runs/${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+          It should now be possible to remove the ${{ github.workflow }} workflow and workarounds for libexpat1 (when containers also include the updated packages).
+
+          See [#249](https://github.com/Chaste/Chaste/issues/249)
+
+    - name: Self-disable the workflow to avoid spam once it succeeds
+      if: success()
+      run: gh workflow disable "$WORKFLOW_NAME"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WORKFLOW_NAME: ${{ github.workflow }}

--- a/.github/workflows/ubuntu-parallel.yml
+++ b/.github/workflows/ubuntu-parallel.yml
@@ -42,6 +42,13 @@ jobs:
         sudo apt update
         sudo apt install chaste-dependencies
 
+    - name: Downgrade libexpat1 (native ubuntu-22.04 only)
+      # if: ${{ matrix.os == 'ubuntu-22.04' }}
+      run: |
+        if dpkg -l | grep libexpat1-dev | grep 2.4.7-1ubuntu0.3; then
+          sudo apt-get install -y --allow-downgrades libexpat1=2.4.7-1 libexpat1-dev=2.4.7-1
+        fi
+
     - name: install and set up Intel LLVM compiler
       run: |
         echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list

--- a/.github/workflows/ubuntu-tests.yml
+++ b/.github/workflows/ubuntu-tests.yml
@@ -50,6 +50,13 @@ jobs:
         sudo apt update
         sudo apt install chaste-dependencies
 
+    - name: Downgrade libexpat1 (native ubuntu-22.04 only)
+      if: ${{ matrix.os == 'ubuntu-22.04' }}
+      run: |
+        if dpkg -l | grep libexpat1-dev | grep 2.4.7-1ubuntu0.3; then
+          sudo apt-get install -y --allow-downgrades libexpat1=2.4.7-1 libexpat1-dev=2.4.7-1
+        fi
+
     - name: install and set up Intel LLVM compiler
       run: |
         echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list


### PR DESCRIPTION
Short-term fix for CI to prevent `libexpat1` upgrade based CI failures (see #249). 

This PR does not fix the underlying issue, but allows CI to pass by downgrading the package(s) on CI.

+ [x] Downgrade libexpat1 for github-hosted native ubuntu-22.04 workflows
+ ~Optionally Downgrade libexpat1 for container based workflows in jammy containers (not currently required, may be needed in the future if containers are updated)~. No longer needed due to changes to [Chaste/chaste-docker](https://github.com/Chaste/chaste-docker)
+ [x] Add nightly workflow to check for when the underlying issue is fixed for ubuntu 22.04 users. Once this workflow passes a comment will be left on #249 and the workflow disabled.
+ [x] `np3` is self hosted, @fcooper8472 is looking at downgrading and pinning libexpat1 there.