### PR TITLE
Suppress clang 14 unused-but-set-variable warnings via [[maybe_unused]]

### DIFF
--- a/global/test/TestStaticPolymorphism.hpp
+++ b/global/test/TestStaticPolymorphism.hpp
@@ -52,7 +52,7 @@ public:
 
     void Run()
     {
-        int total = 0;
+        [[maybe_unused]] int total = 0;
         for (int i=0; i<1e8; i++)
         {
             total += Method(i);
@@ -73,7 +73,7 @@ public:
 
     void Run()
     {
-        int total = 0;
+        [[maybe_unused]] int total = 0;
         for (int i=0; i<1e8; i++)
         {
             total += Method(i);

--- a/lung/test/ventilation/TestAcinarUnitModels.hpp
+++ b/lung/test/ventilation/TestAcinarUnitModels.hpp
@@ -244,7 +244,7 @@ public:
        double pleural_pressure = 0.0;
 
        double ode_volume = 0.0;
-       double flow_integral = 0.0;
+       [[maybe_unused]] double flow_integral = 0.0;
 
        while (!time_stepper.IsTimeAtEnd())
        {


### PR DESCRIPTION
Uses C++ 17 [[[maybe_unused]]](https://en.cppreference.com/w/cpp/language/attributes/maybe_unused) to suppress 3 `unused-but-set-variable` warnings issued by clang-14 within tests.

Closes #256