### PR TITLE
Add GPU support to chaste

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ message ("####################################\n")
 message(STATUS "CMake version: ${CMAKE_VERSION}")
 
 # Since CMake 3.0, version can be supplied to the project() command.  We set it directly, for users on older CMake
-project (Chaste VERSION 2024.2)
+project (Chaste VERSION 2024.2 LANGUAGES CUDA CXX)
 set (Chaste_VERSION_MAJOR 2024 CACHE STRING "Chaste major version number")
 set (Chaste_VERSION_MINOR 2 CACHE STRING "Chaste minor version number")
 
@@ -579,6 +579,32 @@ if (Chaste_ENABLE_TESTING)
     list (APPEND CMAKE_INCLUDE_PATH "${Chaste_SOURCE_DIR}/cxxtest")
     find_package (CxxTest)
 endif ()
+
+####################
+# FIND FLAMEGPU 2 #
+####################
+#t # Minimum CMake version 3.18 for CUDA --std=c++17 
+cmake_minimum_required(VERSION 3.18...3.25 FATAL_ERROR)
+#
+## Optionaly set the version of flamegpu which should be used, ideally a tag (i.e. `v2.0.0-rc`) or branch name, or potentially a commit hash.
+set(FLAMEGPU_VERSION "master" CACHE STRING "FLAMEGPU/FLAMEGPU2 git branch or tag to use")
+## If the above version is a hash instead, also set FLAMEGPU_VERSION_ALLOW_HASH to ON
+# set(FLAMEGPU_VERSION_ALLOW_HASH "ON")
+#
+## Manually specify the FLAMEGPU_VISUALISATION option to provide it prior to original configuration and allow the default to be overridden in the downstream project
+option(FLAMEGPU_VISUALISATION "Enable FLAMEGPU visualisation support" OFF)
+#
+## Our core dependency is FLAMEGPU2 l:warningsib, first lets find it
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/flamegpu2.cmake)
+#
+## Handle CMAKE_CUDA_ARCHITECTURES gracefully, passign the project name for code-injection
+include(${FLAMEGPU_ROOT}/cmake/CUDAArchitectures.cmake)
+flamegpu_init_cuda_architectures(PROJECT Chaste)
+#
+## Include common rules from the FLAMEGPU/FLAMEGPU2 repositories CMake
+include(${FLAMEGPU_ROOT}/cmake/common.cmake)
+#        
+target_link_libraries(Chaste_COMMON_DEPS INTERFACE flamegpu)
 
 ###########################################
 # SETUP AVAILABLE COMPONENTS AND PROJECTS #

--- a/cell_based/src/simulation/modifiers/GPUModifier.cu
+++ b/cell_based/src/simulation/modifiers/GPUModifier.cu
@@ -1,0 +1,199 @@
+/*
+
+Copyright (c) 2005-2024, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "GPUModifier.cuh"
+#include "MeshBasedCellPopulation.hpp"
+
+FLAMEGPU_AGENT_FUNCTION(output_location, flamegpu::MessageNone, flamegpu::MessageBruteForce) {
+    FLAMEGPU->message_out.setVariable<float>("x", FLAMEGPU->getVariable<float>("x"));
+    FLAMEGPU->message_out.setVariable<float>("y", FLAMEGPU->getVariable<float>("y"));
+    FLAMEGPU->message_out.setVariable<float>("radius", FLAMEGPU->getVariable<float>("radius"));
+    return flamegpu::ALIVE;
+}
+
+// Models repulsion force without division/apoptosis
+FLAMEGPU_AGENT_FUNCTION(compute_force_meineke_spring, flamegpu::MessageBruteForce, flamegpu::MessageNone) {
+    const float x = FLAMEGPU->getVariable<float>("x");
+    const float y = FLAMEGPU->getVariable<float>("y");
+    float x_force = 0.0;
+    float y_force = 0.0;
+    float radius = FLAMEGPU->getVariable<float>("radius");
+
+    for (const auto& message : FLAMEGPU->message_in) {
+        float other_x = message.getVariable<float>("x");
+        float other_y = message.getVariable<float>("y");
+        float other_radius = message.getVariable<float>("radius");
+        
+        float x_dist = other_x - x;
+        float y_dist = other_y - y;
+        float distance_between_nodes = sqrt(x_dist * x_dist + y_dist * y_dist);
+        float unit_x = x_dist / distance_between_nodes;
+        float unit_y = y_dist / distance_between_nodes;
+        const float rest_length = radius + other_radius; 
+        float overlap = distance_between_nodes - rest_length;
+        const float spring_stiffness = 15.0f;
+        const float cutoff_length = 1.5f;
+        const float multiplication_factor = 1.0f;
+
+        if (distance_between_nodes > 0.0f) {
+            if (x_dist * x_dist + y_dist * y_dist < cutoff_length) {
+                x_force += multiplication_factor * spring_stiffness * unit_x * overlap; 
+                y_force += multiplication_factor * spring_stiffness * unit_y * overlap; 
+            }
+        }
+
+        
+        FLAMEGPU->setVariable("x_force", x_force);        
+        FLAMEGPU->setVariable("y_force", y_force);        
+    }
+    return flamegpu::ALIVE;
+}
+
+template<unsigned DIM>
+GPUModifier<DIM>::GPUModifier()
+    : AbstractCellBasedSimulationModifier<DIM>(),
+    mpFlameGPUModel(nullptr),
+    mpCellAgentDescription(nullptr),
+    mpFlameGPUSimulation(nullptr)
+{
+}
+
+template<unsigned DIM>
+GPUModifier<DIM>::~GPUModifier()
+{
+}
+
+template<unsigned DIM>
+void GPUModifier<DIM>::UpdateAtEndOfTimeStep(AbstractCellPopulation<DIM,DIM>& rCellPopulation)
+{
+    // Reset the simulation
+    mpFlameGPUSimulation->resetStepCounter();
+
+    // Extract cell locations from chaste
+    // Get number of cells & resize agent vector to match
+    unsigned int numCells = rCellPopulation.rGetMesh().GetNumNodes();
+    mpCellAgentVector->resize(numCells);
+
+    // Set the positions and clear the forces
+    auto& rMesh = rCellPopulation.rGetMesh();
+    auto& cellVector = *mpCellAgentVector; // Grab ref to vector for easier indexing
+    unsigned int i = 0;
+    for (auto iter = rMesh.GetNodeIteratorBegin(); iter != rMesh.GetNodeIteratorEnd(); ++iter) {
+      cellVector[i].setVariable<float>("x", iter->rGetLocation()[0]);
+      cellVector[i].setVariable<float>("y", iter->rGetLocation()[1]);
+      cellVector[i].setVariable<float>("radius", 1.5f);
+      cellVector[i].setVariable<float>("x_force", 0.0f);
+      cellVector[i].setVariable<float>("y_force", 0.0f);
+      i++;
+    }
+
+    // Create cell population for FlameGPU simulation
+    mpFlameGPUSimulation->setPopulationData(*mpCellAgentVector);
+
+    // Run the simulation
+    mpFlameGPUSimulation->simulate();
+
+    // Extract results
+    flamegpu::AgentVector out_pop(*mpCellAgentDescription);
+    mpFlameGPUSimulation->getPopulationData(*mpCellAgentVector);
+
+    // Apply results to chaste - TODO: Assumes no change in pop size. Should always be true for force resolution?
+    i = 0;
+    for (auto iter = rMesh.GetNodeIteratorBegin(); iter != rMesh.GetNodeIteratorEnd(); ++iter) {
+        iter->rGetModifiableLocation()[0] = cellVector[i].getVariable<float>("x");
+        iter->rGetModifiableLocation()[1] = cellVector[i].getVariable<float>("y");
+        i++;
+    }
+}
+
+template<unsigned DIM>
+void GPUModifier<DIM>::SetupSolve(AbstractCellPopulation<DIM,DIM>& rCellPopulation, std::string outputDirectory)
+{
+    mpFlameGPUModel = std::make_unique<flamegpu::ModelDescription>("ForceResolutionModel");
+    
+    // Define an agent
+    mpCellAgentDescription = std::make_unique<flamegpu::AgentDescription>(mpFlameGPUModel->newAgent("cell"));
+    mpCellAgentDescription->newVariable<float>("x");
+    mpCellAgentDescription->newVariable<float>("y");
+    mpCellAgentDescription->newVariable<float>("radius");
+    mpCellAgentDescription->newVariable<float>("x_force");
+    mpCellAgentDescription->newVariable<float>("y_force");
+    
+    // Define the location message
+    flamegpu::MessageBruteForce::Description location_message = mpFlameGPUModel->newMessage<flamegpu::MessageBruteForce>("location_message");
+    location_message.newVariable<float>("x");
+    location_message.newVariable<float>("y");
+    location_message.newVariable<float>("radius");
+
+    // Agent functions
+    flamegpu::AgentFunctionDescription output_location_desc = mpCellAgentDescription->newFunction("output_location", output_location);
+    output_location_desc.setMessageOutput("location_message");
+    
+    flamegpu::AgentFunctionDescription compute_force_desc = mpCellAgentDescription->newFunction("compute_force_meineke_spring", compute_force_meineke_spring);
+    compute_force_desc.setMessageInput("location_message");
+
+    compute_force_desc.dependsOn(output_location_desc);
+    
+    // Set execution root
+    mpFlameGPUModel->addExecutionRoot(output_location_desc);
+    
+    // Generate execution plan
+    mpFlameGPUModel->generateLayers();
+      
+    // Construct a simulation object from the model and configure it to run for a single step
+    mpFlameGPUSimulation = std::make_unique<flamegpu::CUDASimulation>(*mpFlameGPUModel);
+    mpFlameGPUSimulation->SimulationConfig().steps = 1;
+    
+    // Allocate a vector for transferring agent data between host & device
+    mpCellAgentVector = std::make_unique<flamegpu::AgentVector>(*mpCellAgentDescription);
+}
+
+
+template<unsigned DIM>
+void GPUModifier<DIM>::OutputSimulationModifierParameters(out_stream& rParamsFile)
+{
+    // No parameters to output, so just call method on direct parent class
+    AbstractCellBasedSimulationModifier<DIM>::OutputSimulationModifierParameters(rParamsFile);
+}
+
+// Explicit instantiation
+template class GPUModifier<1>;
+template class GPUModifier<2>;
+template class GPUModifier<3>;
+
+// Serialization for Boost >= 1.36
+#include "SerializationExportWrapperForCpp.hpp"
+EXPORT_TEMPLATE_CLASS_SAME_DIMS(GPUModifier)
+

--- a/cell_based/src/simulation/modifiers/GPUModifier.cuh
+++ b/cell_based/src/simulation/modifiers/GPUModifier.cuh
@@ -1,0 +1,118 @@
+/*
+
+Copyright (c) 2005-2024, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef GPUMODIFIER_HPP_
+#define GPUMODIFIER_HPP_
+
+#include "ChasteSerialization.hpp"
+#include <boost/serialization/base_object.hpp>
+
+#include "AbstractCellBasedSimulationModifier.hpp"
+
+#include "flamegpu/flamegpu.h"
+
+/**
+ * A modifier class which at each simulation time step calculates the volume of each cell
+ * and stores it in in the CellData property as "volume". To be used in conjunction with
+ * contact inhibition cell cycle models.
+ */
+template<unsigned DIM>
+class GPUModifier : public AbstractCellBasedSimulationModifier<DIM,DIM>
+{
+    /** Needed for serialization. */
+    friend class boost::serialization::access;
+    /**
+     * Boost Serialization method for archiving/checkpointing.
+     * Archives the object and its member variables.
+     *
+     * @param archive  The boost archive.
+     * @param version  The current version of this class.
+     */
+    template<class Archive>
+    void serialize(Archive & archive, const unsigned int version)
+    {
+        archive & boost::serialization::base_object<AbstractCellBasedSimulationModifier<DIM,DIM> >(*this);
+    }
+
+public:
+
+    /**
+     * Default constructor.
+     */
+    GPUModifier();
+
+    /**
+     * Destructor.
+     */
+    virtual ~GPUModifier();
+
+    /**
+     * Overridden UpdateAtEndOfTimeStep() method.
+     *
+     * Specify what to do in the simulation at the end of each time step.
+     *
+     * @param rCellPopulation reference to the cell population
+     */
+    virtual void UpdateAtEndOfTimeStep(AbstractCellPopulation<DIM,DIM>& rCellPopulation);
+
+    /**
+     * Overridden SetupSolve() method.
+     *
+     * Specify what to do in the simulation before the start of the time loop.
+     * For this class, initialise the FLAME GPU model
+     *
+     * @param rCellPopulation reference to the cell population
+     * @param outputDirectory the output directory, relative to where Chaste output is stored
+     */
+    virtual void SetupSolve(AbstractCellPopulation<DIM,DIM>& rCellPopulation, std::string outputDirectory);
+
+    /**
+     * Overridden OutputSimulationModifierParameters() method.
+     * Output any simulation modifier parameters to file.
+     *
+     * @param rParamsFile the file stream to which the parameters are output
+     */
+    void OutputSimulationModifierParameters(out_stream& rParamsFile);
+    
+    std::unique_ptr<flamegpu::ModelDescription> mpFlameGPUModel;
+    std::unique_ptr<flamegpu::CUDASimulation> mpFlameGPUSimulation;
+    std::unique_ptr<flamegpu::AgentDescription> mpCellAgentDescription;
+    std::unique_ptr<flamegpu::AgentVector> mpCellAgentVector;
+};
+
+#include "SerializationExportWrapper.hpp"
+EXPORT_TEMPLATE_CLASS_SAME_DIMS(GPUModifier)
+
+#endif /*GPUMODIFIER_HPP_*/

--- a/cell_based/test/ContinuousTestPack.txt
+++ b/cell_based/test/ContinuousTestPack.txt
@@ -70,6 +70,7 @@ simulation/Test2dVertexBasedSimulationWithSrnModels.hpp
 simulation/TestDeltaNotchModifier.hpp
 simulation/TestDivisionBiasTrackingModifier.hpp
 simulation/TestExtrinsicPullModifier.hpp
+simulation/TestFlameGPU2.cuh
 simulation/TestNumericalMethods.hpp
 simulation/TestImmersedBoundarySimulationModifier.hpp
 simulation/TestImmersedBoundarySvgWriter.hpp

--- a/cell_based/test/simulation/TestFlameGPU2.cuh
+++ b/cell_based/test/simulation/TestFlameGPU2.cuh
@@ -1,0 +1,119 @@
+/*
+
+Copyright (c) 2005-2024, University of Oxford.
+All rights reserved.
+
+University of Oxford means the Chancellor, Masters and Scholars of the
+University of Oxford, having an administrative office at Wellington
+Square, Oxford OX1 2JD, UK.
+
+This file is part of Chaste.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name of the University of Oxford nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef TESTOFFLATTICESIMULATION_HPP_
+#define TESTOFFLATTICESIMULATION_HPP_
+
+#include <cxxtest/TestSuite.h>
+
+#include <cstdio>
+#include <cmath>
+
+#include "CheckpointArchiveTypes.hpp"
+#include "OffLatticeSimulation.hpp"
+#include "HoneycombMeshGenerator.hpp"
+#include "CylindricalHoneycombMeshGenerator.hpp"
+#include "ToroidalHoneycombMeshGenerator.hpp"
+#include "CellsGenerator.hpp"
+#include "FixedG1GenerationalCellCycleModel.hpp"
+#include "UniformCellCycleModel.hpp"
+#include "NoCellCycleModel.hpp"
+#include "GeneralisedLinearSpringForce.hpp"
+#include "ChemotacticForce.hpp"
+#include "RandomCellKiller.hpp"
+#include "PlaneBasedCellKiller.hpp"
+#include "PlaneBoundaryCondition.hpp"
+#include "AbstractCellBasedWithTimingsTestSuite.hpp"
+#include "MeshBasedCellPopulationWithGhostNodes.hpp"
+#include "NumericFileComparison.hpp"
+#include "CellBasedEventHandler.hpp"
+#include "WildTypeCellMutationState.hpp"
+#include "DifferentiatedCellProliferativeType.hpp"
+#include "OffLatticeSimulationWithMyStoppingEvent.hpp"
+#include "TransitCellProliferativeType.hpp"
+#include "SmartPointers.hpp"
+#include "FileComparison.hpp"
+#include "CellIdWriter.hpp"
+#include "VolumeTrackingModifier.hpp"
+#include "CellBasedSimulationArchiver.hpp"
+#include "ApcOneHitCellMutationState.hpp"
+#include "ApcTwoHitCellMutationState.hpp"
+#include "BetaCateninOneHitCellMutationState.hpp"
+#include "DefaultCellProliferativeType.hpp"
+#include "ForwardEulerNumericalMethod.hpp"
+
+// Cell population writers
+#include "CellMutationStatesCountWriter.hpp"
+#include "CellProliferativeTypesCountWriter.hpp"
+#include "NodeVelocityWriter.hpp"
+#include "VoronoiDataWriter.hpp"
+
+#include "flamegpu/flamegpu.h"
+
+#include "PetscSetupAndFinalize.hpp"
+
+FLAMEGPU_AGENT_FUNCTION(do_nothing, flamegpu::MessageNone, flamegpu::MessageNone) {
+    return flamegpu::ALIVE;
+}
+
+class TestOffLatticeSimulation : public AbstractCellBasedWithTimingsTestSuite
+{
+public:
+
+    void TestFlameGPU2Simulation()
+    {
+
+        flamegpu::ModelDescription model("Chaste Test");
+        
+        // Define an agent
+        flamegpu::AgentDescription agent = model.newAgent("cell"); 
+        agent.newVariable<float>("x");
+
+        // Agent functions
+        flamegpu::AgentFunctionDescription func = agent.newFunction("do_nothing", do_nothing);
+        
+        // Set execution root
+        model.addExecutionRoot(func);
+        
+        //model.addInitFunction(create_agents);
+        
+        model.generateLayers();
+
+        flamegpu::CUDASimulation cuda_model(model);
+        cuda_model.simulate();
+    }
+};
+
+#endif /*TESTOFFLATTICESIMULATION_HPP_*/

--- a/cell_based/test/simulation/TestFlameGPU2.cuh
+++ b/cell_based/test/simulation/TestFlameGPU2.cuh
@@ -144,11 +144,11 @@ FLAMEGPU_AGENT_FUNCTION(test_compute_force_meineke_spring, flamegpu::MessageBrut
         }
 
 
-        FLAMEGPU->setVariable("x_force", x_force);        
-        FLAMEGPU->setVariable("y_force", y_force);        
+        FLAMEGPU->setVariable<float>("x_force", x_force);        
+        FLAMEGPU->setVariable<float>("y_force", y_force);        
         
-        FLAMEGPU->setVariable("x", x + x_force * 0.001);
-        FLAMEGPU->setVariable("y", y + y_force * 0.001);
+        FLAMEGPU->setVariable<float>("x", x + x_force * 0.001);
+        FLAMEGPU->setVariable<float>("y", y + y_force * 0.001);
     }
     return flamegpu::ALIVE;
 }

--- a/cell_based/test/simulation/TestFlameGPU2.cuh
+++ b/cell_based/test/simulation/TestFlameGPU2.cuh
@@ -188,86 +188,86 @@ public:
         /* 
          * Chaste computation 
          */
-        SimulationTime::Instance()->SetEndTimeAndNumberOfTimeSteps(1.0,1);
-        
-        // Create a NodeBasedCellPopulation
-        std::vector<Node<2>*> nodes;
-        nodes.push_back(new Node<2>(0, true, 0.0, 0.0));
-        nodes.push_back(new Node<2>(1, true, 0.5, 0.5));
-        nodes.push_back(new Node<2>(2, true, 1.0, 1.0));
+        //SimulationTime::Instance()->SetEndTimeAndNumberOfTimeSteps(1.0,1);
+        //
+        //// Create a NodeBasedCellPopulation
+        //std::vector<Node<2>*> nodes;
+        //nodes.push_back(new Node<2>(0, true, 0.0, 0.0));
+        //nodes.push_back(new Node<2>(1, true, 0.5, 0.5));
+        //nodes.push_back(new Node<2>(2, true, 1.0, 1.0));
 
-        // Convert this to a NodesOnlyMesh
-        NodesOnlyMesh<2> mesh;
-        mesh.ConstructNodesWithoutMesh(nodes, 100.0);
+        //// Convert this to a NodesOnlyMesh
+        //NodesOnlyMesh<2> mesh;
+        //mesh.ConstructNodesWithoutMesh(nodes, 100.0);
 
-        std::vector<CellPtr> cells;
-        CellsGenerator<FixedG1GenerationalCellCycleModel, 2> cells_generator;
-        cells_generator.GenerateBasic(cells, mesh.GetNumNodes());
+        //std::vector<CellPtr> cells;
+        //CellsGenerator<FixedG1GenerationalCellCycleModel, 2> cells_generator;
+        //cells_generator.GenerateBasic(cells, mesh.GetNumNodes());
 
-        NodeBasedCellPopulation<2> cell_population(mesh, cells);
-        cell_population.Update(); //Needs to be called separately as not in a simulation
+        //NodeBasedCellPopulation<2> cell_population(mesh, cells);
+        //cell_population.Update(); //Needs to be called separately as not in a simulation
 
-        RepulsionForce<2> repulsion_force;
+        //RepulsionForce<2> repulsion_force;
 
-        for (AbstractMesh<2,2>::NodeIterator node_iter = mesh.GetNodeIteratorBegin();
-                node_iter != mesh.GetNodeIteratorEnd();
-                ++node_iter)
-        {
-            node_iter->ClearAppliedForce();
-        }
-        repulsion_force.AddForceContribution(cell_population);
+        //for (AbstractMesh<2,2>::NodeIterator node_iter = mesh.GetNodeIteratorBegin();
+        //        node_iter != mesh.GetNodeIteratorEnd();
+        //        ++node_iter)
+        //{
+        //    node_iter->ClearAppliedForce();
+        //}
+        //repulsion_force.AddForceContribution(cell_population);
 
-        /* 
-         * Flame computation 
-         */
-        flamegpu::ModelDescription model("TestSimpleForceCalculation");
-        
-        // Define an agent
-        flamegpu::AgentDescription cell_agent = model.newAgent("cell"); 
-        cell_agent.newVariable<float>("x");
-        cell_agent.newVariable<float>("y");
-        cell_agent.newVariable<float>("radius");
-        cell_agent.newVariable<float>("x_force");
-        cell_agent.newVariable<float>("y_force");
-        
-        // Define the location message
-        flamegpu::MessageBruteForce::Description location_message = model.newMessage<flamegpu::MessageBruteForce>("location_message");
-        location_message.newVariable<float>("x");
-        location_message.newVariable<float>("y");
-        location_message.newVariable<float>("radius");
+        ///* 
+        // * Flame computation 
+        // */
+        //flamegpu::ModelDescription model("TestSimpleForceCalculation");
+        //
+        //// Define an agent
+        //flamegpu::AgentDescription cell_agent = model.newAgent("cell"); 
+        //cell_agent.newVariable<float>("x");
+        //cell_agent.newVariable<float>("y");
+        //cell_agent.newVariable<float>("radius");
+        //cell_agent.newVariable<float>("x_force");
+        //cell_agent.newVariable<float>("y_force");
+        //
+        //// Define the location message
+        //flamegpu::MessageBruteForce::Description location_message = model.newMessage<flamegpu::MessageBruteForce>("location_message");
+        //location_message.newVariable<float>("x");
+        //location_message.newVariable<float>("y");
+        //location_message.newVariable<float>("radius");
 
-        // Agent functions
-        flamegpu::AgentFunctionDescription output_location_desc = cell_agent.newFunction("output_location", test_output_location);
-        output_location_desc.setMessageOutput("location_message");
-        
-        flamegpu::AgentFunctionDescription compute_force_desc = cell_agent.newFunction("compute_force_meineke_spring", test_compute_force_meineke_spring);
-        compute_force_desc.setMessageInput("location_message");
+        //// Agent functions
+        //flamegpu::AgentFunctionDescription output_location_desc = cell_agent.newFunction("test_output_location", test_output_location);
+        //output_location_desc.setMessageOutput("location_message");
+        //
+        //flamegpu::AgentFunctionDescription compute_force_desc = cell_agent.newFunction("test_compute_force_meineke_spring", test_compute_force_meineke_spring);
+        //compute_force_desc.setMessageInput("location_message");
 
-        compute_force_desc.dependsOn(output_location_desc);
-        
-        // Set execution root
-        model.addExecutionRoot(output_location_desc);
-        
-        model.addInitFunction(test_simple_force_create_agents);
-        
-        model.generateLayers();
+        //compute_force_desc.dependsOn(output_location_desc);
+        //
+        //// Set execution root
+        //model.addExecutionRoot(output_location_desc);
+        //
+        //model.addInitFunction(test_simple_force_create_agents);
+        //
+        //model.generateLayers();
 
-        flamegpu::CUDASimulation cuda_model(model);
-        cuda_model.SimulationConfig().steps = 1;
-        cuda_model.simulate();
-        
-        // Get results
-        flamegpu::AgentVector out_pop(cell_agent);
-        cuda_model.getPopulationData(out_pop);
-        
-        /*
-         * Compare forces
-         */
-        
-        for (int i = 0; i < 3; i++) {
-            TS_ASSERT_DELTA(cell_population.GetNode(i)->rGetAppliedForce()[0], out_pop[i].getVariable<float>("x_force"), 1e-4);
-            TS_ASSERT_DELTA(cell_population.GetNode(i)->rGetAppliedForce()[1], out_pop[i].getVariable<float>("y_force"), 1e-4);
-        }
+        //flamegpu::CUDASimulation cuda_model(model);
+        //cuda_model.SimulationConfig().steps = 1;
+        //cuda_model.simulate();
+        //
+        //// Get results
+        //flamegpu::AgentVector out_pop(cell_agent);
+        //cuda_model.getPopulationData(out_pop);
+        //
+        ///*
+        // * Compare forces
+        // */
+        //
+        //for (int i = 0; i < 3; i++) {
+        //    TS_ASSERT_DELTA(cell_population.GetNode(i)->rGetAppliedForce()[0], out_pop[i].getVariable<float>("x_force"), 1e-4);
+        //    TS_ASSERT_DELTA(cell_population.GetNode(i)->rGetAppliedForce()[1], out_pop[i].getVariable<float>("y_force"), 1e-4);
+        //}
     }
     
     void TestGPUModifier() {
@@ -307,6 +307,54 @@ public:
 
         MAKE_PTR(GPUModifier<2>, gpuModifier);
         simulator.AddSimulationModifier(gpuModifier);
+
+        // Run simulation
+        simulator.Solve();
+
+        // Avoid memory leak
+        for (unsigned i=0; i<nodes.size(); i++)
+        {
+            delete nodes[i];
+        }
+    }
+
+    void TestCPUPathway() {
+        
+        double size_of_box = 8.0;
+        unsigned cells_across = 12;
+        double scaling = size_of_box/(double(cells_across-1));
+
+        // Create a simple 3D NodeBasedCellPopulation consisting of cells evenly spaced in a regular grid
+        std::vector<Node<2>*> nodes;
+        unsigned index = 0;
+        for (unsigned i=0; i<cells_across; i++)
+        {
+            for (unsigned j=0; j<cells_across; j++)
+            {
+                nodes.push_back(new Node<2>(index, false,  (double) i * scaling , (double) j * scaling));
+                index++;
+            }
+        }
+
+        NodesOnlyMesh<2> mesh;
+        mesh.ConstructNodesWithoutMesh(nodes, 1.5);
+
+        std::vector<CellPtr> cells;
+        MAKE_PTR(TransitCellProliferativeType, p_transit_type);
+        CellsGenerator<UniformCellCycleModel, 2> cells_generator;
+        cells_generator.GenerateBasicRandom(cells, mesh.GetNumNodes(), p_transit_type);
+
+        NodeBasedCellPopulation<2> node_based_cell_population(mesh, cells);
+        //node_based_cell_population.AddCellPopulationCountWriter<CellProliferativeTypesCountWriter>();
+
+        // Set up cell-based simulation
+        OffLatticeSimulation<2> simulator(node_based_cell_population);
+        simulator.SetOutputDirectory("GPUNodeBased");
+        simulator.SetSamplingTimestepMultiple(12);
+        simulator.SetEndTime(1.0);
+
+        MAKE_PTR(GeneralisedLinearSpringForce<2>, springForce);
+        simulator.AddForce(springForce);
 
         // Run simulation
         simulator.Solve();

--- a/cmake/Modules/ChasteMacros.cmake
+++ b/cmake/Modules/ChasteMacros.cmake
@@ -420,11 +420,20 @@ endmacro(Chaste_DO_PROJECT)
 # process the apps folder
 ##########################################################
 macro(Chaste_DO_APPS_COMMON component)
+    message("Configuring apps folder for ${component}")
     include_directories(SYSTEM "${Chaste_THIRD_PARTY_INCLUDE_DIRS}" "${Chaste_INCLUDE_DIRS}")
     include_directories(SYSTEM "${CXXTEST_INCLUDES}")
-    file(GLOB_RECURSE Chaste_${component}_APPS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} src/*.cpp)
+    message("Directory is ${CMAKE_CURRENT_SOURCE_DIR}")
+    file(GLOB_RECURSE Chaste_${component}_APPS 
+         RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+         ${CMAKE_CURRENT_SOURCE_DIR}/src *.cpp *.cu *.cuh)
     foreach(app ${Chaste_${component}_APPS})
-        string(REGEX REPLACE ".*/([a-zA-Z0-9_]+)[.]cpp" "\\1" appName "${app}")
+        message("Now processing app ${app}")
+        string(REPLACE "src/" "" appNameNoSrc "${app}")
+        string(REGEX REPLACE ".*/([a-zA-Z0-9_-]+)[.]cpp" "\\1" appName "${appNameNoSrc}")
+        string(REGEX REPLACE ".*/([a-zA-Z0-9_-]+)[.]cu" "\\1" appName "${appNameNoSrc}")
+        string(REGEX REPLACE ".*/([a-zA-Z0-9_-]+)[.]cuh" "\\1" appName "${appNameNoSrc}")
+        message("appName is now ${appName}")
         if (${component} MATCHES "project_")
             message("Configuring ${appName} app for ${component}")
             set(component_library chaste_${component})
@@ -493,10 +502,10 @@ endmacro(Chaste_DO_APPS_COMMON)
 # these wrap chaste_do_apps_common for both the main
 # Chaste apps directory and external project apps dirs
 ##########################################################
-macro(Chaste_DO_APPS_PROJECT projectName)
+macro(chaste_do_apps_project projectName)
     message("Configuring apps for project ${projectName}")
     Chaste_DO_APPS_COMMON(project_${projectName})
-endmacro(Chaste_DO_APPS_PROJECT)
+endmacro(chaste_do_apps_project)
 
 macro(Chaste_DO_APPS_MAIN)
     message("Configuring main Chaste apps")

--- a/cmake/flamegpu2.cmake
+++ b/cmake/flamegpu2.cmake
@@ -1,0 +1,75 @@
+include(FetchContent)
+cmake_policy(SET CMP0079 NEW)
+
+# If overridden by the user, attempt to use that
+if (FLAMEGPU_ROOT)
+    # Look for the main flamegpu.h header to get the abs path, but only look relative to the hints/paths, no cmake defaults. Do not cache the result.
+    set(FLAMEGPU_INCLUDE_HEADER_FILE include/flamegpu/flamegpu.h)
+    find_path(FLAMEGPU_ROOT_ABS
+        NAMES
+            ${FLAMEGPU_INCLUDE_HEADER_FILE}
+        HINTS
+            ${FLAMEGPU_ROOT}
+        PATHS
+            ${FLAMEGPU_ROOT}
+        NO_DEFAULT_PATH
+        NO_CACHE
+    )
+    # If found, use the local flamegpu, otherwise error.
+    if(FLAMEGPU_ROOT_ABS)
+        # If the correct flamegpu root was found, output a successful status message
+        message(STATUS "Found FLAMEGPU_ROOT: ${FLAMEGPU_ROOT_ABS} (${FLAMEGPU_ROOT})")
+        # update the value to the non abs version, in local and parent scope.
+        set(FLAMEGPU_ROOT "${FLAMEGPU_ROOT_ABS}")
+        # And set up the flamegpu build 
+        add_subdirectory(${FLAMEGPU_ROOT_ABS} ${CMAKE_CURRENT_BINARY_DIR}/_deps/flamegpu2-build)
+    else()
+        # Send a fatal error if the flamegpu root passed is invalid.
+        message(FATAL_ERROR "Invalid FLAMEGPU_ROOT '${FLAMEGPU_ROOT}'.\nFLAMEGPU_ROOT must be a valid directory containing '${FLAMEGPU_INCLUDE_HEADER_FILE}'")
+    endif()
+else()
+    # If a FLAMEGPU_VERSION has not been defined, set it to the default option.
+    if(NOT DEFINED FLAMEGPU_VERSION OR FLAMEGPU_VERSION STREQUAL "")
+        set(FLAMEGPU_VERSION "master" CACHE STRING "Git branch or tag to use")
+    endif()
+    
+    # If the FLAME GPU version is a hash not a branch or tag, 
+    if(NOT DEFINED FLAMEGPU_VERSION_ALLOW_HASH OR FLAMEGPU_VERSION_ALLOW_HASH STREQUAL "")
+        set(FLAMEGPU_VERSION_ALLOW_HASH "OFF" CACHE BOOL "Boolean to enable use of a git hash in FLAMEGPU_VERSION. This will slow down CMake configuration.")
+    endif()
+
+    # Allow users to switch to forks with relative ease.
+    if(NOT DEFINED FLAMEGPU_REPOSITORY OR FLAMEGPU_REPOSITORY STREQUAL "")
+        set(FLAMEGPU_REPOSITORY "https://github.com/FLAMEGPU/FLAMEGPU2.git" CACHE STRING "Remote Git Repository for FLAME GPU 2+")
+    endif()
+    
+    # CMake does not support simple negation, so map to a differnt non cache variable to invert to the correct truthyness for GIT_SHALLOW
+    set(USE_GIT_SHALLOW "ON")
+    if(FLAMEGPU_VERSION_ALLOW_HASH)
+        set(USE_GIT_SHALLOW OFF)
+    endif()
+    # Declare the fetch content target usign the above optional variables
+    FetchContent_Declare(
+        flamegpu2
+        GIT_REPOSITORY ${FLAMEGPU_REPOSITORY}
+        GIT_TAG        ${FLAMEGPU_VERSION}
+        GIT_SHALLOW    ${USE_GIT_SHALLOW}
+        GIT_PROGRESS   ON
+        # UPDATE_DISCONNECTED   ON
+    )
+    unset(USE_GIT_SHALLOW)
+
+    # Fetch and populate the content if required.
+    FetchContent_GetProperties(flamegpu2)
+    if(NOT flamegpu2_POPULATED)
+        FetchContent_Populate(flamegpu2)   
+        mark_as_advanced(FORCE BUILD_TESTS)
+        # Add the subdirectory
+        add_subdirectory(${flamegpu2_SOURCE_DIR} ${flamegpu2_BINARY_DIR})
+        # Add flamegpu2' expected location to the prefix path.
+        set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${flamegpu2_SOURCE_DIR}/cmake")
+    endif()
+
+    message(STATUS "Found FLAMEGPU2 ${flamegpu2_SOURCE_DIR}")
+    set(FLAMEGPU_ROOT ${flamegpu2_SOURCE_DIR})
+endif()


### PR DESCRIPTION
This PR relates to #265 and adds GPU support for elements of chaste simulations.

# Meeting minutes 29/10/2024
## Proof of concept
- Agreed that targeting force resolution & integration is a sensible next step
- Aim is to produce a minimal working example using FLAME GPU to perform force calculations
- On updating FLAME simulation data vs 'clean slate' each time step - better to restart the flame sim each step by clearing agent count and pulling all the data fresh from chaste. Clearing agent count will preserve the allocated memory and avoid allocation costs per timestep. Also leaves open future possibility of running multiple physics steps per biological step without having to use a submodel. The FLAME model can just run until some condition is met.
- Minimal model can be produced by embedding the FLAME simulation in a modifier. The modifier performs all the functionality that the force class and time stepper usually would. No force is added to the chaste sim via the conventional method, meaning the CPU will not perform any force calculations. 
- FLAME model definition can take place during the simulation modifier construction
- Use a test which does some simple force calculations using both chaste and flame to compare results & demonstrate equivalence
- Expand to perform full force calculations in the simulation then benchmark against CPU for different sizes of population

## Long term integration
- Write up options for this in report on GPU acceleration of Chaste
  - How to handle construction of GPU model?
  - How much should the user be involved vs automation?
  - Where should the FLAME model / CUDASimulation objects live?
  - How to handle data transfers?

# To Do
- [x] Create branch for GPU work
- [x] Modify chaste CMake to pull in FLAME GPU
- [x] Modify chaste CMake to build FLAME GPU
- [x] Add flamegpu target as dependency
- [x] Get chaste to build with nvcc  (cuda compiler)
- [x] Modify cmake to recognise .cu/.cuh files in the chaste build process
- [x] Create a new test file for GPU functionality, which includes flamegpu.h
- [x] Add a test which runs a minimal FLAME GPU simulation
- [x] Create a test which performs equivalent force calculations in chaste and with flame
- [x] Create a modifier which performs the force calculations
- [x] Disable the force calculations & integration in the CPU pathway
- [x] Benchmark
- [ ] Update testing infrastructure

 