### PR TITLE
Move to chaste/base image for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,13 +3,13 @@
 	"name": "Chaste",
 
 	// To start from an image with pre-built Chaste libraries from the develop branch, use the following line:
-	"image": "chaste/develop",
+	// "image": "chaste/develop",
 	// If you prefer to start with a container with the latest Chaste release pre-built, use the following line:
 	// "image": "chaste/release",
 	// Note: specific versions can be selected by adding one of the the tags listed on Docker Hub e.g.:
 	// "image": "chaste/release:2021.1",
 	// Otherwise, to start from a bare environment with no pre-built Chaste libraries, uncomment the following line:
-	// "image": "chaste/base",
+	"image": "chaste/base",
 
 	"mounts": [
 		{


### PR DESCRIPTION
When GitHub creates a new codespace, there is an intermediate (undocumented) provisioning step, with less space available than the resulting codespace machine.

As a result, using the larger pre-built image doesn't allow users to create a default Chaste codespace.

This PR changes the default to chaste/base which allows creation of codespaces.