### PR TITLE
Update conda build recipes

### DIFF
--- a/.github/workflows/pychaste-conda-tests.yml
+++ b/.github/workflows/pychaste-conda-tests.yml
@@ -53,6 +53,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           channels: conda-forge,pychaste
 
+      - name: Show environment packages
+        run: conda list
+
       - name: Configure PyChaste
         run: |
           cmake \

--- a/.github/workflows/pychaste-conda-tests.yml
+++ b/.github/workflows/pychaste-conda-tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/pychaste-conda-tests.yml
+++ b/.github/workflows/pychaste-conda-tests.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y castxml clang cmake xvfb
+          sudo apt-get install -y castxml clang cmake libx11-dev xvfb
 
       - name: Setup Miniconda Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/pychaste-conda-tests.yml
+++ b/.github/workflows/pychaste-conda-tests.yml
@@ -49,7 +49,7 @@ jobs:
           auto-update-conda: true
           use-mamba: true
           miniforge-version: latest
-          environment-file: pychaste/src/py/conda/environment.yml
+          environment-file: pychaste/src/py/conda/envs/env_python${{ matrix.python-version }}.yaml
           python-version: ${{ matrix.python-version }}
           channels: conda-forge,pychaste
 
@@ -58,10 +58,10 @@ jobs:
           cmake \
             -DChaste_ENABLE_PYCHASTE=ON \
             -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=ON \
             -DCMAKE_INSTALL_PREFIX="${CONDA_PREFIX}" \
             -DCMAKE_PREFIX_PATH="${CONDA_PREFIX}" \
             -DCMAKE_LIBRARY_PATH="${CONDA_PREFIX}/lib" \
-            -DBUILD_SHARED_LIBS=ON \
             -DBOOST_ROOT="${CONDA_PREFIX}" \
             -DHDF5_C_COMPILER_EXECUTABLE="${CONDA_PREFIX}/bin/h5pcc" \
             -DPETSC_DIR="${CONDA_PREFIX}" \

--- a/pychaste/dynamic/templates/PopulationWriterCustomTemplate.py
+++ b/pychaste/dynamic/templates/PopulationWriterCustomTemplate.py
@@ -40,28 +40,88 @@ class PopulationWriterCustomTemplate(cppwg.templates.custom.Custom):
 
     def get_class_cpp_def_code(self, class_name):
         """
-        Creates custom wrapper code for adding population and cell writers.
+        Custom wrapper code for adding writers to cell populations.
         """
-        population_writers = ["VoronoiDataWriter"]
 
-        cell_writers = ["CellLabelWriter"]
+        code = ""
 
-        population_writer_template = """\
-        .def("AddPopulationWriter{writer}", &{class_name}::AddPopulationWriter<{writer}>)
-"""
+        # Add cell writers
+        cell_writers = [
+            "CellAgesWriter",
+            "CellAncestorWriter",
+            "CellAppliedForceWriter",
+            "CellCycleModelProteinConcentrationsWriter",
+            "CellDataItemWriter",
+            "CellDeltaNotchWriter",
+            "CellIdWriter",
+            "CellLabelWriter",
+            "CellLocationIndexWriter",
+            "CellMutationStatesWriter",
+            "CellProliferativePhasesWriter",
+            "CellProliferativeTypesWriter",
+            "CellRadiusWriter",
+            "CellRosetteRankWriter",
+            "CellVolumesWriter",
+            "LegacyCellProliferativeTypesWriter",
+        ]
 
         cell_writer_template = """\
         .def("AddCellWriter{writer}", &{class_name}::AddCellWriter<{writer}>)
 """
 
-        code = ""
-
-        for writer in population_writers:
-            replacements = {"class_name": class_name, "writer": writer}
-            code += population_writer_template.format(**replacements)
-
         for writer in cell_writers:
             replacements = {"class_name": class_name, "writer": writer}
             code += cell_writer_template.format(**replacements)
+
+        # Add cell population count writers
+        cell_population_count_writers = [
+            "CellMutationStatesCountWriter",
+            "CellProliferativeTypesCountWriter",
+            "CellProliferativePhasesCountWriter",
+        ]
+
+        cell_population_count_writer_template = """\
+        .def("AddCellPopulationCountWriter{writer}", &{class_name}::AddCellPopulationCountWriter<{writer}>)
+"""
+        for writer in cell_population_count_writers:
+            replacements = {"class_name": class_name, "writer": writer}
+            code += cell_population_count_writer_template.format(**replacements)
+
+        # Add cell population event writers
+        cell_population_event_writers = [
+            "CellDivisionLocationsWriter",
+            "CellRemovalLocationsWriter",
+        ]
+
+        cell_population_event_writer_template = """\
+        .def("AddCellPopulationEventWriter{writer}", &{class_name}::AddCellPopulationEventWriter<{writer}>)
+"""
+        for writer in cell_population_event_writers:
+            replacements = {"class_name": class_name, "writer": writer}
+            code += cell_population_event_writer_template.format(**replacements)
+
+        # Add population writers
+        population_writers = [
+            "BoundaryNodeWriter",
+            "CellPopulationAdjacencyMatrixWriter",
+            "CellPopulationAreaWriter",
+            "CellPopulationElementWriter",
+            "HeterotypicBoundaryLengthWriter",
+            "NodeLocationWriter",
+            "NodeVelocityWriter",
+            "RadialCellDataDistributionWriter",
+            "VertexIntersectionSwapLocationsWriter",
+            "VertexT1SwapLocationsWriter",
+            "VertexT2SwapLocationsWriter",
+            "VertexT3SwapLocationsWriter",
+            "VoronoiDataWriter",
+        ]
+
+        population_writer_template = """\
+        .def("AddPopulationWriter{writer}", &{class_name}::AddPopulationWriter<{writer}>)
+"""
+        for writer in population_writers:
+            replacements = {"class_name": class_name, "writer": writer}
+            code += population_writer_template.format(**replacements)
 
         return code

--- a/pychaste/src/py/conda/README.md
+++ b/pychaste/src/py/conda/README.md
@@ -58,7 +58,7 @@ Login and upload the package:
 
 ```bash
 anaconda login
-anaconda upload -u 'pychaste' ./build_artifacts/<chaste>-<version>-<hash>.tar.bz2
+anaconda upload -u 'pychaste' ./build_artifacts/linux64/<chaste>-<version>-<hash>.tar.bz2
 ```
 
 ## Directory structure

--- a/pychaste/src/py/conda/README.md
+++ b/pychaste/src/py/conda/README.md
@@ -37,8 +37,8 @@ There should be a `<chaste>-<version>-<hash>.tar.bz2` file in the directory.
 Test the newly built package by installing it in a conda environment:
 
 ```bash
-conda create -n py38-env python=3.8
-conda activate py38-env
+conda create -n pychaste-env python=3.10
+conda activate pychaste-env
 conda install -c ./build_artifacts <chaste>-<version>-<hash>.tar.bz2
 ```
 

--- a/pychaste/src/py/conda/build-package.sh
+++ b/pychaste/src/py/conda/build-package.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 # Example usage:
-#   ./build-package.sh --variant=linux_64_python3.8_cpython --branch=2024.1 --parallel=4
+#   ./build-package.sh --variant=linux_64_python3.10_cpython --branch=2024.1 --parallel=4
 #
 # Intended for use in a build container e.g.:
 #   docker run --rm -it quay.io/condaforge/linux-anvil-cos7-x86_64 /bin/bash

--- a/pychaste/src/py/conda/build-package.sh
+++ b/pychaste/src/py/conda/build-package.sh
@@ -95,6 +95,7 @@ conda list --show-channel-urls
 /usr/bin/sudo -n yum install -y libXt-devel mesa-libGLU-devel patch
 
 # Get source code
+# TODO: pre-generate wrappers outside the build container
 git clone --recursive --branch "${branch}" --depth 1 https://github.com/Chaste/Chaste.git /tmp/Chaste
 
 # Build conda package

--- a/pychaste/src/py/conda/build-package.sh
+++ b/pychaste/src/py/conda/build-package.sh
@@ -48,18 +48,21 @@ export PYTHONUNBUFFERED=1
 mkdir -p "${CONDA_BLD_PATH}"
 
 cat >~/.condarc <<CONDARC
+
 conda-build:
   root-dir: ${CONDA_BLD_PATH}
 pkgs_dirs:
   - ${CONDA_BLD_PATH}/pkg_cache
   - /opt/conda/pkgs
+solver: libmamba
+
 CONDARC
 
 # Install conda build tools
 mamba install --update-specs --yes --quiet --channel conda-forge \
-  conda-build pip boa liblief=0.11.5 conda-forge-ci-setup=3
+  conda-build pip boa liblief conda-forge-ci-setup
 mamba update --update-specs --yes --quiet --channel conda-forge \
-  conda-build pip boa liblief=0.11.5 conda-forge-ci-setup=3
+  conda-build pip boa liblief conda-forge-ci-setup
 
 # Configure conda channels
 conda config --add channels conda-forge

--- a/pychaste/src/py/conda/environment.yml
+++ b/pychaste/src/py/conda/environment.yml
@@ -2,19 +2,19 @@ channels:
   - conda-forge
   - pychaste
 dependencies:
-  - boost-cpp<1.84
-  - hdf5<14.0=*mpich*
+  - boost-cpp>=1.65,<1.84
+  - hdf5>=1.10,<1.14=*mpich*
   - jupyterlab
   - matplotlib
-  - metis
+  - metis>=4.0,<6.0
   - mpi4py
-  - mpich
+  - mpich>=4.0,<5.0
   - numpy
-  - parmetis
-  - petsc<3.20
-  - petsc4py
-  - sundials<7.0
-  - vtk<10.0
-  - xerces-c
+  - parmetis>=4.0,<6.0
+  - petsc>=3.12,<3.20
+  - petsc4py>=3.12,<3.20
+  - sundials>=3.0,<7.0
+  - vtk>=7.1,<9.4
+  - xerces-c>=3.0,<4.0
   - xsd
   - xvfbwrapper

--- a/pychaste/src/py/conda/envs/env_python3.10.yaml
+++ b/pychaste/src/py/conda/envs/env_python3.10.yaml
@@ -2,7 +2,7 @@ channels:
   - conda-forge
   - pychaste
 dependencies:
-  - boost-cpp>=1.65,<1.84
+  - boost-cpp>=1.70,<1.84
   - hdf5>=1.10,<1.14=*mpich*
   - jupyterlab
   - matplotlib

--- a/pychaste/src/py/conda/envs/env_python3.10.yaml
+++ b/pychaste/src/py/conda/envs/env_python3.10.yaml
@@ -15,7 +15,7 @@ dependencies:
   - petsc4py>=3.18,<3.19
   - python=3.10
   - sundials>=6.0,<7.0
-  - vtk>=9.1,<9.4
+  - vtk>=9.2,<9.3
   - xerces-c>=3.2,<4.0
   - xsd>=4.0,<4.1
   - xvfbwrapper

--- a/pychaste/src/py/conda/envs/env_python3.10.yaml
+++ b/pychaste/src/py/conda/envs/env_python3.10.yaml
@@ -2,19 +2,20 @@ channels:
   - conda-forge
   - pychaste
 dependencies:
-  - boost-cpp>=1.70,<1.84
-  - hdf5>=1.10,<1.14=*mpich*
+  - boost-cpp>=1.80,<1.84
+  - hdf5>=1.12,<1.13=*mpich*
   - jupyterlab
   - matplotlib
-  - metis>=4.0,<6.0
-  - mpi4py
+  - metis>=5.0,<6.0
+  - mpi4py>=3.0,<4.0
   - mpich>=4.0,<5.0
-  - numpy
-  - parmetis>=4.0,<6.0
-  - petsc>=3.12,<3.20
-  - petsc4py>=3.12,<3.20
-  - sundials>=3.0,<7.0
-  - vtk>=7.1,<9.4
-  - xerces-c>=3.0,<4.0
-  - xsd
+  - numpy>=1.26,<2.0
+  - parmetis>=4.0,<5.0
+  - petsc>=3.18,<3.19
+  - petsc4py>=3.18,<3.19
+  - python=3.10
+  - sundials>=6.0,<7.0
+  - vtk>=9.1,<9.4
+  - xerces-c>=3.2,<4.0
+  - xsd>=4.0,<4.1
   - xvfbwrapper

--- a/pychaste/src/py/conda/envs/env_python3.11.yaml
+++ b/pychaste/src/py/conda/envs/env_python3.11.yaml
@@ -1,0 +1,20 @@
+channels:
+  - conda-forge
+  - pychaste
+dependencies:
+  - boost-cpp>=1.70,<1.84
+  - hdf5>=1.10,<1.14=*mpich*
+  - jupyterlab
+  - matplotlib
+  - metis>=4.0,<6.0
+  - mpi4py
+  - mpich>=4.0,<5.0
+  - numpy
+  - parmetis>=4.0,<6.0
+  - petsc>=3.12,<3.20
+  - petsc4py>=3.12,<3.20
+  - sundials>=3.0,<7.0
+  - vtk>=7.1,<9.4
+  - xerces-c>=3.0,<4.0
+  - xsd
+  - xvfbwrapper

--- a/pychaste/src/py/conda/envs/env_python3.11.yaml
+++ b/pychaste/src/py/conda/envs/env_python3.11.yaml
@@ -2,19 +2,20 @@ channels:
   - conda-forge
   - pychaste
 dependencies:
-  - boost-cpp>=1.70,<1.84
-  - hdf5>=1.10,<1.14=*mpich*
+  - boost-cpp>=1.80,<1.84
+  - hdf5>=1.12,<1.13=*mpich*
   - jupyterlab
   - matplotlib
   - metis>=4.0,<6.0
-  - mpi4py
+  - mpi4py>=3.0,<4.0
   - mpich>=4.0,<5.0
-  - numpy
-  - parmetis>=4.0,<6.0
-  - petsc>=3.12,<3.20
-  - petsc4py>=3.12,<3.20
-  - sundials>=3.0,<7.0
-  - vtk>=7.1,<9.4
-  - xerces-c>=3.0,<4.0
-  - xsd
+  - numpy>=1.26,<2.0
+  - parmetis>=4.0,<5.0
+  - petsc>=3.18,<3.19
+  - petsc4py>=3.18,<3.19
+  - python=3.11
+  - sundials>=6.0,<7.0
+  - vtk>=9.1,<9.4
+  - xerces-c>=3.2,<4.0
+  - xsd>=4.0,<4.1
   - xvfbwrapper

--- a/pychaste/src/py/conda/envs/env_python3.11.yaml
+++ b/pychaste/src/py/conda/envs/env_python3.11.yaml
@@ -15,7 +15,7 @@ dependencies:
   - petsc4py>=3.18,<3.19
   - python=3.11
   - sundials>=6.0,<7.0
-  - vtk>=9.1,<9.4
+  - vtk>=9.2,<9.3
   - xerces-c>=3.2,<4.0
   - xsd>=4.0,<4.1
   - xvfbwrapper

--- a/pychaste/src/py/conda/envs/env_python3.12.yaml
+++ b/pychaste/src/py/conda/envs/env_python3.12.yaml
@@ -1,0 +1,20 @@
+channels:
+  - conda-forge
+  - pychaste
+dependencies:
+  - boost-cpp>=1.70,<1.84
+  - hdf5>=1.10,<1.14=*mpich*
+  - jupyterlab
+  - matplotlib
+  - metis>=4.0,<6.0
+  - mpi4py
+  - mpich>=4.0,<5.0
+  - numpy
+  - parmetis>=4.0,<6.0
+  - petsc>=3.12,<3.20
+  - petsc4py>=3.12,<3.20
+  - sundials>=3.0,<7.0
+  - vtk>=7.1,<9.4
+  - xerces-c>=3.0,<4.0
+  - xsd
+  - xvfbwrapper

--- a/pychaste/src/py/conda/envs/env_python3.12.yaml
+++ b/pychaste/src/py/conda/envs/env_python3.12.yaml
@@ -2,19 +2,20 @@ channels:
   - conda-forge
   - pychaste
 dependencies:
-  - boost-cpp>=1.70,<1.84
-  - hdf5>=1.10,<1.14=*mpich*
+  - boost-cpp>=1.80,<1.86
+  - hdf5>=1.14,<1.15=*mpich*
   - jupyterlab
   - matplotlib
-  - metis>=4.0,<6.0
-  - mpi4py
+  - metis>=5.0,<6.0
+  - mpi4py>=4.0,<5.0
   - mpich>=4.0,<5.0
-  - numpy
-  - parmetis>=4.0,<6.0
-  - petsc>=3.12,<3.20
-  - petsc4py>=3.12,<3.20
-  - sundials>=3.0,<7.0
-  - vtk>=7.1,<9.4
-  - xerces-c>=3.0,<4.0
-  - xsd
+  - numpy>=1.26,<2.0
+  - parmetis>=4.0,<5.0
+  - petsc>=3.20,<3.21
+  - petsc4py>=3.20,<3.21
+  - python=3.12
+  - sundials>=6.0,<7.0
+  - vtk>=9.1,<9.4
+  - xerces-c>=3.3,<4.0
+  - xsd>=4.0,<4.1
   - xvfbwrapper

--- a/pychaste/src/py/conda/envs/env_python3.12.yaml
+++ b/pychaste/src/py/conda/envs/env_python3.12.yaml
@@ -3,6 +3,7 @@ channels:
   - pychaste
 dependencies:
   - boost-cpp>=1.80,<1.86
+  - eigen>=3.0,<4.0
   - hdf5>=1.14,<1.15=*mpich*
   - jupyterlab
   - matplotlib
@@ -15,7 +16,7 @@ dependencies:
   - petsc4py>=3.20,<3.21
   - python=3.12
   - sundials>=6.0,<7.0
-  - vtk>=9.1,<9.4
+  - vtk>=9.3,<9.4
   - xerces-c>=3.3,<4.0
   - xsd>=4.0,<4.1
   - xvfbwrapper

--- a/pychaste/src/py/conda/envs/env_python3.13.yaml
+++ b/pychaste/src/py/conda/envs/env_python3.13.yaml
@@ -1,0 +1,20 @@
+channels:
+  - conda-forge
+  - pychaste
+dependencies:
+  - boost-cpp>=1.70,<1.84
+  - hdf5>=1.10,<1.14=*mpich*
+  - jupyterlab
+  - matplotlib
+  - metis>=4.0,<6.0
+  - mpi4py
+  - mpich>=4.0,<5.0
+  - numpy
+  - parmetis>=4.0,<6.0
+  - petsc>=3.12,<3.20
+  - petsc4py>=3.12,<3.20
+  - sundials>=3.0,<7.0
+  - vtk>=7.1,<9.4
+  - xerces-c>=3.0,<4.0
+  - xsd
+  - xvfbwrapper

--- a/pychaste/src/py/conda/envs/env_python3.13.yaml
+++ b/pychaste/src/py/conda/envs/env_python3.13.yaml
@@ -3,6 +3,7 @@ channels:
   - pychaste
 dependencies:
   - boost-cpp>=1.80,<1.86
+  - eigen>=3.0,<4.0
   - hdf5>=1.14,<1.15=*mpich*
   - jupyterlab
   - matplotlib
@@ -15,7 +16,7 @@ dependencies:
   - petsc4py>=3.22,<3.23
   - python=3.13
   - sundials>=6.0,<7.0
-  - vtk>=9.1,<9.4
+  - vtk>=9.3,<9.4
   - xerces-c>=3.3,<4.0
   - xsd>=4.0,<4.1
   - xvfbwrapper

--- a/pychaste/src/py/conda/envs/env_python3.13.yaml
+++ b/pychaste/src/py/conda/envs/env_python3.13.yaml
@@ -2,19 +2,20 @@ channels:
   - conda-forge
   - pychaste
 dependencies:
-  - boost-cpp>=1.70,<1.84
-  - hdf5>=1.10,<1.14=*mpich*
+  - boost-cpp>=1.80,<1.86
+  - hdf5>=1.14,<1.15=*mpich*
   - jupyterlab
   - matplotlib
-  - metis>=4.0,<6.0
-  - mpi4py
+  - metis>=5.0,<6.0
+  - mpi4py>=4.0,<5.0
   - mpich>=4.0,<5.0
-  - numpy
-  - parmetis>=4.0,<6.0
-  - petsc>=3.12,<3.20
-  - petsc4py>=3.12,<3.20
-  - sundials>=3.0,<7.0
-  - vtk>=7.1,<9.4
-  - xerces-c>=3.0,<4.0
-  - xsd
+  - numpy>=1.26,<3.0
+  - parmetis>=4.0,<5.0
+  - petsc>=3.22,<3.23
+  - petsc4py>=3.22,<3.23
+  - python=3.13
+  - sundials>=6.0,<7.0
+  - vtk>=9.1,<9.4
+  - xerces-c>=3.3,<4.0
+  - xsd>=4.0,<4.1
   - xvfbwrapper

--- a/pychaste/src/py/conda/envs/env_python3.9.yaml
+++ b/pychaste/src/py/conda/envs/env_python3.9.yaml
@@ -1,0 +1,20 @@
+channels:
+  - conda-forge
+  - pychaste
+dependencies:
+  - boost-cpp>=1.70,<1.84
+  - hdf5>=1.10,<1.14=*mpich*
+  - jupyterlab
+  - matplotlib
+  - metis>=4.0,<6.0
+  - mpi4py
+  - mpich>=4.0,<5.0
+  - numpy
+  - parmetis>=4.0,<6.0
+  - petsc>=3.12,<3.20
+  - petsc4py>=3.12,<3.20
+  - sundials>=3.0,<7.0
+  - vtk>=7.1,<9.4
+  - xerces-c>=3.0,<4.0
+  - xsd
+  - xvfbwrapper

--- a/pychaste/src/py/conda/envs/env_python3.9.yaml
+++ b/pychaste/src/py/conda/envs/env_python3.9.yaml
@@ -2,19 +2,20 @@ channels:
   - conda-forge
   - pychaste
 dependencies:
-  - boost-cpp>=1.70,<1.84
-  - hdf5>=1.10,<1.14=*mpich*
+  - boost-cpp>=1.80,<1.84
+  - hdf5>=1.12,<1.13=*mpich*
   - jupyterlab
   - matplotlib
-  - metis>=4.0,<6.0
-  - mpi4py
+  - metis>=5.0,<6.0
+  - mpi4py>=3.0,<4.0
   - mpich>=4.0,<5.0
-  - numpy
-  - parmetis>=4.0,<6.0
-  - petsc>=3.12,<3.20
-  - petsc4py>=3.12,<3.20
-  - sundials>=3.0,<7.0
-  - vtk>=7.1,<9.4
-  - xerces-c>=3.0,<4.0
-  - xsd
+  - numpy>=1.26,<2.0
+  - parmetis>=4.0,<5.0
+  - petsc>=3.18,<3.19
+  - petsc4py>=3.18,<3.19
+  - python=3.9
+  - sundials>=6.0,<7.0
+  - vtk>=9.1,<9.4
+  - xerces-c>=3.2,<4.0
+  - xsd>=4.0,<4.1
   - xvfbwrapper

--- a/pychaste/src/py/conda/envs/env_python3.9.yaml
+++ b/pychaste/src/py/conda/envs/env_python3.9.yaml
@@ -15,7 +15,7 @@ dependencies:
   - petsc4py>=3.18,<3.19
   - python=3.9
   - sundials>=6.0,<7.0
-  - vtk>=9.1,<9.4
+  - vtk>=9.2,<9.3
   - xerces-c>=3.2,<4.0
   - xsd>=4.0,<4.1
   - xvfbwrapper

--- a/pychaste/src/py/conda/recipe/build.sh
+++ b/pychaste/src/py/conda/recipe/build.sh
@@ -3,6 +3,9 @@
 mkdir -p ${PREFIX}/build
 cd ${PREFIX}/build || exit
 
+mkdir pychaste
+cp -r /tmp/wrappers pychaste/
+
 # Modify pip settings for internal Chaste Python env
 export PIP_NO_DEPENDENCIES="False"
 export PIP_NO_INDEX="False"
@@ -38,6 +41,7 @@ ${PYTHON} -m pip install -v pychaste/package --prefix="${PREFIX}"
 # Cleanup
 rm -rf \
   cell_based/CMakeFiles \
+  chaste_python3_venv \
   global/CMakeFiles \
   io/CMakeFiles \
   linalg/CMakeFiles \
@@ -46,4 +50,5 @@ rm -rf \
   pde/CMakeFiles \
   python \
   pychaste/CMakeFiles \
-  pychaste/package
+  pychaste/package \
+  pychaste/wrappers

--- a/pychaste/src/py/conda/recipe/build.sh
+++ b/pychaste/src/py/conda/recipe/build.sh
@@ -3,9 +3,6 @@
 mkdir -p ${PREFIX}/build
 cd ${PREFIX}/build || exit
 
-mkdir pychaste
-cp -r /tmp/wrappers pychaste/
-
 # Modify pip settings for internal Chaste Python env
 export PIP_NO_DEPENDENCIES="False"
 export PIP_NO_INDEX="False"

--- a/pychaste/src/py/conda/recipe/meta.yaml
+++ b/pychaste/src/py/conda/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "2024.1" %}
-{% set build = 0 %}
+{% set build = 1 %}
 {% set build_string = "py{}h{}_{}".format(CONDA_PY, PKG_HASH, build) %}
 
 package:
@@ -16,32 +16,72 @@ requirements:
   build:
     - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}
-    - cmake
-    - make
-    - python
-    - pip
-    - distro
-    - git
     - {{ cdt('libice-devel') }}
     - {{ cdt('libsm-devel') }}
     - {{ cdt('libx11-devel') }}
     - {{ cdt('libxext') }}
     - {{ cdt('libxt-devel') }}
-
-  host:
-    - boost-cpp<1.84
-    - hdf5<14.0=*mpich*
+    - boost-cpp
+    - cmake
+    - distro
+    - git
+    - hdf5
+    - hdf5 * mpi_mpich*
+    - libtiff
+    - make
     - matplotlib
     - metis
     - mpi4py
     - mpich
     - numpy
     - parmetis
-    - petsc<3.20
+    - petsc
+    - petsc4py
+    - pip
+    - python
+    - sundials
+    - vtk
+    - xerces-c
+    - xsd
+    - xvfbwrapper
+
+  host:
+    - boost-cpp
+    - hdf5
+    - hdf5 * mpi_mpich*
+    - libtiff
+    - matplotlib
+    - metis
+    - mpi4py
+    - mpich
+    - numpy
+    - parmetis
+    - petsc
+    - petsc4py
+    - pip
+    - python
+    - sundials
+    - vtk
+    - xerces-c
+    - xsd
+    - xvfbwrapper
+
+  run:
+    - boost-cpp
+    - hdf5
+    - hdf5 * mpi_mpich*
+    - libtiff
+    - matplotlib
+    - metis
+    - mpi4py
+    - mpich
+    - numpy
+    - parmetis
+    - petsc
     - petsc4py
     - python
-    - sundials<7.0
-    - vtk<10.0
+    - sundials
+    - vtk
     - xerces-c
     - xsd
     - xvfbwrapper

--- a/pychaste/src/py/conda/recipe/meta.yaml
+++ b/pychaste/src/py/conda/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2024.1" %}
+{% set version = "2024.2" %}
 {% set build = 1 %}
 {% set build_string = "py{}h{}_{}".format(CONDA_PY, PKG_HASH, build) %}
 

--- a/pychaste/src/py/conda/variants/linux_64_python3.10_cpython.yaml
+++ b/pychaste/src/py/conda/variants/linux_64_python3.10_cpython.yaml
@@ -16,7 +16,7 @@ fortran_compiler:
 fortran_compiler_version:
   - "11"
 boostcpp:
-  - ">=1.65,<1.84"
+  - ">=1.70,<1.84"
 hdf5:
   - ">=1.10,<1.14"
 metis:

--- a/pychaste/src/py/conda/variants/linux_64_python3.10_cpython.yaml
+++ b/pychaste/src/py/conda/variants/linux_64_python3.10_cpython.yaml
@@ -15,12 +15,45 @@ fortran_compiler:
   - gfortran
 fortran_compiler_version:
   - "11"
+boostcpp:
+  - ">=1.65,<1.84"
+hdf5:
+  - ">=1.10,<1.14"
+metis:
+  - ">=4.0,<6.0"
+mpich:
+  - ">=4.0,<5.0"
+parmetis:
+  - ">=4.0,<6.0"
+petsc:
+  - ">=3.12,<3.20"
+python:
+  - 3.10.* *_cpython
+sundials:
+  - ">=3.0,<7.0"
+vtk:
+  - ">=7.1,<9.4"
+xercesc:
+  - ">=3.0,<4.0"
 pin_run_as_build:
+  boost-cpp:
+    min_pin: x.x
+    max_pin: x.x
+  libtiff:
+    min_pin: x.x
+    max_pin: x.x
+  petsc:
+    min_pin: x.x
+    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x
-python:
-  - 3.10.* *_cpython
+  sundials:
+    min_pin: x.x
+    max_pin: x.x
+  vtk:
+    min_pin: x.x
+    max_pin: x.x
 target_platform:
   - linux-64
 zip_keys:

--- a/pychaste/src/py/conda/variants/linux_64_python3.10_cpython.yaml
+++ b/pychaste/src/py/conda/variants/linux_64_python3.10_cpython.yaml
@@ -27,6 +27,8 @@ parmetis:
   - ">=4.0,<6.0"
 petsc:
   - ">=3.12,<3.20"
+petsc4py:
+  - ">=3.12,<3.20"
 python:
   - 3.10.* *_cpython
 sundials:
@@ -43,6 +45,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
   petsc:
+    min_pin: x.x
+    max_pin: x.x
+  petsc4py:
     min_pin: x.x
     max_pin: x.x
   python:

--- a/pychaste/src/py/conda/variants/linux_64_python3.11_cpython.yaml
+++ b/pychaste/src/py/conda/variants/linux_64_python3.11_cpython.yaml
@@ -16,7 +16,7 @@ fortran_compiler:
 fortran_compiler_version:
   - "11"
 boostcpp:
-  - ">=1.65,<1.84"
+  - ">=1.70,<1.84"
 hdf5:
   - ">=1.10,<1.14"
 metis:

--- a/pychaste/src/py/conda/variants/linux_64_python3.11_cpython.yaml
+++ b/pychaste/src/py/conda/variants/linux_64_python3.11_cpython.yaml
@@ -15,12 +15,45 @@ fortran_compiler:
   - gfortran
 fortran_compiler_version:
   - "11"
+boostcpp:
+  - ">=1.65,<1.84"
+hdf5:
+  - ">=1.10,<1.14"
+metis:
+  - ">=4.0,<6.0"
+mpich:
+  - ">=4.0,<5.0"
+parmetis:
+  - ">=4.0,<6.0"
+petsc:
+  - ">=3.12,<3.20"
+python:
+  - 3.11.* *_cpython
+sundials:
+  - ">=3.0,<7.0"
+vtk:
+  - ">=7.1,<9.4"
+xercesc:
+  - ">=3.0,<4.0"
 pin_run_as_build:
+  boost-cpp:
+    min_pin: x.x
+    max_pin: x.x
+  libtiff:
+    min_pin: x.x
+    max_pin: x.x
+  petsc:
+    min_pin: x.x
+    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x
-python:
-  - 3.11.* *_cpython
+  sundials:
+    min_pin: x.x
+    max_pin: x.x
+  vtk:
+    min_pin: x.x
+    max_pin: x.x
 target_platform:
   - linux-64
 zip_keys:

--- a/pychaste/src/py/conda/variants/linux_64_python3.11_cpython.yaml
+++ b/pychaste/src/py/conda/variants/linux_64_python3.11_cpython.yaml
@@ -27,6 +27,8 @@ parmetis:
   - ">=4.0,<6.0"
 petsc:
   - ">=3.12,<3.20"
+petsc4py:
+  - ">=3.12,<3.20"
 python:
   - 3.11.* *_cpython
 sundials:
@@ -43,6 +45,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
   petsc:
+    min_pin: x.x
+    max_pin: x.x
+  petsc4py:
     min_pin: x.x
     max_pin: x.x
   python:

--- a/pychaste/src/py/conda/variants/linux_64_python3.12_cpython.yaml
+++ b/pychaste/src/py/conda/variants/linux_64_python3.12_cpython.yaml
@@ -27,6 +27,8 @@ parmetis:
   - ">=4.0,<6.0"
 petsc:
   - ">=3.12,<3.20"
+petsc4py:
+  - ">=3.12,<3.20"
 python:
   - 3.12.* *_cpython
 sundials:
@@ -43,6 +45,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
   petsc:
+    min_pin: x.x
+    max_pin: x.x
+  petsc4py:
     min_pin: x.x
     max_pin: x.x
   python:

--- a/pychaste/src/py/conda/variants/linux_64_python3.12_cpython.yaml
+++ b/pychaste/src/py/conda/variants/linux_64_python3.12_cpython.yaml
@@ -16,7 +16,7 @@ fortran_compiler:
 fortran_compiler_version:
   - "11"
 boostcpp:
-  - ">=1.65,<1.84"
+  - ">=1.70,<1.84"
 hdf5:
   - ">=1.10,<1.14"
 metis:

--- a/pychaste/src/py/conda/variants/linux_64_python3.12_cpython.yaml
+++ b/pychaste/src/py/conda/variants/linux_64_python3.12_cpython.yaml
@@ -15,12 +15,45 @@ fortran_compiler:
   - gfortran
 fortran_compiler_version:
   - "11"
+boostcpp:
+  - ">=1.65,<1.84"
+hdf5:
+  - ">=1.10,<1.14"
+metis:
+  - ">=4.0,<6.0"
+mpich:
+  - ">=4.0,<5.0"
+parmetis:
+  - ">=4.0,<6.0"
+petsc:
+  - ">=3.12,<3.20"
+python:
+  - 3.12.* *_cpython
+sundials:
+  - ">=3.0,<7.0"
+vtk:
+  - ">=7.1,<9.4"
+xercesc:
+  - ">=3.0,<4.0"
 pin_run_as_build:
+  boost-cpp:
+    min_pin: x.x
+    max_pin: x.x
+  libtiff:
+    min_pin: x.x
+    max_pin: x.x
+  petsc:
+    min_pin: x.x
+    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x
-python:
-  - 3.12.* *_cpython
+  sundials:
+    min_pin: x.x
+    max_pin: x.x
+  vtk:
+    min_pin: x.x
+    max_pin: x.x
 target_platform:
   - linux-64
 zip_keys:

--- a/pychaste/src/py/conda/variants/linux_64_python3.13_cpython.yaml
+++ b/pychaste/src/py/conda/variants/linux_64_python3.13_cpython.yaml
@@ -28,7 +28,7 @@ parmetis:
 petsc:
   - ">=3.12,<3.20"
 python:
-  - 3.8.* *_cpython
+  - 3.13.* *_cpython
 sundials:
   - ">=3.0,<7.0"
 vtk:

--- a/pychaste/src/py/conda/variants/linux_64_python3.13_cpython.yaml
+++ b/pychaste/src/py/conda/variants/linux_64_python3.13_cpython.yaml
@@ -16,7 +16,7 @@ fortran_compiler:
 fortran_compiler_version:
   - "11"
 boostcpp:
-  - ">=1.65,<1.84"
+  - ">=1.70,<1.84"
 hdf5:
   - ">=1.10,<1.14"
 metis:

--- a/pychaste/src/py/conda/variants/linux_64_python3.13_cpython.yaml
+++ b/pychaste/src/py/conda/variants/linux_64_python3.13_cpython.yaml
@@ -27,6 +27,8 @@ parmetis:
   - ">=4.0,<6.0"
 petsc:
   - ">=3.12,<3.20"
+petsc4py:
+  - ">=3.12,<3.20"
 python:
   - 3.13.* *_cpython
 sundials:
@@ -43,6 +45,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
   petsc:
+    min_pin: x.x
+    max_pin: x.x
+  petsc4py:
     min_pin: x.x
     max_pin: x.x
   python:

--- a/pychaste/src/py/conda/variants/linux_64_python3.8_cpython.yaml
+++ b/pychaste/src/py/conda/variants/linux_64_python3.8_cpython.yaml
@@ -15,12 +15,45 @@ fortran_compiler:
   - gfortran
 fortran_compiler_version:
   - "11"
+boostcpp:
+  - ">=1.65,<1.84"
+hdf5:
+  - ">=1.10,<1.14"
+metis:
+  - ">=4.0,<6.0"
+mpich:
+  - ">=4.0,<5.0"
+parmetis:
+  - ">=4.0,<6.0"
+petsc:
+  - ">=3.12,<3.20"
+python:
+  - 3.8.* *_cpython
+sundials:
+  - ">=3.0,<7.0"
+vtk:
+  - ">=7.1,<9.4"
+xercesc:
+  - ">=3.0,<4.0"
 pin_run_as_build:
+  boost-cpp:
+    min_pin: x.x
+    max_pin: x.x
+  libtiff:
+    min_pin: x.x
+    max_pin: x.x
+  petsc:
+    min_pin: x.x
+    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x
-python:
-  - 3.8.* *_cpython
+  sundials:
+    min_pin: x.x
+    max_pin: x.x
+  vtk:
+    min_pin: x.x
+    max_pin: x.x
 target_platform:
   - linux-64
 zip_keys:

--- a/pychaste/src/py/conda/variants/linux_64_python3.9_cpython.yaml
+++ b/pychaste/src/py/conda/variants/linux_64_python3.9_cpython.yaml
@@ -16,7 +16,7 @@ fortran_compiler:
 fortran_compiler_version:
   - "11"
 boostcpp:
-  - ">=1.65,<1.84"
+  - ">=1.70,<1.84"
 hdf5:
   - ">=1.10,<1.14"
 metis:

--- a/pychaste/src/py/conda/variants/linux_64_python3.9_cpython.yaml
+++ b/pychaste/src/py/conda/variants/linux_64_python3.9_cpython.yaml
@@ -27,6 +27,8 @@ parmetis:
   - ">=4.0,<6.0"
 petsc:
   - ">=3.12,<3.20"
+petsc4py:
+  - ">=3.12,<3.20"
 python:
   - 3.9.* *_cpython
 sundials:
@@ -43,6 +45,9 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
   petsc:
+    min_pin: x.x
+    max_pin: x.x
+  petsc4py:
     min_pin: x.x
     max_pin: x.x
   python:

--- a/pychaste/src/py/conda/variants/linux_64_python3.9_cpython.yaml
+++ b/pychaste/src/py/conda/variants/linux_64_python3.9_cpython.yaml
@@ -15,12 +15,45 @@ fortran_compiler:
   - gfortran
 fortran_compiler_version:
   - "11"
+boostcpp:
+  - ">=1.65,<1.84"
+hdf5:
+  - ">=1.10,<1.14"
+metis:
+  - ">=4.0,<6.0"
+mpich:
+  - ">=4.0,<5.0"
+parmetis:
+  - ">=4.0,<6.0"
+petsc:
+  - ">=3.12,<3.20"
+python:
+  - 3.9.* *_cpython
+sundials:
+  - ">=3.0,<7.0"
+vtk:
+  - ">=7.1,<9.4"
+xercesc:
+  - ">=3.0,<4.0"
 pin_run_as_build:
+  boost-cpp:
+    min_pin: x.x
+    max_pin: x.x
+  libtiff:
+    min_pin: x.x
+    max_pin: x.x
+  petsc:
+    min_pin: x.x
+    max_pin: x.x
   python:
     min_pin: x.x
     max_pin: x.x
-python:
-  - 3.9.* *_cpython
+  sundials:
+    min_pin: x.x
+    max_pin: x.x
+  vtk:
+    min_pin: x.x
+    max_pin: x.x
 target_platform:
   - linux-64
 zip_keys:

--- a/pychaste/src/py/setup.cfg
+++ b/pychaste/src/py/setup.cfg
@@ -43,17 +43,18 @@ classifiers =
     Topic :: Scientific/Engineering
     Operating System :: POSIX
     License :: OSI Approved :: BSD License
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
 
 [options]
 zip_safe = False
 include_package_data = True
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.9
 install_requires =
     matplotlib
     numpy


### PR DESCRIPTION
Closes #368

- [x] Pin specific dependency versions for each version of Python.
- [x] Drop support for Python 3.8 which is now at EOL.
- [x] Add support for Python 3.13.
- [x] Test on:
  - [x] Python 3.9
  - [x]  Python 3.10
  - [x]  Python 3.11
  - [x]  Python 3.12
  - [x]  Python 3.13
- [x] Update custom population wrapper template for adding writers to cell populations