### PR TITLE
400 Refactor Cell Populations wrt AbstractTwoBodyInteractionForce

### DIFF
--- a/cell_based/src/population/AbstractCentreBasedCellPopulation.hpp
+++ b/cell_based/src/population/AbstractCentreBasedCellPopulation.hpp
@@ -284,16 +284,6 @@ public:
     virtual bool IsParticle(unsigned index);
 
     /**
-     * Method to return the connected nodes in  a centre based simulation.
-     *
-     * As this method is pure virtual, it must be overridden
-     * in subclasses.
-     *
-     * @return Node pairs for force calculation.
-     */
-    virtual std::vector< std::pair<Node<SPACE_DIM>*, Node<SPACE_DIM>* > >& rGetNodePairs()=0;
-
-    /**
      * @return mMeinekeDivisionSeparation
      */
     double GetMeinekeDivisionSeparation();

--- a/cell_based/src/population/AbstractOffLatticeCellPopulation.cpp
+++ b/cell_based/src/population/AbstractOffLatticeCellPopulation.cpp
@@ -100,6 +100,18 @@ double AbstractOffLatticeCellPopulation<ELEMENT_DIM, SPACE_DIM>::GetAbsoluteMove
 }
 
 template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
+const std::vector<std::pair<Node<SPACE_DIM>*, Node<SPACE_DIM>*> >& AbstractOffLatticeCellPopulation<ELEMENT_DIM, SPACE_DIM>::rGetNodePairs() const
+{
+    EXCEPTION("This method must be overridden in any derived cell population using this functionality.");
+}
+
+template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
+std::vector<std::pair<Node<SPACE_DIM>*, Node<SPACE_DIM>*> >& AbstractOffLatticeCellPopulation<ELEMENT_DIM, SPACE_DIM>::rGetModifiableNodePairs()
+{
+    return mNodePairs;
+}
+
+template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
 void AbstractOffLatticeCellPopulation<ELEMENT_DIM, SPACE_DIM>::OutputCellPopulationParameters(out_stream& rParamsFile)
 {
     *rParamsFile << "\t\t<DampingConstantNormal>" << mDampingConstantNormal << "</DampingConstantNormal>\n";

--- a/cell_based/src/population/AbstractOffLatticeCellPopulation.cpp
+++ b/cell_based/src/population/AbstractOffLatticeCellPopulation.cpp
@@ -102,7 +102,7 @@ double AbstractOffLatticeCellPopulation<ELEMENT_DIM, SPACE_DIM>::GetAbsoluteMove
 template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
 const std::vector<std::pair<Node<SPACE_DIM>*, Node<SPACE_DIM>*> >& AbstractOffLatticeCellPopulation<ELEMENT_DIM, SPACE_DIM>::rGetNodePairs() const
 {
-    EXCEPTION("This method must be overridden in any derived cell population using this functionality.");
+    return mNodePairs;
 }
 
 template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>

--- a/cell_based/src/population/AbstractOffLatticeCellPopulation.hpp
+++ b/cell_based/src/population/AbstractOffLatticeCellPopulation.hpp
@@ -98,7 +98,7 @@ protected:
      * Some derived populations (e.g. VertexBased) do not use this, but others (e.g.
      * NodeBased) need to provide pairs of nodes for force calculations.
      */
-    mutable std::vector<std::pair<Node<SPACE_DIM>*, Node<SPACE_DIM>*> > mNodePairs = {};
+    std::vector<std::pair<Node<SPACE_DIM>*, Node<SPACE_DIM>*> > mNodePairs = {};
 
     /**
      * Constructor that just takes in a mesh.

--- a/cell_based/src/population/AbstractOffLatticeCellPopulation.hpp
+++ b/cell_based/src/population/AbstractOffLatticeCellPopulation.hpp
@@ -220,20 +220,20 @@ public:
     /**
      * Method to return the connected nodes in an off-lattice population.
      *
-     * This method throws an exception in the abstract class, warning the user that
-     * it must be overridden in any derived cell population for which it has meaning.
+     * Note that the derived populations are responsible for updating this vector. If
+     * you call this method on a population that doesn't use mNodePairs, you will just
+     * receive a reference to an empty vector.
      *
      * @return A vector of pairs of nodes that may interact mechanically.
      */
     [[nodiscard]] virtual const std::vector<std::pair<Node<SPACE_DIM>*, Node<SPACE_DIM>*> >& rGetNodePairs() const;
 
     /**
-     * Return modifiable mNodePairs vector, with no additional computation.
+     * Return modifiable mNodePairs vector.
      *
-     * This will not recalculate node pairs as may happen, for instance, in
-     * MeshBasedCellPopulation::rGetNodePairs. This method should only be used if you
-     * need to modify the underlying vector itself. To simply iterate over pairs of
-     * nodes, call the const rGetNodePairs method instead.
+     * This method should only be used if you need to modify the underlying vector
+     * itself. To simply iterate over pairs of nodes, call the const rGetNodePairs
+     * method instead.
      *
      * @return A modifiable reference to mNodePairs.
      */

--- a/cell_based/src/population/AbstractOffLatticeCellPopulation.hpp
+++ b/cell_based/src/population/AbstractOffLatticeCellPopulation.hpp
@@ -93,6 +93,14 @@ protected:
     double mAbsoluteMovementThreshold;
 
     /**
+     * Node pairs that may interact, for force calculations.
+     *
+     * Some derived populations (e.g. VertexBased) do not use this, but others (e.g.
+     * NodeBased) need to provide pairs of nodes for force calculations.
+     */
+    mutable std::vector<std::pair<Node<SPACE_DIM>*, Node<SPACE_DIM>*> > mNodePairs = {};
+
+    /**
      * Constructor that just takes in a mesh.
      *
      * @param rMesh the mesh for the cell population.
@@ -208,6 +216,28 @@ public:
      * @return mDampingConstantMutant
      */
     double GetDampingConstantMutant();
+
+    /**
+     * Method to return the connected nodes in an off-lattice population.
+     *
+     * This method throws an exception in the abstract class, warning the user that
+     * it must be overridden in any derived cell population for which it has meaning.
+     *
+     * @return A vector of pairs of nodes that may interact mechanically.
+     */
+    [[nodiscard]] virtual const std::vector<std::pair<Node<SPACE_DIM>*, Node<SPACE_DIM>*> >& rGetNodePairs() const;
+
+    /**
+     * Return modifiable mNodePairs vector, with no additional computation.
+     *
+     * This will not recalculate node pairs as may happen, for instance, in
+     * MeshBasedCellPopulation::rGetNodePairs. This method should only be used if you
+     * need to modify the underlying vector itself. To simply iterate over pairs of
+     * nodes, call the const rGetNodePairs method instead.
+     *
+     * @return A modifiable reference to mNodePairs.
+     */
+    [[nodiscard]] virtual std::vector<std::pair<Node<SPACE_DIM>*, Node<SPACE_DIM>*> >& rGetModifiableNodePairs();
 
     /**
      * Overridden OutputCellPopulationParameters() method.

--- a/cell_based/src/population/AbstractOffLatticeCellPopulation.hpp
+++ b/cell_based/src/population/AbstractOffLatticeCellPopulation.hpp
@@ -69,7 +69,6 @@ private:
         archive & mDampingConstantNormal;
         archive & mDampingConstantMutant;
         archive & mAbsoluteMovementThreshold;
-        archive & mNodePairs;
     }
 
 protected:

--- a/cell_based/src/population/AbstractOffLatticeCellPopulation.hpp
+++ b/cell_based/src/population/AbstractOffLatticeCellPopulation.hpp
@@ -69,6 +69,7 @@ private:
         archive & mDampingConstantNormal;
         archive & mDampingConstantMutant;
         archive & mAbsoluteMovementThreshold;
+        archive & mNodePairs;
     }
 
 protected:

--- a/cell_based/src/population/MeshBasedCellPopulation.cpp
+++ b/cell_based/src/population/MeshBasedCellPopulation.cpp
@@ -75,6 +75,8 @@ MeshBasedCellPopulation<ELEMENT_DIM, SPACE_DIM>::MeshBasedCellPopulation(Mutable
         Validate();
     }
 
+    UpdateNodePairs();
+
     // Initialise the applied force at each node to zero
     for (typename AbstractMesh<ELEMENT_DIM, SPACE_DIM>::NodeIterator node_iter = this->rGetMesh().GetNodeIteratorBegin();
          node_iter != this->rGetMesh().GetNodeIteratorEnd();
@@ -91,6 +93,7 @@ MeshBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>::MeshBasedCellPopulation(MutableM
     mpMutableMesh = static_cast<MutableMesh<ELEMENT_DIM,SPACE_DIM>* >(&(this->mrMesh));
     mpVoronoiTessellation = nullptr;
     mDeleteMesh = true;
+    UpdateNodePairs();
 }
 
 template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
@@ -286,6 +289,16 @@ unsigned MeshBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>::RemoveDeadCells()
 }
 
 template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
+void MeshBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>::UpdateNodePairs()
+{
+    this->mNodePairs.clear();
+    for (SpringIterator spring_it = SpringsBegin(); spring_it != SpringsEnd(); ++spring_it)
+    {
+        this->mNodePairs.emplace_back(spring_it.GetNodeA(), spring_it.GetNodeB());
+    }
+}
+
+template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
 void MeshBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>::Update(bool hasHadBirthsOrDeaths)
 {
     ///\todo check if there is a more efficient way of keeping track of node velocity information (#2404)
@@ -435,11 +448,7 @@ void MeshBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>::Update(bool hasHadBirthsOrD
     }
 
     // Update node pairs. Note, this must happen after remeshing.
-    this->mNodePairs.clear();
-    for (SpringIterator spring_it = SpringsBegin(); spring_it != SpringsEnd(); ++spring_it)
-    {
-        this->mNodePairs.emplace_back(spring_it.GetNodeA(), spring_it.GetNodeB());
-    }
+    UpdateNodePairs();
 
     // Tessellate if needed
     TessellateIfNeeded();

--- a/cell_based/src/population/MeshBasedCellPopulation.cpp
+++ b/cell_based/src/population/MeshBasedCellPopulation.cpp
@@ -1176,16 +1176,6 @@ void MeshBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>::SetAreaBasedDampingConstant
     mAreaBasedDampingConstantParameter = areaBasedDampingConstantParameter;
 }
 
-// LCOV_EXCL_START
-template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
-std::vector< std::pair<Node<SPACE_DIM>*, Node<SPACE_DIM>* > >& MeshBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>::rGetNodePairs()
-{
-    //mNodePairs.Clear();
-    NEVER_REACHED;
-    return mNodePairs;
-}
-// LCOV_EXCL_STOP
-
 template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
 void MeshBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>::OutputCellPopulationParameters(out_stream& rParamsFile)
 {

--- a/cell_based/src/population/MeshBasedCellPopulation.cpp
+++ b/cell_based/src/population/MeshBasedCellPopulation.cpp
@@ -1021,7 +1021,7 @@ typename MeshBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>::SpringIterator& MeshBas
 
 template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
 MeshBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>::SpringIterator::SpringIterator(
-            const MeshBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>& rCellPopulation,
+            MeshBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>& rCellPopulation,
             typename MutableMesh<ELEMENT_DIM,SPACE_DIM>::EdgeIterator edgeIter)
     : mrCellPopulation(rCellPopulation),
       mEdgeIter(edgeIter)

--- a/cell_based/src/population/MeshBasedCellPopulation.cpp
+++ b/cell_based/src/population/MeshBasedCellPopulation.cpp
@@ -291,13 +291,6 @@ void MeshBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>::Update(bool hasHadBirthsOrD
     ///\todo check if there is a more efficient way of keeping track of node velocity information (#2404)
     bool output_node_velocities = (this-> template HasWriter<NodeVelocityWriter>());
 
-    // Update node pairs
-    this->mNodePairs.empty();
-    for (SpringIterator spring_it = SpringsBegin(); spring_it != SpringsEnd(); ++spring_it)
-    {
-        this->mNodePairs.emplace_back(spring_it.GetNodeA(), spring_it.GetNodeB());
-    }
-
     /**
      * If node radii are set, then we must keep a record of these, since they will be cleared during
      * the remeshing process. We then restore these attributes to the nodes after calling ReMesh().
@@ -439,6 +432,13 @@ void MeshBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>::Update(bool hasHadBirthsOrD
          ++spring_it)
     {
         this->mMarkedSprings.erase(**spring_it);
+    }
+
+    // Update node pairs. Note, this must happen after remeshing.
+    this->mNodePairs.clear();
+    for (SpringIterator spring_it = SpringsBegin(); spring_it != SpringsEnd(); ++spring_it)
+    {
+        this->mNodePairs.emplace_back(spring_it.GetNodeA(), spring_it.GetNodeB());
     }
 
     // Tessellate if needed

--- a/cell_based/src/population/MeshBasedCellPopulation.cpp
+++ b/cell_based/src/population/MeshBasedCellPopulation.cpp
@@ -291,6 +291,13 @@ void MeshBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>::Update(bool hasHadBirthsOrD
     ///\todo check if there is a more efficient way of keeping track of node velocity information (#2404)
     bool output_node_velocities = (this-> template HasWriter<NodeVelocityWriter>());
 
+    // Update node pairs
+    this->mNodePairs.empty();
+    for (SpringIterator spring_it = SpringsBegin(); spring_it != SpringsEnd(); ++spring_it)
+    {
+        this->mNodePairs.emplace_back(spring_it.GetNodeA(), spring_it.GetNodeB());
+    }
+
     /**
      * If node radii are set, then we must keep a record of these, since they will be cleared during
      * the remeshing process. We then restore these attributes to the nodes after calling ReMesh().
@@ -1014,7 +1021,7 @@ typename MeshBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>::SpringIterator& MeshBas
 
 template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
 MeshBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>::SpringIterator::SpringIterator(
-            MeshBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>& rCellPopulation,
+            const MeshBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>& rCellPopulation,
             typename MutableMesh<ELEMENT_DIM,SPACE_DIM>::EdgeIterator edgeIter)
     : mrCellPopulation(rCellPopulation),
       mEdgeIter(edgeIter)

--- a/cell_based/src/population/MeshBasedCellPopulation.hpp
+++ b/cell_based/src/population/MeshBasedCellPopulation.hpp
@@ -100,6 +100,7 @@ private:
         archive & mOffsetNewBoundaryNodes;
         archive & mHasVariableRestLength;
         this->Validate();
+        this->UpdateNodePairs();
     }
 
 protected:

--- a/cell_based/src/population/MeshBasedCellPopulation.hpp
+++ b/cell_based/src/population/MeshBasedCellPopulation.hpp
@@ -158,6 +158,9 @@ protected:
     /** Whether springs have variable rest lengths. */
     bool mHasVariableRestLength;
 
+    /** Update mNodePairs using the SpringIterator. */
+    virtual void UpdateNodePairs();
+
     /**
      * Update mIsGhostNode if required by a remesh.
      *

--- a/cell_based/src/population/MeshBasedCellPopulation.hpp
+++ b/cell_based/src/population/MeshBasedCellPopulation.hpp
@@ -158,9 +158,6 @@ protected:
     /** Whether springs have variable rest lengths. */
     bool mHasVariableRestLength;
 
-    /** Node pairs for force calculations. */
-    std::vector< std::pair<Node<SPACE_DIM>*, Node<SPACE_DIM>* > > mNodePairs;
-
     /**
      * Update mIsGhostNode if required by a remesh.
      *
@@ -551,13 +548,6 @@ public:
      * @param areaBasedDampingConstantParameter the new value of mAreaBasedDampingConstantParameter
      */
     void SetAreaBasedDampingConstantParameter(double areaBasedDampingConstantParameter);
-
-    /**
-     * Overridden rGetNodePairs method which uses the Delaunay triangulatiuon
-     *
-     * @return Node pairs for force calculation.
-     */
-    std::vector< std::pair<Node<SPACE_DIM>*, Node<SPACE_DIM>* > >& rGetNodePairs();
 
     /**
      * Outputs CellPopulation parameters to file

--- a/cell_based/src/population/MeshBasedCellPopulationWithGhostNodes.cpp
+++ b/cell_based/src/population/MeshBasedCellPopulationWithGhostNodes.cpp
@@ -92,7 +92,6 @@ MeshBasedCellPopulationWithGhostNodes<DIM>::MeshBasedCellPopulationWithGhostNode
       mGhostGhostSpringStiffness(ghostGhostSpringStiffness),
       mGhostSpringRestLength(ghostSpringRestLength)
 {
-    this->UpdateNodePairs();
 }
 
 template<unsigned DIM>

--- a/cell_based/src/population/MeshBasedCellPopulationWithGhostNodes.cpp
+++ b/cell_based/src/population/MeshBasedCellPopulationWithGhostNodes.cpp
@@ -79,6 +79,7 @@ MeshBasedCellPopulationWithGhostNodes<DIM>::MeshBasedCellPopulationWithGhostNode
         this->mIsGhostNode = std::vector<bool>(this->GetNumNodes(), false);
         Validate();
     }
+    this->UpdateNodePairs();
 }
 
 template<unsigned DIM>
@@ -91,6 +92,7 @@ MeshBasedCellPopulationWithGhostNodes<DIM>::MeshBasedCellPopulationWithGhostNode
       mGhostGhostSpringStiffness(ghostGhostSpringStiffness),
       mGhostSpringRestLength(ghostSpringRestLength)
 {
+    this->UpdateNodePairs();
 }
 
 template<unsigned DIM>

--- a/cell_based/src/population/NodeBasedCellPopulation.cpp
+++ b/cell_based/src/population/NodeBasedCellPopulation.cpp
@@ -112,7 +112,7 @@ TetrahedralMesh<DIM, DIM>* NodeBasedCellPopulation<DIM>::GetTetrahedralMeshForPd
 template<unsigned DIM>
 void NodeBasedCellPopulation<DIM>::Clear()
 {
-    mNodePairs.clear();
+    this->mNodePairs.clear();
 }
 
 template<unsigned DIM>
@@ -166,11 +166,11 @@ void NodeBasedCellPopulation<DIM>::Update(bool hasHadBirthsOrDeaths)
 
     RefreshHaloCells();
 
-    mpNodesOnlyMesh->CalculateInteriorNodePairs(mNodePairs);
+    mpNodesOnlyMesh->CalculateInteriorNodePairs(this->mNodePairs);
 
     AddReceivedHaloCells();
 
-    mpNodesOnlyMesh->CalculateBoundaryNodePairs(mNodePairs);
+    mpNodesOnlyMesh->CalculateBoundaryNodePairs(this->mNodePairs);
 
     /*
      * Update cell radii based on CellData
@@ -285,10 +285,10 @@ void NodeBasedCellPopulation<DIM>::UpdateParticlesAfterReMesh(NodeMap& rMap)
 {
 }
 
-template<unsigned DIM>
-std::vector< std::pair<Node<DIM>*, Node<DIM>* > >& NodeBasedCellPopulation<DIM>::rGetNodePairs()
+template <unsigned DIM>
+const std::vector<std::pair<Node<DIM>*, Node<DIM>*> >& NodeBasedCellPopulation<DIM>::rGetNodePairs() const
 {
-    return mNodePairs;
+    return this->mNodePairs;
 }
 
 template<unsigned DIM>

--- a/cell_based/src/population/NodeBasedCellPopulation.cpp
+++ b/cell_based/src/population/NodeBasedCellPopulation.cpp
@@ -285,12 +285,6 @@ void NodeBasedCellPopulation<DIM>::UpdateParticlesAfterReMesh(NodeMap& rMap)
 {
 }
 
-template <unsigned DIM>
-const std::vector<std::pair<Node<DIM>*, Node<DIM>*> >& NodeBasedCellPopulation<DIM>::rGetNodePairs() const
-{
-    return this->mNodePairs;
-}
-
 template<unsigned DIM>
 void NodeBasedCellPopulation<DIM>::OutputCellPopulationParameters(out_stream& rParamsFile)
 {

--- a/cell_based/src/population/NodeBasedCellPopulation.hpp
+++ b/cell_based/src/population/NodeBasedCellPopulation.hpp
@@ -346,16 +346,6 @@ public:
     void Update(bool hasHadBirthsOrDeaths=true);
 
     /**
-     * Overridden method to return pairs of nodes.
-     *
-     * This vector is calculated using a box collection, and is updated in the ::Update
-     * method each timestep.
-     *
-     * @return A vector of pairs of nodes that may interact mechanically.
-     */
-    [[nodiscard]] const std::vector<std::pair<Node<DIM>*, Node<DIM>*> >& rGetNodePairs() const override;
-
-    /**
      * Outputs CellPopulation parameters to file
      *
      * As this method is pure virtual, it must be overridden

--- a/cell_based/src/population/NodeBasedCellPopulation.hpp
+++ b/cell_based/src/population/NodeBasedCellPopulation.hpp
@@ -68,9 +68,6 @@ private:
     /** Vector of maximal spatial positions in each dimension. */
     c_vector<double, DIM> mMaxSpatialPositions;
 
-    /** Node pairs for force calculations. */
-    std::vector< std::pair<Node<DIM>*, Node<DIM>* > > mNodePairs;
-
     /** Whether to delete the nodes-only mesh (taken in one of the constructors, defaults to false). */
     bool mDeleteMesh;
 
@@ -349,11 +346,14 @@ public:
     void Update(bool hasHadBirthsOrDeaths=true);
 
     /**
-     * Overridden rGetNodePairs method
+     * Overridden method to return pairs of nodes.
      *
-     * @return Node pairs for force calculation.
+     * This vector is calculated using a box collection, and is updated in the ::Update
+     * method each timestep.
+     *
+     * @return A vector of pairs of nodes that may interact mechanically.
      */
-    std::vector< std::pair<Node<DIM>*, Node<DIM>* > >& rGetNodePairs();
+    [[nodiscard]] const std::vector<std::pair<Node<DIM>*, Node<DIM>*> >& rGetNodePairs() const override;
 
     /**
      * Outputs CellPopulation parameters to file

--- a/cell_based/src/population/forces/AbstractTwoBodyInteractionForce.cpp
+++ b/cell_based/src/population/forces/AbstractTwoBodyInteractionForce.cpp
@@ -35,6 +35,9 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "AbstractTwoBodyInteractionForce.hpp"
 
+#include "AbstractOffLatticeCellPopulation.hpp"
+#include "Warnings.hpp"
+
 template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
 AbstractTwoBodyInteractionForce<ELEMENT_DIM,SPACE_DIM>::AbstractTwoBodyInteractionForce()
    : AbstractForce<ELEMENT_DIM,SPACE_DIM>(),
@@ -63,53 +66,32 @@ double AbstractTwoBodyInteractionForce<ELEMENT_DIM,SPACE_DIM>::GetCutOffLength()
     return mMechanicsCutOffLength;
 }
 
-template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
-void AbstractTwoBodyInteractionForce<ELEMENT_DIM,SPACE_DIM>::AddForceContribution(AbstractCellPopulation<ELEMENT_DIM,SPACE_DIM>& rCellPopulation)
+template <unsigned ELEMENT_DIM, unsigned SPACE_DIM>
+void AbstractTwoBodyInteractionForce<ELEMENT_DIM, SPACE_DIM>::AddForceContribution(AbstractCellPopulation<ELEMENT_DIM, SPACE_DIM>& rCellPopulation)
 {
     // Throw an exception message if not using a subclass of AbstractCentreBasedCellPopulation
-    if (dynamic_cast<AbstractCentreBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>*>(&rCellPopulation) == nullptr)
+    if (dynamic_cast<AbstractOffLatticeCellPopulation<ELEMENT_DIM,SPACE_DIM>*>(&rCellPopulation) == nullptr)
     {
-        EXCEPTION("Subclasses of AbstractTwoBodyInteractionForce are to be used with subclasses of AbstractCentreBasedCellPopulation only");
+        EXCEPTION("Subclasses of AbstractTwoBodyInteractionForce are to be used with subclasses of AbstractOffLatticeCellPopulation only");
     }
 
-    ///\todo this could be tidied by using the rGetNodePairs for all populations and moving the below calculation into the MutableMesh.
-    if (bool(dynamic_cast<MeshBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>*>(&rCellPopulation)))
+    const auto r_node_pairs = static_cast<AbstractOffLatticeCellPopulation<ELEMENT_DIM,SPACE_DIM>*>(&rCellPopulation)->rGetNodePairs();
+    if (r_node_pairs.empty())
     {
-        MeshBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>* p_static_cast_cell_population = static_cast<MeshBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>*>(&rCellPopulation);
-
-        // Iterate over all springs and add force contributions
-        for (typename MeshBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>::SpringIterator spring_iterator = p_static_cast_cell_population->SpringsBegin();
-             spring_iterator != p_static_cast_cell_population->SpringsEnd();
-             ++spring_iterator)
-        {
-            unsigned nodeA_global_index = spring_iterator.GetNodeA()->GetIndex();
-            unsigned nodeB_global_index = spring_iterator.GetNodeB()->GetIndex();
-
-            // Calculate the force between nodes
-            c_vector<double, SPACE_DIM> force = CalculateForceBetweenNodes(nodeA_global_index, nodeB_global_index, rCellPopulation);
-
-            // Add the force contribution to each node
-            c_vector<double, SPACE_DIM> negative_force = -1.0*force;
-            spring_iterator.GetNodeB()->AddAppliedForceContribution(negative_force);
-            spring_iterator.GetNodeA()->AddAppliedForceContribution(force);
-        }
+        WARN_ONCE_ONLY("No node pairs found. Does this cell population support updating mNodePairs?"
+                       " Currently this force class works only with NodeBased and MeshBased cell populations.");
     }
-    else    // This is a NodeBasedCellPopulation
+
+    for (const auto& [p_node_a, p_node_b] : r_node_pairs)
     {
-        AbstractCentreBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>* p_static_cast_cell_population = static_cast<AbstractCentreBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>*>(&rCellPopulation);
+        unsigned node_a_index = p_node_a->GetIndex();
+        unsigned node_b_index = p_node_b->GetIndex();
 
-        const std::vector< std::pair<Node<SPACE_DIM>*, Node<SPACE_DIM>* > >& r_node_pairs = p_static_cast_cell_population->rGetNodePairs();
-        for (const auto& [p_node_a, p_node_b] : r_node_pairs)
-        {
-            unsigned node_a_index = p_node_a->GetIndex();
-            unsigned node_b_index = p_node_b->GetIndex();
+        c_vector<double, SPACE_DIM> force = CalculateForceBetweenNodes(node_a_index, node_b_index, rCellPopulation);
+        assert(std::none_of(force.begin(), force.end(), [](double x){ return std::isnan(x); }));
 
-            c_vector<double, SPACE_DIM> force = CalculateForceBetweenNodes(node_a_index, node_b_index, rCellPopulation);
-            assert(std::none_of(force.begin(), force.end(), [](double x) { return std::isnan(x); }));
-
-            p_node_a->AddAppliedForceContribution(force);
-            p_node_b->AddAppliedForceContribution(-1.0 * force);
-        }
+        p_node_a->AddAppliedForceContribution(force);
+        p_node_b->AddAppliedForceContribution(-1.0 * force);
     }
 }
 

--- a/cell_based/src/population/forces/AbstractTwoBodyInteractionForce.cpp
+++ b/cell_based/src/population/forces/AbstractTwoBodyInteractionForce.cpp
@@ -98,28 +98,17 @@ void AbstractTwoBodyInteractionForce<ELEMENT_DIM,SPACE_DIM>::AddForceContributio
     {
         AbstractCentreBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>* p_static_cast_cell_population = static_cast<AbstractCentreBasedCellPopulation<ELEMENT_DIM,SPACE_DIM>*>(&rCellPopulation);
 
-        std::vector< std::pair<Node<SPACE_DIM>*, Node<SPACE_DIM>* > >& r_node_pairs = p_static_cast_cell_population->rGetNodePairs();
-
-        for (typename std::vector< std::pair<Node<SPACE_DIM>*, Node<SPACE_DIM>* > >::iterator iter = r_node_pairs.begin();
-            iter != r_node_pairs.end();
-            iter++)
+        const std::vector< std::pair<Node<SPACE_DIM>*, Node<SPACE_DIM>* > >& r_node_pairs = p_static_cast_cell_population->rGetNodePairs();
+        for (const auto& [p_node_a, p_node_b] : r_node_pairs)
         {
-            std::pair<Node<SPACE_DIM>*, Node<SPACE_DIM>* > pair = *iter;
+            unsigned node_a_index = p_node_a->GetIndex();
+            unsigned node_b_index = p_node_b->GetIndex();
 
-            unsigned node_a_index = pair.first->GetIndex();
-            unsigned node_b_index = pair.second->GetIndex();
-
-            // Calculate the force between nodes
             c_vector<double, SPACE_DIM> force = CalculateForceBetweenNodes(node_a_index, node_b_index, rCellPopulation);
-            for (unsigned j=0; j<SPACE_DIM; j++)
-            {
-                assert(!std::isnan(force[j]));
-            }
+            assert(std::none_of(force.begin(), force.end(), [](double x) { return std::isnan(x); }));
 
-            // Add the force contribution to each node
-            c_vector<double, SPACE_DIM> negative_force = -1.0*force;
-            pair.first->AddAppliedForceContribution(force);
-            pair.second->AddAppliedForceContribution(negative_force);
+            p_node_a->AddAppliedForceContribution(force);
+            p_node_b->AddAppliedForceContribution(-1.0 * force);
         }
     }
 }

--- a/cell_based/src/population/forces/AbstractTwoBodyInteractionForce.hpp
+++ b/cell_based/src/population/forces/AbstractTwoBodyInteractionForce.hpp
@@ -37,8 +37,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define ABSTRACTTWOBODYINTERACTIONFORCE_HPP_
 
 #include "AbstractForce.hpp"
-#include "MeshBasedCellPopulation.hpp"
-#include "NodeBasedCellPopulation.hpp"
+
 /**
  * An abstract class for two-body force laws.
  *

--- a/cell_based/src/population/forces/BuskeAdhesiveForce.cpp
+++ b/cell_based/src/population/forces/BuskeAdhesiveForce.cpp
@@ -35,6 +35,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "BuskeAdhesiveForce.hpp"
 
+#include "NodeBasedCellPopulation.hpp"
+
 template<unsigned DIM>
 BuskeAdhesiveForce<DIM>::BuskeAdhesiveForce()
    : AbstractTwoBodyInteractionForce<DIM>(),

--- a/cell_based/src/population/forces/BuskeElasticForce.cpp
+++ b/cell_based/src/population/forces/BuskeElasticForce.cpp
@@ -35,6 +35,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "BuskeElasticForce.hpp"
 
+#include "NodeBasedCellPopulation.hpp"
+
 template<unsigned DIM>
 BuskeElasticForce<DIM>::BuskeElasticForce()
    : AbstractTwoBodyInteractionForce<DIM>(),

--- a/cell_based/src/population/forces/GeneralisedLinearSpringForce.cpp
+++ b/cell_based/src/population/forces/GeneralisedLinearSpringForce.cpp
@@ -35,7 +35,11 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "GeneralisedLinearSpringForce.hpp"
 
-template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
+#include "AbstractCentreBasedCellPopulation.hpp"
+#include "MeshBasedCellPopulation.hpp"
+#include "NodeBasedCellPopulation.hpp"
+
+template <unsigned ELEMENT_DIM, unsigned SPACE_DIM>
 GeneralisedLinearSpringForce<ELEMENT_DIM,SPACE_DIM>::GeneralisedLinearSpringForce()
    : AbstractTwoBodyInteractionForce<ELEMENT_DIM,SPACE_DIM>(),
      mMeinekeSpringStiffness(15.0),        // denoted by mu in Meineke et al, 2001 (doi:10.1046/j.0960-7722.2001.00216.x)

--- a/cell_based/src/population/forces/RepulsionForce.cpp
+++ b/cell_based/src/population/forces/RepulsionForce.cpp
@@ -50,17 +50,9 @@ void RepulsionForce<DIM>::AddForceContribution(AbstractCellPopulation<DIM>& rCel
         EXCEPTION("RepulsionForce is to be used with a NodeBasedCellPopulation only");
     }
 
-    std::vector< std::pair<Node<DIM>*, Node<DIM>* > >& r_node_pairs = (static_cast<NodeBasedCellPopulation<DIM>*>(&rCellPopulation))->rGetNodePairs();
-
-    for (typename std::vector< std::pair<Node<DIM>*, Node<DIM>* > >::iterator iter = r_node_pairs.begin();
-        iter != r_node_pairs.end();
-        iter++)
+    const std::vector< std::pair<Node<DIM>*, Node<DIM>* > >& r_node_pairs = (static_cast<NodeBasedCellPopulation<DIM>*>(&rCellPopulation))->rGetNodePairs();
+    for (const auto& [p_node_a, p_node_b] : r_node_pairs)
     {
-        std::pair<Node<DIM>*, Node<DIM>* > pair = *iter;
-
-        Node<DIM>* p_node_a = pair.first;
-        Node<DIM>* p_node_b = pair.second;
-
         // Get the node locations
         const c_vector<double, DIM>& r_node_a_location = p_node_a->rGetLocation();
         const c_vector<double, DIM>& r_node_b_location = p_node_b->rGetLocation();

--- a/cell_based/test/population/TestForces.hpp
+++ b/cell_based/test/population/TestForces.hpp
@@ -67,6 +67,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "FileComparison.hpp"
 #include "SimpleTargetAreaModifier.hpp"
 #include "OffLatticeSimulation.hpp"
+#include "Warnings.hpp"
 
 #include "PetscSetupAndFinalize.hpp"
 

--- a/cell_based/test/population/TestForces.hpp
+++ b/cell_based/test/population/TestForces.hpp
@@ -1915,10 +1915,12 @@ public:
         VertexBasedCellPopulation<2> cell_population(mesh, cells);
         cell_population.InitialiseCells();
 
-        // Test that a subclass of AbstractTwoBodyInteractionForce throws the correct exception
+        // Test that a subclass of AbstractTwoBodyInteractionForce emits the appropraite warning
         GeneralisedLinearSpringForce<2> spring_force;
-        TS_ASSERT_THROWS_THIS(spring_force.AddForceContribution(cell_population),
-                "Subclasses of AbstractTwoBodyInteractionForce are to be used with subclasses of AbstractCentreBasedCellPopulation only");
+        spring_force.AddForceContribution(cell_population);
+        TS_ASSERT_EQUALS(Warnings::Instance()->GetNextWarningMessage(),
+            "No node pairs found. Does this cell population support updating mNodePairs?"
+            " Currently this force class works only with NodeBased and MeshBased cell populations.");
 
         // Test that RepulsionForce throws the correct exception
         RepulsionForce<2> repulsion_force;

--- a/cell_based/test/population/TestForces.hpp
+++ b/cell_based/test/population/TestForces.hpp
@@ -1917,6 +1917,7 @@ public:
 
         // Test that a subclass of AbstractTwoBodyInteractionForce emits the appropraite warning
         GeneralisedLinearSpringForce<2> spring_force;
+        Warnings::QuietDestroy(); // Clear any warnings before the expected one
         spring_force.AddForceContribution(cell_population);
         TS_ASSERT_EQUALS(Warnings::Instance()->GetNextWarningMessage(),
             "No node pairs found. Does this cell population support updating mNodePairs?"

--- a/cell_based/test/population/TestMeshBasedCellPopulation.hpp
+++ b/cell_based/test/population/TestMeshBasedCellPopulation.hpp
@@ -1626,32 +1626,22 @@ public:
         // Create cell population
         MeshBasedCellPopulation<2> cell_population(mesh, cells);
 
-        // Node pairs are not calculated until Update()
+        const auto& r_node_pairs = cell_population.rGetNodePairs();
+        TS_ASSERT_EQUALS(r_node_pairs.size(), 8ul);
+
+        auto vec_idx = 0ul;
+        for (auto spring_it = cell_population.SpringsBegin(); spring_it != cell_population.SpringsEnd(); ++spring_it)
         {
-            const auto& r_node_pairs = cell_population.rGetNodePairs();
-            TS_ASSERT(r_node_pairs.empty());
-        }
+            const unsigned spring_it_node_a_idx = spring_it.GetNodeA()->GetIndex();
+            const unsigned spring_it_node_b_idx = spring_it.GetNodeB()->GetIndex();
 
-        // After update, we should have all node pairs
-        {
-            cell_population.Update();
-            const auto& r_node_pairs = cell_population.rGetNodePairs();
-            TS_ASSERT_EQUALS(r_node_pairs.size(), 8ul);
+            const unsigned vec_node_a_idx = r_node_pairs[vec_idx].first->GetIndex();
+            const unsigned vec_node_b_idx = r_node_pairs[vec_idx].second->GetIndex();
 
-            auto vec_idx = 0ul;
-            for (auto spring_it = cell_population.SpringsBegin(); spring_it != cell_population.SpringsEnd(); ++spring_it)
-            {
-                const unsigned spring_it_node_a_idx = spring_it.GetNodeA()->GetIndex();
-                const unsigned spring_it_node_b_idx = spring_it.GetNodeB()->GetIndex();
+            TS_ASSERT_EQUALS(spring_it_node_a_idx, vec_node_a_idx);
+            TS_ASSERT_EQUALS(spring_it_node_b_idx, vec_node_b_idx);
 
-                const unsigned vec_node_a_idx = r_node_pairs[vec_idx].first->GetIndex();
-                const unsigned vec_node_b_idx = r_node_pairs[vec_idx].second->GetIndex();
-
-                TS_ASSERT_EQUALS(spring_it_node_a_idx, vec_node_a_idx);
-                TS_ASSERT_EQUALS(spring_it_node_b_idx, vec_node_b_idx);
-
-                vec_idx++;
-            }
+            vec_idx++;
         }
     }
 };

--- a/cell_based/test/population/TestMeshBasedCellPopulation.hpp
+++ b/cell_based/test/population/TestMeshBasedCellPopulation.hpp
@@ -1129,7 +1129,7 @@ public:
         TS_ASSERT_DELTA(ages_data[2], 2.0, 1e-9);
         TS_ASSERT_DELTA(ages_data[3], 3.0, 1e-9);
         TS_ASSERT_DELTA(ages_data[4], 4.0, 1e-9);
- #endif //CHASTE_VTK
+#endif //CHASTE_VTK
     }
 
     void TestCellPopulationWritersIn3d()
@@ -1608,6 +1608,51 @@ public:
         TS_ASSERT_DELTA(p_tet_mesh->GetNode(1)->rGetLocation()[1], 0.0, 1e-6);
         TS_ASSERT_DELTA(p_tet_mesh->GetNode(2)->rGetLocation()[0], 0.5, 1e-6);
         TS_ASSERT_DELTA(p_tet_mesh->GetNode(2)->rGetLocation()[1], 0.5*sqrt(3.0), 1e-6);
+    }
+
+    void TestGetNodePairs()
+    {
+        // Create a simple mesh
+        TrianglesMeshReader<2,2> mesh_reader("mesh/test/data/square_4_elements");
+        MutableMesh<2,2> mesh;
+        mesh.ConstructFromMeshReader(mesh_reader);
+
+        // Set up cells, one for each node. Give each a birth time of -node_index,
+        // so the age = node_index
+        std::vector<CellPtr> cells;
+        CellsGenerator<FixedG1GenerationalCellCycleModel, 2> cells_generator;
+        cells_generator.GenerateBasic(cells, mesh.GetNumNodes());
+
+        // Create cell population
+        MeshBasedCellPopulation<2> cell_population(mesh, cells);
+
+        // Node pairs are not calculated until Update()
+        {
+            const auto& r_node_pairs = cell_population.rGetNodePairs();
+            TS_ASSERT(r_node_pairs.empty());
+        }
+
+        // After update, we should have all node pairs
+        {
+            cell_population.Update();
+            const auto& r_node_pairs = cell_population.rGetNodePairs();
+            TS_ASSERT_EQUALS(r_node_pairs.size(), 8ul);
+
+            auto vec_idx = 0ul;
+            for (auto spring_it = cell_population.SpringsBegin(); spring_it != cell_population.SpringsEnd(); ++spring_it)
+            {
+                const unsigned spring_it_node_a_idx = spring_it.GetNodeA()->GetIndex();
+                const unsigned spring_it_node_b_idx = spring_it.GetNodeB()->GetIndex();
+
+                const unsigned vec_node_a_idx = r_node_pairs[vec_idx].first->GetIndex();
+                const unsigned vec_node_b_idx = r_node_pairs[vec_idx].second->GetIndex();
+
+                TS_ASSERT_EQUALS(spring_it_node_a_idx, vec_node_a_idx);
+                TS_ASSERT_EQUALS(spring_it_node_b_idx, vec_node_b_idx);
+
+                vec_idx++;
+            }
+        }
     }
 };
 

--- a/cell_based/test/population/TestNodeBasedCellPopulation.hpp
+++ b/cell_based/test/population/TestNodeBasedCellPopulation.hpp
@@ -226,8 +226,7 @@ public:
 
         cell_population.Update();
 
-        std::vector< std::pair<Node<2>*, Node<2>* > >& r_node_pairs = cell_population.rGetNodePairs();
-        r_node_pairs.clear();
+        cell_population.rGetModifiableNodePairs().clear();
 
         // Set a new cut-off
         if (PetscTools::IsSequential()) // This causes nodes to jump to different process in parallel

--- a/cell_based/test/population/TestVertexBasedCellPopulation.hpp
+++ b/cell_based/test/population/TestVertexBasedCellPopulation.hpp
@@ -1520,22 +1520,6 @@ public:
         delete p_tetrahedral_mesh;
     }
 
-    void TestGetNodePairsException()
-    {
-        // Create a small cell population
-        HoneycombVertexMeshGenerator generator(1, 1);
-        boost::shared_ptr<MutableVertexMesh<2,2> > p_mesh = generator.GetMesh();
-
-        std::vector<CellPtr> cells;
-        CellsGenerator<FixedG1GenerationalCellCycleModel, 2> cells_generator;
-        cells_generator.GenerateBasic(cells, p_mesh->GetNumElements());
-
-        VertexBasedCellPopulation<2> cell_population(*p_mesh, cells);
-
-        TS_ASSERT_THROWS_THIS((void) cell_population.rGetNodePairs(),
-            "This method must be overridden in any derived cell population using this functionality.");
-    }
-
     void TestGetCellDataItemAtPdeNode()
     {
         // Create a small cell population

--- a/cell_based/test/population/TestVertexBasedCellPopulation.hpp
+++ b/cell_based/test/population/TestVertexBasedCellPopulation.hpp
@@ -1520,6 +1520,22 @@ public:
         delete p_tetrahedral_mesh;
     }
 
+    void TestGetNodePairsException()
+    {
+        // Create a small cell population
+        HoneycombVertexMeshGenerator generator(1, 1);
+        boost::shared_ptr<MutableVertexMesh<2,2> > p_mesh = generator.GetMesh();
+
+        std::vector<CellPtr> cells;
+        CellsGenerator<FixedG1GenerationalCellCycleModel, 2> cells_generator;
+        cells_generator.GenerateBasic(cells, p_mesh->GetNumElements());
+
+        VertexBasedCellPopulation<2> cell_population(*p_mesh, cells);
+
+        TS_ASSERT_THROWS_THIS((void) cell_population.rGetNodePairs(),
+            "This method must be overridden in any derived cell population using this functionality.");
+    }
+
     void TestGetCellDataItemAtPdeNode()
     {
         // Create a small cell population

--- a/cell_based/test/simulation/TestOffLatticeSimulationWithPdes.hpp
+++ b/cell_based/test/simulation/TestOffLatticeSimulationWithPdes.hpp
@@ -73,6 +73,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "EllipticBoxDomainPdeModifier.hpp"
 #include "EllipticGrowingDomainPdeModifier.hpp"
 #include "RadialCellDataDistributionWriter.hpp"
+#include "NodesOnlyMesh.hpp"
+#include "NodeBasedCellPopulation.hpp"
 
 class SimplePdeForTesting : public AbstractLinearEllipticPde<2,2>
 {

--- a/cell_based/test/tutorial/TestCreatingAndUsingANewCellCycleModelTutorial.hpp
+++ b/cell_based/test/tutorial/TestCreatingAndUsingANewCellCycleModelTutorial.hpp
@@ -85,6 +85,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "HoneycombMeshGenerator.hpp"
 #include "WildTypeCellMutationState.hpp"
 #include "GeneralisedLinearSpringForce.hpp"
+#include "MeshBasedCellPopulation.hpp"
 #include "OffLatticeSimulation.hpp"
 #include "StemCellProliferativeType.hpp"
 #include "TransitCellProliferativeType.hpp"

--- a/cell_based/test/tutorial/TestCreatingAndUsingANewCellKillerTutorial.hpp
+++ b/cell_based/test/tutorial/TestCreatingAndUsingANewCellKillerTutorial.hpp
@@ -81,6 +81,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "HoneycombMeshGenerator.hpp"
 #include "FixedG1GenerationalCellCycleModel.hpp"
 #include "GeneralisedLinearSpringForce.hpp"
+#include "MeshBasedCellPopulation.hpp"
 #include "OffLatticeSimulation.hpp"
 #include "CellsGenerator.hpp"
 #include "SmartPointers.hpp"

--- a/cell_based/test/tutorial/TestCreatingAndUsingANewCellMutationStateTutorial.hpp
+++ b/cell_based/test/tutorial/TestCreatingAndUsingANewCellMutationStateTutorial.hpp
@@ -73,6 +73,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "WildTypeCellMutationState.hpp"
 #include "FixedG1GenerationalCellCycleModel.hpp"
 #include "GeneralisedLinearSpringForce.hpp"
+#include "MeshBasedCellPopulation.hpp"
 #include "OffLatticeSimulation.hpp"
 #include "CellMutationStatesCountWriter.hpp"
 #include "CellsGenerator.hpp"

--- a/cell_based/test/tutorial/TestCreatingAndUsingANewCellPopulationBoundaryConditionTutorial.hpp
+++ b/cell_based/test/tutorial/TestCreatingAndUsingANewCellPopulationBoundaryConditionTutorial.hpp
@@ -75,6 +75,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "CellsGenerator.hpp"
 #include "FixedG1GenerationalCellCycleModel.hpp"
 #include "GeneralisedLinearSpringForce.hpp"
+#include "MeshBasedCellPopulation.hpp"
 #include "SmartPointers.hpp"
 #include "FakePetscSetup.hpp"
 

--- a/cell_based/test/tutorial/TestCreatingAndUsingANewCellPropertyTutorial.hpp
+++ b/cell_based/test/tutorial/TestCreatingAndUsingANewCellPropertyTutorial.hpp
@@ -83,6 +83,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "CellLabel.hpp"
 #include "FixedG1GenerationalCellCycleModel.hpp"
 #include "GeneralisedLinearSpringForce.hpp"
+#include "NodeBasedCellPopulation.hpp"
 #include "CellMutationStatesCountWriter.hpp"
 #include "OffLatticeSimulation.hpp"
 #include "SmartPointers.hpp"

--- a/cell_based/test/tutorial/TestCreatingAndUsingANewForceTutorial.hpp
+++ b/cell_based/test/tutorial/TestCreatingAndUsingANewForceTutorial.hpp
@@ -71,6 +71,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "HoneycombMeshGenerator.hpp"
 #include "FixedG1GenerationalCellCycleModel.hpp"
 #include "GeneralisedLinearSpringForce.hpp"
+#include "MeshBasedCellPopulation.hpp"
 #include "OffLatticeSimulation.hpp"
 #include "CellsGenerator.hpp"
 #include "TransitCellProliferativeType.hpp"

--- a/cell_based/test/tutorial/TestCreatingAndUsingNewCellBasedWritersTutorial.hpp
+++ b/cell_based/test/tutorial/TestCreatingAndUsingNewCellBasedWritersTutorial.hpp
@@ -80,6 +80,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "CellLabel.hpp"
 #include "FixedG1GenerationalCellCycleModel.hpp"
 #include "GeneralisedLinearSpringForce.hpp"
+#include "MeshBasedCellPopulation.hpp"
+#include "NodeBasedCellPopulation.hpp"
 #include "CellMutationStatesCountWriter.hpp"
 #include "OffLatticeSimulation.hpp"
 #include "SmartPointers.hpp"

--- a/cell_based/test/tutorial/TestRunningTumourSpheroidSimulationsTutorial.hpp
+++ b/cell_based/test/tutorial/TestRunningTumourSpheroidSimulationsTutorial.hpp
@@ -73,6 +73,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "AbstractCellBasedTestSuite.hpp"
 #include "HoneycombMeshGenerator.hpp"
 #include "GeneralisedLinearSpringForce.hpp"
+#include "MeshBasedCellPopulation.hpp"
 #include "RandomNumberGenerator.hpp"
 #include "SmartPointers.hpp"
 /*

--- a/crypt/test/mechanics/TestCryptProjectionForce.hpp
+++ b/crypt/test/mechanics/TestCryptProjectionForce.hpp
@@ -51,6 +51,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "HoneycombMeshGenerator.hpp"
 #include "CryptProjectionForce.hpp"
 #include "GeneralisedLinearSpringForce.hpp"
+#include "NodeBasedCellPopulation.hpp"
 #include "WntConcentration.hpp"
 #include "SimulationTime.hpp"
 #include "MutableMesh.hpp"

--- a/crypt/test/mechanics/TestLinearSpringWithVariableSpringConstantsForce.hpp
+++ b/crypt/test/mechanics/TestLinearSpringWithVariableSpringConstantsForce.hpp
@@ -46,6 +46,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "VanLeeuwen2009WntSwatCellCycleModelHypothesisTwo.hpp"
 #include "CylindricalHoneycombMeshGenerator.hpp"
 #include "LinearSpringWithVariableSpringConstantsForce.hpp"
+#include "NodeBasedCellPopulation.hpp"
 #include "WntConcentration.hpp"
 #include "CryptSimulation2d.hpp"
 #include "StemCellProliferativeType.hpp"


### PR DESCRIPTION
Addresses #400 by modifying the cell population hierarchy so that every off lattice population has an `mNodePairs` member, which cell populations can choose to keep updated if they wish.

Right now this is NodeBased and MeshBased, but will also include SemBased (and potentially ManyVertexBased in future).

Main changes:

- `mNodePairs` moved from `AbstractCentreBasedCellPopulation` up one to `AbstractOffLatticeCellPopulation`
- `rGetNodePairs` now returns that, and it's up to each derived population to decide if it wants to keep that updated or not
- `AbstractTwoBodyInteractionForce` now just iterates over all node pairs, but will emit a warning (only once) if there are no node pairs, suggesting you check whether your cell population is updating node pairs.
- `MeshBasedCellPopulation` now updates node pairs using the spring iterator. This could be rolled out to a few places, e.g. updating rest lengths, because it's a little bit nontrivial keeping track of which springs are visited in the iterator. Calculating only once per timestep will be marginally more efficient than repeatedly using the iterator.