### PR TITLE
GPU code patch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -604,6 +604,7 @@ flamegpu_init_cuda_architectures(PROJECT Chaste)
 ## Include common rules from the FLAMEGPU/FLAMEGPU2 repositories CMake
 include(${FLAMEGPU_ROOT}/cmake/common.cmake)
 #        
+target_compile_options(flamegpu PRIVATE -Wno-error)
 target_link_libraries(Chaste_COMMON_DEPS INTERFACE flamegpu)
 
 ###########################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ message ("####################################\n")
 message(STATUS "CMake version: ${CMAKE_VERSION}")
 
 # Since CMake 3.0, version can be supplied to the project() command.  We set it directly, for users on older CMake
-project (Chaste VERSION 2024.2 LANGUAGES CUDA CXX)
+project (Chaste VERSION 2024.2 LANGUAGES CUDA C CXX)
 set (Chaste_VERSION_MAJOR 2024 CACHE STRING "Chaste major version number")
 set (Chaste_VERSION_MINOR 2 CACHE STRING "Chaste minor version number")
 


### PR DESCRIPTION
### Changes
* Enables C:
    This is because CMake is otherwise unable to find HDF5 when it has not been packaged together with PETSc.

* Turns off warnings-as-errors for flamegpu:
   Setting `FLAMEGPU_WARNINGS_AS_ERRORS=OFF` did not succeed because Chaste settings override it, so this sets `-Wno-error` directly for flamegpu instead.