### PR TITLE
Add links to website and discussions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1140,6 +1140,16 @@ foreach (component ${Chaste_COMPONENTS})
 endforeach (component ${Chaste_COMPONENTS})
 
 
+message(STATUS "")
+message(STATUS "----------------------------------------------------------")
+message(STATUS "Chaste documentation and tutorials:")
+message(STATUS "    https://chaste.github.io/")
+message(STATUS "Ask questions and get help from the core development team:")
+message(STATUS "    https://github.com/Chaste/Chaste/discussions")
+message(STATUS "----------------------------------------------------------")
+message(STATUS "")
+
+
 set (CPACK_DEBIAN_PACKAGE_DEPENDS "cmake, g++, libopenmpi-dev, petsc-dev (>= 2.3.3-14), libhdf5-openmpi-dev, xsdcxx, libboost-serialization-dev, libboost-filesystem-dev, libparmetis-dev, libxerces-c3-dev, libsundials-serial-dev, libvtk5-dev, python-lxml, python-rdflib")
 set (CPACK_DEBIAN_PACKAGE_RECOMMENDS "valgrind, libfltk1.1")
 set (CPACK_DEBIAN_PACKAGE_SUGGESTS "libgoogle-perftools-dev, doxygen, graphviz, eclipse-cdt, gnuplot")


### PR DESCRIPTION
See #470 

A simple change that will result in a message that looks like this each time a user configures Chaste:
<img width="1512" height="667" alt="image" src="https://github.com/user-attachments/assets/e627f980-032f-4617-acc8-895c9cd6679a" />

Hopefully this will be enough to hint to users that they can get in touch with us directly.

Thoughts / comments welcome.