### PR TITLE
Adaptive timestep loop

### DIFF
--- a/cell_based/src/simulation/OffLatticeSimulation.cpp
+++ b/cell_based/src/simulation/OffLatticeSimulation.cpp
@@ -45,7 +45,8 @@ template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
 OffLatticeSimulation<ELEMENT_DIM,SPACE_DIM>::OffLatticeSimulation(AbstractCellPopulation<ELEMENT_DIM,SPACE_DIM>& rCellPopulation,
                                                 bool deleteCellPopulationInDestructor,
                                                 bool initialiseCells)
-    : AbstractCellBasedSimulation<ELEMENT_DIM,SPACE_DIM>(rCellPopulation, deleteCellPopulationInDestructor, initialiseCells)
+    : AbstractCellBasedSimulation<ELEMENT_DIM,SPACE_DIM>(rCellPopulation, deleteCellPopulationInDestructor, initialiseCells),
+    mMaxAdaptiveTimeSteps(5)
 {
     if (!dynamic_cast<AbstractOffLatticeCellPopulation<ELEMENT_DIM,SPACE_DIM>*>(&rCellPopulation))
     {
@@ -95,6 +96,21 @@ const std::vector<boost::shared_ptr<AbstractForce<ELEMENT_DIM, SPACE_DIM> > >& O
     return mForceCollection;
 }
 
+// KARRIGAN
+template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
+void OffLatticeSimulation<ELEMENT_DIM,SPACE_DIM>::SetMaxAdaptiveTimeStep(unsigned pMaxAdaptiveTimeStep)
+{
+    mMaxAdaptiveTimeSteps = pMaxAdaptiveTimeStep;
+}
+
+template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
+unsigned OffLatticeSimulation<ELEMENT_DIM,SPACE_DIM>::GetMaxAdaptiveTimeStep() 
+{
+    return mMaxAdaptiveTimeSteps;
+}
+
+// KARRIGAN
+
 template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
 void OffLatticeSimulation<ELEMENT_DIM,SPACE_DIM>::UpdateCellLocationsAndTopology()
 {
@@ -138,7 +154,7 @@ void OffLatticeSimulation<ELEMENT_DIM,SPACE_DIM>::UpdateCellLocationsAndTopology
         {
             int adaptive_timer = 0;
             // Detects if a node has travelled too far in a single time step
-            if (mpNumericalMethod->HasAdaptiveTimestep() && adaptive_timer < 5 )
+            if (mpNumericalMethod->HasAdaptiveTimestep() && adaptive_timer < mMaxAdaptiveTimeSteps )
             {
                 // If adaptivity is switched on, revert node locations and choose a suitably smaller time step
                 RevertToOldLocations(old_node_locations);

--- a/cell_based/src/simulation/OffLatticeSimulation.cpp
+++ b/cell_based/src/simulation/OffLatticeSimulation.cpp
@@ -136,17 +136,25 @@ void OffLatticeSimulation<ELEMENT_DIM,SPACE_DIM>::UpdateCellLocationsAndTopology
         }
         catch (StepSizeException& e)
         {
+            int adaptive_timer = 0;
             // Detects if a node has travelled too far in a single time step
             if (mpNumericalMethod->HasAdaptiveTimestep())
             {
                 // If adaptivity is switched on, revert node locations and choose a suitably smaller time step
                 RevertToOldLocations(old_node_locations);
+                if (adaptive_timer < 5 ){
                 present_time_step = std::min(e.GetSuggestedNewStep(), target_time_step - time_advanced_so_far);
+                adaptive_timer += 1;
+                } else {
+                // If adaptivity is not improving the issue, terminate with an error to prevent infinite loop
+                EXCEPTION(e.what());
+                }
             }
             else
             {
                 // If adaptivity is switched off, terminate with an error
                 EXCEPTION(e.what());
+                std::cout << "Reached here in Off Lattice Simulation 6\n" << std::endl;
             }
         }
     }

--- a/cell_based/src/simulation/OffLatticeSimulation.cpp
+++ b/cell_based/src/simulation/OffLatticeSimulation.cpp
@@ -154,7 +154,6 @@ void OffLatticeSimulation<ELEMENT_DIM,SPACE_DIM>::UpdateCellLocationsAndTopology
             {
                 // If adaptivity is switched off, terminate with an error
                 EXCEPTION(e.what());
-                std::cout << "Reached here in Off Lattice Simulation 6\n" << std::endl;
             }
         }
     }

--- a/cell_based/src/simulation/OffLatticeSimulation.cpp
+++ b/cell_based/src/simulation/OffLatticeSimulation.cpp
@@ -138,21 +138,16 @@ void OffLatticeSimulation<ELEMENT_DIM,SPACE_DIM>::UpdateCellLocationsAndTopology
         {
             int adaptive_timer = 0;
             // Detects if a node has travelled too far in a single time step
-            if (mpNumericalMethod->HasAdaptiveTimestep())
+            if (mpNumericalMethod->HasAdaptiveTimestep() && adaptive_timer < 5 )
             {
                 // If adaptivity is switched on, revert node locations and choose a suitably smaller time step
                 RevertToOldLocations(old_node_locations);
-                if (adaptive_timer < 5 ){
                 present_time_step = std::min(e.GetSuggestedNewStep(), target_time_step - time_advanced_so_far);
                 adaptive_timer += 1;
-                } else {
-                // If adaptivity is not improving the issue, terminate with an error to prevent infinite loop
-                EXCEPTION(e.what());
-                }
             }
             else
             {
-                // If adaptivity is switched off, terminate with an error
+                // If adaptivity is switched off or we have reached the accepted number of adaptive attempts, terminate with an error
                 EXCEPTION(e.what());
             }
         }

--- a/cell_based/src/simulation/OffLatticeSimulation.cpp
+++ b/cell_based/src/simulation/OffLatticeSimulation.cpp
@@ -45,8 +45,7 @@ template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
 OffLatticeSimulation<ELEMENT_DIM,SPACE_DIM>::OffLatticeSimulation(AbstractCellPopulation<ELEMENT_DIM,SPACE_DIM>& rCellPopulation,
                                                 bool deleteCellPopulationInDestructor,
                                                 bool initialiseCells)
-    : AbstractCellBasedSimulation<ELEMENT_DIM,SPACE_DIM>(rCellPopulation, deleteCellPopulationInDestructor, initialiseCells),
-    mMaxAdaptiveTimeSteps(5)
+    : AbstractCellBasedSimulation<ELEMENT_DIM,SPACE_DIM>(rCellPopulation, deleteCellPopulationInDestructor, initialiseCells)
 {
     if (!dynamic_cast<AbstractOffLatticeCellPopulation<ELEMENT_DIM,SPACE_DIM>*>(&rCellPopulation))
     {
@@ -98,13 +97,13 @@ const std::vector<boost::shared_ptr<AbstractForce<ELEMENT_DIM, SPACE_DIM> > >& O
 
 // KARRIGAN
 template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
-void OffLatticeSimulation<ELEMENT_DIM,SPACE_DIM>::SetMaxAdaptiveTimeStep(unsigned pMaxAdaptiveTimeStep)
+void OffLatticeSimulation<ELEMENT_DIM,SPACE_DIM>::SetMaxAdaptiveTimeStep(unsigned maxAdaptiveTimeStep)
 {
-    mMaxAdaptiveTimeSteps = pMaxAdaptiveTimeStep;
+    mMaxAdaptiveTimeSteps = maxAdaptiveTimeStep;
 }
 
 template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
-unsigned OffLatticeSimulation<ELEMENT_DIM,SPACE_DIM>::GetMaxAdaptiveTimeStep() 
+unsigned OffLatticeSimulation<ELEMENT_DIM,SPACE_DIM>::GetMaxAdaptiveTimeStep() const 
 {
     return mMaxAdaptiveTimeSteps;
 }
@@ -152,7 +151,7 @@ void OffLatticeSimulation<ELEMENT_DIM,SPACE_DIM>::UpdateCellLocationsAndTopology
         }
         catch (StepSizeException& e)
         {
-            int adaptive_timer = 0;
+            unsigned adaptive_timer = 0;
             // Detects if a node has travelled too far in a single time step
             if (mpNumericalMethod->HasAdaptiveTimestep() && adaptive_timer < mMaxAdaptiveTimeSteps )
             {

--- a/cell_based/src/simulation/OffLatticeSimulation.cpp
+++ b/cell_based/src/simulation/OffLatticeSimulation.cpp
@@ -138,23 +138,17 @@ void OffLatticeSimulation<ELEMENT_DIM,SPACE_DIM>::UpdateCellLocationsAndTopology
         {
             int adaptive_timer = 0;
             // Detects if a node has travelled too far in a single time step
-            if (mpNumericalMethod->HasAdaptiveTimestep())
+            if (mpNumericalMethod->HasAdaptiveTimestep() && adaptive_timer < 5 )
             {
                 // If adaptivity is switched on, revert node locations and choose a suitably smaller time step
                 RevertToOldLocations(old_node_locations);
-                if (adaptive_timer < 5 ){
                 present_time_step = std::min(e.GetSuggestedNewStep(), target_time_step - time_advanced_so_far);
                 adaptive_timer += 1;
-                } else {
-                // If adaptivity is not improving the issue, terminate with an error to prevent infinite loop
-                EXCEPTION(e.what());
-                }
             }
             else
             {
-                // If adaptivity is switched off, terminate with an error
+                // If adaptivity is switched off or we have reached the accepted number of adaptive attempts, terminate with an error
                 EXCEPTION(e.what());
-                std::cout << "Reached here in Off Lattice Simulation 6\n" << std::endl;
             }
         }
     }

--- a/cell_based/src/simulation/OffLatticeSimulation.hpp
+++ b/cell_based/src/simulation/OffLatticeSimulation.hpp
@@ -103,6 +103,9 @@ protected:
     /** The numerical method to use in this simulation. Defaults to the explicit forward Euler method. */
     boost::shared_ptr<AbstractNumericalMethod<ELEMENT_DIM, SPACE_DIM> > mpNumericalMethod;
 
+    /** Variable for the allowed number of adaptive time step changes before outputting underlying exception. */
+    int mMaxAdaptiveTimeSteps;
+
     /**
      * Overridden UpdateCellLocationsAndTopology() method.
      *
@@ -185,6 +188,18 @@ public:
      * @return the current numerical method.
      */
     const boost::shared_ptr<AbstractNumericalMethod<ELEMENT_DIM, SPACE_DIM> > GetNumericalMethod() const;
+
+    /**
+     * Set the maximum number of adaptive timesteps that can be attempted before outputting the underlying exception.
+     *
+     * @param pMaxAdaptiveTimeStep max adaptive timestep parameter
+     */
+    void SetMaxAdaptiveTimeStep(unsigned pMaxAdaptiveTimeStep);
+
+    /**
+     * @return the maximum allowed number of attempted timestep reductions.
+     */
+    unsigned GetMaxAdaptiveTimeStep();
 
     /**
      * Overridden OutputAdditionalSimulationSetup() method.

--- a/cell_based/src/simulation/OffLatticeSimulation.hpp
+++ b/cell_based/src/simulation/OffLatticeSimulation.hpp
@@ -104,7 +104,7 @@ protected:
     boost::shared_ptr<AbstractNumericalMethod<ELEMENT_DIM, SPACE_DIM> > mpNumericalMethod;
 
     /** Variable for the allowed number of adaptive time step changes before outputting underlying exception. */
-    int mMaxAdaptiveTimeSteps;
+    unsigned mMaxAdaptiveTimeSteps = 5;
 
     /**
      * Overridden UpdateCellLocationsAndTopology() method.
@@ -192,14 +192,14 @@ public:
     /**
      * Set the maximum number of adaptive timesteps that can be attempted before outputting the underlying exception.
      *
-     * @param pMaxAdaptiveTimeStep max adaptive timestep parameter
+     * @param maxAdaptiveTimeStep max adaptive timestep parameter
      */
-    void SetMaxAdaptiveTimeStep(unsigned pMaxAdaptiveTimeStep);
+    void SetMaxAdaptiveTimeStep(const unsigned maxAdaptiveTimeStep);
 
     /**
      * @return the maximum allowed number of attempted timestep reductions.
      */
-    unsigned GetMaxAdaptiveTimeStep();
+    unsigned GetMaxAdaptiveTimeStep() const;
 
     /**
      * Overridden OutputAdditionalSimulationSetup() method.

--- a/cell_based/test/simulation/TestOffLatticeSimulation.hpp
+++ b/cell_based/test/simulation/TestOffLatticeSimulation.hpp
@@ -1375,6 +1375,7 @@ public:
         simulator.SetOutputDirectory("TestOffLatticeSimulationWithAdaptivity");
         simulator.SetEndTime(5.0);
         simulator.SetDt(0.1);
+        simulator.SetMaxAdaptiveTimeStep(3);
 
         // Pass an adaptive numerical method to the simulation
         boost::shared_ptr<AbstractNumericalMethod<2,2> > p_method(new ForwardEulerNumericalMethod<2,2>());
@@ -1393,6 +1394,7 @@ public:
         simulator.Solve();
 
         TS_ASSERT_EQUALS(simulator.rGetCellPopulation().GetNumRealCells(), 14u);
+        TS_ASSERT_EQUALS(simulator.GetMaxAdaptiveTimeStep(),3);
 
         // Check cells have moved to the correct location
         TS_ASSERT_DELTA(simulator.rGetCellPopulation().rGetMesh().GetNode(0)->rGetLocation()[0], 0.3169,1e-4);

--- a/cell_based/test/simulation/TestOffLatticeSimulation.hpp
+++ b/cell_based/test/simulation/TestOffLatticeSimulation.hpp
@@ -1375,7 +1375,7 @@ public:
         simulator.SetOutputDirectory("TestOffLatticeSimulationWithAdaptivity");
         simulator.SetEndTime(5.0);
         simulator.SetDt(0.1);
-        simulator.SetMaxAdaptiveTimeStep(3);
+        simulator.SetMaxAdaptiveTimeStep(3u);
 
         // Pass an adaptive numerical method to the simulation
         boost::shared_ptr<AbstractNumericalMethod<2,2> > p_method(new ForwardEulerNumericalMethod<2,2>());
@@ -1394,7 +1394,7 @@ public:
         simulator.Solve();
 
         TS_ASSERT_EQUALS(simulator.rGetCellPopulation().GetNumRealCells(), 14u);
-        TS_ASSERT_EQUALS(simulator.GetMaxAdaptiveTimeStep(),3);
+        TS_ASSERT_EQUALS(simulator.GetMaxAdaptiveTimeStep(), 3u);
 
         // Check cells have moved to the correct location
         TS_ASSERT_DELTA(simulator.rGetCellPopulation().rGetMesh().GetNode(0)->rGetLocation()[0], 0.3169,1e-4);


### PR DESCRIPTION
This pull request relates to Issue #448 (https://github.com/Chaste/Chaste/issues/448).

In some rare instances, vertex mesh simulations would infinitely loop and never reached completion or exit due to any error. Initially thought to be a soft crash this was actually being caused due to the following lines of code in OffLatticeSimulation.cpp when adaptive time step was turned on (Starts on line 137).

```
        catch (StepSizeException& e)
        {
            // Detects if a node has travelled too far in a single time step
            if (mpNumericalMethod->HasAdaptiveTimestep())
            {
                // If adaptivity is switched on, revert node locations and choose a suitably smaller time step
                RevertToOldLocations(old_node_locations);
                present_time_step = std::min(e.GetSuggestedNewStep(), target_time_step - time_advanced_so_far);
            }
            else
            {
                // If adaptivity is switched off, terminate with an error
                EXCEPTION(e.what());
            }
        }
```

In cases where adaptive time step was turned on but a terminal error was never received, the catching of exceptions led to the incrementally decreasing time-step being called infinitely. As a way to fix this I suggest changing the code in the following way: 

```
catch (StepSizeException& e)
        {
            int adaptive_timer = 0;
            // Detects if a node has travelled too far in a single time step
            if (mpNumericalMethod->HasAdaptiveTimestep())
            {
                // If adaptivity is switched on, revert node locations and choose a suitably smaller time step
                RevertToOldLocations(old_node_locations);
                if (adaptive_timer < 5 ){
                present_time_step = std::min(e.GetSuggestedNewStep(), target_time_step - time_advanced_so_far);
                adaptive_timer += 1;
                } else {
                // If adaptivity is not improving the issue, terminate with an error to prevent infinite loop
                EXCEPTION(e.what());
                }
            }
            else
            {
                // If adaptivity is switched off, terminate with an error
                EXCEPTION(e.what());
            }
        }
```

 By adding the variable **adaptive_timer** and only allowing the loop to be called a pre-determined number of times (in this case 5) it prevents the possibility of the adaptive time step leading to infinite loops. 5 attempts at reducing the time-step feels like a reasonable number for attempting to save a simulation. This could even be made into a parameter the user could control. 


