### PR TITLE
Modernize: replace BOOST_FOREACH with range-based for loops

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -44,7 +44,7 @@ Cpp11BracedListStyle: false
 DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
-ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+ForEachMacros:   [ foreach, Q_FOREACH ]
 IncludeCategories:
   - Regex:           '"FakePetscSetup.hpp"'
     Priority:        99

--- a/cell_based/src/population/AbstractCellPopulation.cpp
+++ b/cell_based/src/population/AbstractCellPopulation.cpp
@@ -481,13 +481,13 @@ template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
 void AbstractCellPopulation<ELEMENT_DIM, SPACE_DIM>::CloseRoundRobinWritersFiles()
 {
     typedef AbstractCellWriter<ELEMENT_DIM, SPACE_DIM> cell_writer_t;
-    BOOST_FOREACH(boost::shared_ptr<cell_writer_t> p_cell_writer, mCellWriters)
+    for (boost::shared_ptr<cell_writer_t> p_cell_writer : mCellWriters)
     {
         p_cell_writer->CloseFile();
     }
 
     typedef AbstractCellPopulationWriter<ELEMENT_DIM, SPACE_DIM> pop_writer_t;
-    BOOST_FOREACH(boost::shared_ptr<pop_writer_t> p_pop_writer, mCellPopulationWriters)
+    for (boost::shared_ptr<pop_writer_t> p_pop_writer : mCellPopulationWriters)
     {
         p_pop_writer->CloseFile();
     }
@@ -497,13 +497,13 @@ template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
 void AbstractCellPopulation<ELEMENT_DIM, SPACE_DIM>::CloseWritersFiles()
 {
     typedef AbstractCellWriter<ELEMENT_DIM, SPACE_DIM> cell_writer_t;
-    BOOST_FOREACH(boost::shared_ptr<cell_writer_t> p_cell_writer, mCellWriters)
+    for (boost::shared_ptr<cell_writer_t> p_cell_writer : mCellWriters)
     {
         p_cell_writer->CloseFile();
     }
 
     typedef AbstractCellPopulationWriter<ELEMENT_DIM, SPACE_DIM> pop_writer_t;
-    BOOST_FOREACH(boost::shared_ptr<pop_writer_t> p_pop_writer, mCellPopulationWriters)
+    for (boost::shared_ptr<pop_writer_t> p_pop_writer : mCellPopulationWriters)
     {
         p_pop_writer->CloseFile();
     }
@@ -547,14 +547,14 @@ void AbstractCellPopulation<ELEMENT_DIM, SPACE_DIM>::OpenWritersFiles(OutputFile
 
     // Open output files for any cell writers
     typedef AbstractCellWriter<ELEMENT_DIM, SPACE_DIM> cell_writer_t;
-    BOOST_FOREACH(boost::shared_ptr<cell_writer_t> p_cell_writer, mCellWriters)
+    for (boost::shared_ptr<cell_writer_t> p_cell_writer : mCellWriters)
     {
         p_cell_writer->OpenOutputFile(rOutputFileHandler);
     }
 
     // Open output files and write headers for any population writers
     typedef AbstractCellPopulationWriter<ELEMENT_DIM, SPACE_DIM> pop_writer_t;
-    BOOST_FOREACH(boost::shared_ptr<pop_writer_t> p_pop_writer, mCellPopulationWriters)
+    for (boost::shared_ptr<pop_writer_t> p_pop_writer : mCellPopulationWriters)
     {
         p_pop_writer->OpenOutputFile(rOutputFileHandler);
         p_pop_writer->WriteHeader(this);
@@ -562,7 +562,7 @@ void AbstractCellPopulation<ELEMENT_DIM, SPACE_DIM>::OpenWritersFiles(OutputFile
 
     // Open output files and write headers for any population count writers
     typedef AbstractCellPopulationCountWriter<ELEMENT_DIM, SPACE_DIM> count_writer_t;
-    BOOST_FOREACH(boost::shared_ptr<count_writer_t> p_count_writer, mCellPopulationCountWriters)
+    for (boost::shared_ptr<count_writer_t> p_count_writer : mCellPopulationCountWriters)
     {
         p_count_writer->OpenOutputFile(rOutputFileHandler);
         p_count_writer->WriteHeader(this);
@@ -570,7 +570,7 @@ void AbstractCellPopulation<ELEMENT_DIM, SPACE_DIM>::OpenWritersFiles(OutputFile
 
     // Open output files and write headers for any population event writers
     typedef AbstractCellPopulationEventWriter<ELEMENT_DIM, SPACE_DIM> event_writer_t;
-    BOOST_FOREACH(boost::shared_ptr<event_writer_t> p_event_writer, mCellPopulationEventWriters)
+    for (boost::shared_ptr<event_writer_t> p_event_writer : mCellPopulationEventWriters)
     {
         p_event_writer->OpenOutputFile(rOutputFileHandler);
         p_event_writer->WriteHeader(this);
@@ -582,11 +582,11 @@ void AbstractCellPopulation<ELEMENT_DIM, SPACE_DIM>::OpenRoundRobinWritersFilesF
 {
     typedef AbstractCellWriter<ELEMENT_DIM, SPACE_DIM> cell_writer_t;
     typedef AbstractCellPopulationWriter<ELEMENT_DIM, SPACE_DIM> pop_writer_t;
-    BOOST_FOREACH(boost::shared_ptr<cell_writer_t> p_cell_writer, mCellWriters)
+    for (boost::shared_ptr<cell_writer_t> p_cell_writer : mCellWriters)
     {
         p_cell_writer->OpenOutputFileForAppend(rOutputFileHandler);
     }
-    BOOST_FOREACH(boost::shared_ptr<pop_writer_t> p_pop_writer, mCellPopulationWriters)
+    for (boost::shared_ptr<pop_writer_t> p_pop_writer : mCellPopulationWriters)
     {
         p_pop_writer->OpenOutputFileForAppend(rOutputFileHandler);
     }
@@ -611,11 +611,11 @@ void AbstractCellPopulation<ELEMENT_DIM, SPACE_DIM>::WriteResultsToFiles(const s
             // The master process writes time stamps
             if (PetscTools::AmMaster())
             {
-                BOOST_FOREACH(boost::shared_ptr<cell_writer_t> p_cell_writer, mCellWriters)
+                for (boost::shared_ptr<cell_writer_t> p_cell_writer : mCellWriters)
                 {
                     p_cell_writer->WriteTimeStamp();
                 }
-                BOOST_FOREACH(boost::shared_ptr<pop_writer_t> p_pop_writer, mCellPopulationWriters)
+                for (boost::shared_ptr<pop_writer_t> p_pop_writer : mCellPopulationWriters)
                 {
                     p_pop_writer->WriteTimeStamp();
                 }
@@ -633,11 +633,11 @@ void AbstractCellPopulation<ELEMENT_DIM, SPACE_DIM>::WriteResultsToFiles(const s
             // The top-most process adds a newline
             if (PetscTools::AmTopMost())
             {
-                BOOST_FOREACH(boost::shared_ptr<cell_writer_t> p_cell_writer, mCellWriters)
+                for (boost::shared_ptr<cell_writer_t> p_cell_writer : mCellWriters)
                 {
                     p_cell_writer->WriteNewline();
                 }
-                BOOST_FOREACH(boost::shared_ptr<pop_writer_t> p_pop_writer, mCellPopulationWriters)
+                for (boost::shared_ptr<pop_writer_t> p_pop_writer : mCellPopulationWriters)
                 {
                     p_pop_writer->WriteNewline();
                 }
@@ -652,7 +652,7 @@ void AbstractCellPopulation<ELEMENT_DIM, SPACE_DIM>::WriteResultsToFiles(const s
         if (PetscTools::AmMaster())
         {
             // Open mCellPopulationCountWriters in append mode for writing, and write time stamps
-            BOOST_FOREACH(boost::shared_ptr<count_writer_t> p_count_writer, mCellPopulationCountWriters)
+            for (boost::shared_ptr<count_writer_t> p_count_writer : mCellPopulationCountWriters)
             {
                 p_count_writer->OpenOutputFileForAppend(output_file_handler);
                 p_count_writer->WriteTimeStamp();
@@ -668,7 +668,7 @@ void AbstractCellPopulation<ELEMENT_DIM, SPACE_DIM>::WriteResultsToFiles(const s
         if (PetscTools::AmMaster())
         {
             // Add a newline and close any output files
-            BOOST_FOREACH(boost::shared_ptr<count_writer_t> p_count_writer, mCellPopulationCountWriters)
+            for (boost::shared_ptr<count_writer_t> p_count_writer : mCellPopulationCountWriters)
             {
                 p_count_writer->WriteNewline();
                 p_count_writer->CloseFile();
@@ -682,7 +682,7 @@ void AbstractCellPopulation<ELEMENT_DIM, SPACE_DIM>::WriteResultsToFiles(const s
         if (PetscTools::AmMaster())
         {
             // Open mCellPopulationCountWriters in append mode for writing
-            BOOST_FOREACH(boost::shared_ptr<event_writer_t> p_event_writer, mCellPopulationEventWriters)
+            for (boost::shared_ptr<event_writer_t> p_event_writer : mCellPopulationEventWriters)
             {
                 p_event_writer->OpenOutputFileForAppend(output_file_handler);
             }
@@ -697,7 +697,7 @@ void AbstractCellPopulation<ELEMENT_DIM, SPACE_DIM>::WriteResultsToFiles(const s
         if (PetscTools::AmMaster())
         {
             // Close any output files
-            BOOST_FOREACH(boost::shared_ptr<event_writer_t> p_event_writer, mCellPopulationEventWriters)
+            for (boost::shared_ptr<event_writer_t> p_event_writer : mCellPopulationEventWriters)
             {
                 p_event_writer->CloseFile();
             }

--- a/cell_based/src/population/AbstractCellPopulation.hpp
+++ b/cell_based/src/population/AbstractCellPopulation.hpp
@@ -53,7 +53,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <boost/serialization/set.hpp>
 #include <boost/serialization/shared_ptr.hpp>
 
-#include <boost/foreach.hpp>
 
 #include "AbstractMesh.hpp"
 #include "TetrahedralMesh.hpp"
@@ -895,7 +894,7 @@ public:
     bool HasWriter() const
     {
         typedef AbstractCellPopulationWriter<ELEMENT_DIM, SPACE_DIM> population_writer_t;
-        BOOST_FOREACH(boost::shared_ptr<population_writer_t> p_pop_writer, mCellPopulationWriters)
+        for (boost::shared_ptr<population_writer_t> p_pop_writer : mCellPopulationWriters)
         {
             if (dynamic_cast<T<ELEMENT_DIM, SPACE_DIM>* >(p_pop_writer.get()))
             {
@@ -903,7 +902,7 @@ public:
             }
         }
         typedef AbstractCellWriter<ELEMENT_DIM, SPACE_DIM> cell_writer_t;
-        BOOST_FOREACH(boost::shared_ptr<cell_writer_t> p_cell_writer, mCellWriters)
+        for (boost::shared_ptr<cell_writer_t> p_cell_writer : mCellWriters)
         {
             if (dynamic_cast<T<ELEMENT_DIM, SPACE_DIM>* >(p_cell_writer.get()))
             {
@@ -911,7 +910,7 @@ public:
             }
         }
         typedef AbstractCellPopulationCountWriter<ELEMENT_DIM, SPACE_DIM> count_writer_t;
-        BOOST_FOREACH(boost::shared_ptr<count_writer_t> p_count_writer, mCellPopulationCountWriters)
+        for (boost::shared_ptr<count_writer_t> p_count_writer : mCellPopulationCountWriters)
         {
             if (dynamic_cast<T<ELEMENT_DIM, SPACE_DIM>* >(p_count_writer.get()))
             {
@@ -919,7 +918,7 @@ public:
             }
         }
         typedef AbstractCellPopulationEventWriter<ELEMENT_DIM, SPACE_DIM> event_writer_t;
-        BOOST_FOREACH(boost::shared_ptr<event_writer_t> p_event_writer, mCellPopulationEventWriters)
+        for (boost::shared_ptr<event_writer_t> p_event_writer : mCellPopulationEventWriters)
         {
             if (dynamic_cast<T<ELEMENT_DIM, SPACE_DIM>* >(p_event_writer.get()))
             {

--- a/crypt/test/simulation/Test2DMeshBasedCryptRepresentativeSimulation.hpp
+++ b/crypt/test/simulation/Test2DMeshBasedCryptRepresentativeSimulation.hpp
@@ -38,7 +38,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <cxxtest/TestSuite.h>
 
-#include <boost/foreach.hpp>
 
 // Must be included before any other cell_based or crypt headers
 #include "CellBasedSimulationArchiver.hpp"
@@ -100,7 +99,7 @@ public:
 
         // Following is done in two lines to avoid a bug in Intel compiler v12.0
         std::vector<FileFinder> temp_files = test_data_directory.FindMatches("*");
-        BOOST_FOREACH(FileFinder temp_file, temp_files)
+        for (FileFinder temp_file : temp_files)
         {
             archive_handler.CopyFileTo(temp_file);
         }

--- a/crypt/test/simulation/TestArchiveFormat.hpp
+++ b/crypt/test/simulation/TestArchiveFormat.hpp
@@ -42,7 +42,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "CellBasedSimulationArchiver.hpp"
 
 #include <iomanip>
-#include <boost/foreach.hpp>
 #include "CryptSimulation2d.hpp"
 #include "GeneralisedLinearSpringForce.hpp"
 #include "CylindricalHoneycombMeshGenerator.hpp"
@@ -120,7 +119,7 @@ public:
 
         // Following is done in two lines to avoid a bug in Intel compiler v12.0
         std::vector<FileFinder> temp_files = test_data_directory.FindMatches("*");
-        BOOST_FOREACH(FileFinder temp_file, temp_files)
+        for (FileFinder temp_file : temp_files)
         {
             archive_handler.CopyFileTo(temp_file);
         }

--- a/global/src/fortests/FileComparison.hpp
+++ b/global/src/fortests/FileComparison.hpp
@@ -37,7 +37,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "AbstractFileComparison.hpp"
 #include <vector>
-#include <boost/foreach.hpp>
 
 #include <cxxtest/TestSuite.h>
 
@@ -228,7 +227,7 @@ public:
             if (!mIgnorableContent.empty())
             {
                 bool skip_this_line = false;
-                BOOST_FOREACH(const std::string& rText, mIgnorableContent)
+                for (const std::string& rText : mIgnorableContent)
                 {
                     size_t found1 = buffer1.find(rText);
                     size_t found2 = buffer2.find(rText);

--- a/global/test/TestArchivingHelperClasses.hpp
+++ b/global/test/TestArchivingHelperClasses.hpp
@@ -44,7 +44,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>
-#include <boost/foreach.hpp>
 #include <boost/version.hpp>
 
 #include "ArchiveLocationInfo.hpp"

--- a/heart/src/odes/AbstractBackwardEulerCardiacCell.hpp
+++ b/heart/src/odes/AbstractBackwardEulerCardiacCell.hpp
@@ -532,7 +532,6 @@ protected:
 // Debugging
 #ifndef NDEBUG
 #include "OutputFileHandler.hpp"
-#include <boost/foreach.hpp>
 template<unsigned SIZE>
 void DumpJacobianToFile(double time, const double rCurrentGuess[SIZE], double rJacobian[SIZE][SIZE],
                         const std::vector<double>& rY)
@@ -541,7 +540,7 @@ void DumpJacobianToFile(double time, const double rCurrentGuess[SIZE], double rJ
     out_stream p_file = handler.OpenOutputFile("J.txt", std::ios::app);
     (*p_file) << "At " << time << " " << SIZE << std::endl;
     (*p_file) << "rY";
-    BOOST_FOREACH(double y, rY)
+    for (double y : rY)
     {
         (*p_file) << " " << y;
     }

--- a/heart/src/odes/CellMLToSharedLibraryConverter.cpp
+++ b/heart/src/odes/CellMLToSharedLibraryConverter.cpp
@@ -41,7 +41,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstring> // For strerror()
 #include <cerrno> // For errno
 
-#include <boost/foreach.hpp>
 
 #include "ChasteSyscalls.hpp"
 #include "Exception.hpp"
@@ -191,7 +190,7 @@ void CellMLToSharedLibraryConverter::ConvertCellmlToSo(const std::string& rCellm
             std::string cellml_leaf_name = cellml_file.GetLeafNameNoExtension();
             std::vector<FileFinder> cellml_files = cellml_folder.FindMatches(cellml_leaf_name + "*");
 
-            BOOST_FOREACH(const FileFinder& r_cellml_file, cellml_files)
+            for (const FileFinder& r_cellml_file : cellml_files)
             {
                 r_cellml_file.CopyTo(tmp_folder);
             }

--- a/heart/src/problem/AbstractCardiacProblem.cpp
+++ b/heart/src/problem/AbstractCardiacProblem.cpp
@@ -457,7 +457,7 @@ void AbstractCardiacProblem<ELEMENT_DIM, SPACE_DIM, PROBLEM_DIM>::Solve()
     {
         progress_reporter_dir = ""; // progress printed to CHASTE_TEST_OUTPUT
     }
-    BOOST_FOREACH (boost::shared_ptr<AbstractOutputModifier> p_output_modifier, mOutputModifiers)
+    for (boost::shared_ptr<AbstractOutputModifier> p_output_modifier : mOutputModifiers)
     {
         p_output_modifier->InitialiseAtStart(this->mpMesh->GetDistributedVectorFactory(), this->mpMesh->rGetNodePermutation());
         p_output_modifier->ProcessSolutionAtTimeStep(stepper.GetTime(), initial_condition, PROBLEM_DIM);
@@ -549,7 +549,7 @@ void AbstractCardiacProblem<ELEMENT_DIM, SPACE_DIM, PROBLEM_DIM>::Solve()
             HeartEventHandler::EndEvent(HeartEventHandler::WRITE_OUTPUT);
         }
 
-        BOOST_FOREACH (boost::shared_ptr<AbstractOutputModifier> p_output_modifier, mOutputModifiers)
+        for (boost::shared_ptr<AbstractOutputModifier> p_output_modifier : mOutputModifiers)
         {
             p_output_modifier->ProcessSolutionAtTimeStep(stepper.GetTime(), mSolution, PROBLEM_DIM);
         }
@@ -575,7 +575,7 @@ void AbstractCardiacProblem<ELEMENT_DIM, SPACE_DIM, PROBLEM_DIM>::Solve()
 
     // Close the file that stores voltage values
     progress_reporter.PrintFinalising();
-    BOOST_FOREACH (boost::shared_ptr<AbstractOutputModifier> p_output_modifier, mOutputModifiers)
+    for (boost::shared_ptr<AbstractOutputModifier> p_output_modifier : mOutputModifiers)
     {
         p_output_modifier->FinaliseAtEnd();
     }

--- a/heart/test/ionicmodels/CodegenLongHelperTestSuite.hpp
+++ b/heart/test/ionicmodels/CodegenLongHelperTestSuite.hpp
@@ -46,7 +46,6 @@ the CellML files will be downloaded on the cmake step into _deps/cellml_repo-src
 
 #include <algorithm>
 #include <boost/assign/list_of.hpp>
-#include <boost/foreach.hpp>
 #include <cstring>
 #include <iostream>
 #include <vector>
@@ -249,7 +248,7 @@ protected:
     // Returns a list of all models in special_treatment_models that exist in all_models and deletes these models from all_models
     std::vector<std::string> special_treatment_models(std::vector<std::string>& all_models, std::vector<std::string> special_treatment_models)
     {
-        BOOST_FOREACH (std::string model, special_treatment_models)
+        for (std::string model : special_treatment_models)
         {
             auto special_model = std::find(all_models.begin(), all_models.end(), model);
             bool found = special_model != all_models.end();

--- a/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongAnalyticCvode.hpp
+++ b/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongAnalyticCvode.hpp
@@ -38,7 +38,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "CodegenLongHelperTestSuite.hpp"
 
-#include <boost/foreach.hpp>
 #include <vector>
 
 #include "HeartConfig.hpp"

--- a/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongAnalyticCvodeOpt.hpp
+++ b/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongAnalyticCvodeOpt.hpp
@@ -38,7 +38,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "CodegenLongHelperTestSuite.hpp"
 
-#include <boost/foreach.hpp>
 #include <vector>
 
 #include "HeartConfig.hpp"

--- a/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongBackwardEuler.hpp
+++ b/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongBackwardEuler.hpp
@@ -38,7 +38,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "CodegenLongHelperTestSuite.hpp"
 
-#include <boost/foreach.hpp>
 #include <vector>
 
 #include "HeartConfig.hpp"

--- a/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongBackwardEulerOpt.hpp
+++ b/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongBackwardEulerOpt.hpp
@@ -38,7 +38,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "CodegenLongHelperTestSuite.hpp"
 
-#include <boost/foreach.hpp>
 #include <vector>
 
 #include "HeartConfig.hpp"

--- a/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongEasyModels.hpp
+++ b/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongEasyModels.hpp
@@ -38,7 +38,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "CodegenLongHelperTestSuite.hpp"
 
-#include <boost/foreach.hpp>
 #include <vector>
 
 #include "HeartConfig.hpp"

--- a/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongGeneralisedRushLarsenFirstOrder.hpp
+++ b/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongGeneralisedRushLarsenFirstOrder.hpp
@@ -39,7 +39,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cxxtest/TestSuite.h>
 #include "CodegenLongHelperTestSuite.hpp"
 
-#include <boost/foreach.hpp>
 #include <vector>
 
 #include "HeartConfig.hpp"

--- a/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongGeneralisedRushLarsenFirstOrderOpt.hpp
+++ b/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongGeneralisedRushLarsenFirstOrderOpt.hpp
@@ -39,7 +39,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cxxtest/TestSuite.h>
 #include "CodegenLongHelperTestSuite.hpp"
 
-#include <boost/foreach.hpp>
 #include <vector>
 
 #include "HeartConfig.hpp"

--- a/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongGeneralisedRushLarsenSecondOrder.hpp
+++ b/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongGeneralisedRushLarsenSecondOrder.hpp
@@ -38,7 +38,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "CodegenLongHelperTestSuite.hpp"
 
-#include <boost/foreach.hpp>
 #include <vector>
 
 #include "HeartConfig.hpp"

--- a/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongGeneralisedRushLarsenSecondOrderOpt.hpp
+++ b/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongGeneralisedRushLarsenSecondOrderOpt.hpp
@@ -38,7 +38,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "CodegenLongHelperTestSuite.hpp"
 
-#include <boost/foreach.hpp>
 #include <vector>
 
 #include "HeartConfig.hpp"

--- a/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongNormal.hpp
+++ b/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongNormal.hpp
@@ -38,7 +38,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "CodegenLongHelperTestSuite.hpp"
 
-#include <boost/foreach.hpp>
 #include <vector>
 
 #include "HeartConfig.hpp"

--- a/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongNormalOpt.hpp
+++ b/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongNormalOpt.hpp
@@ -38,7 +38,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "CodegenLongHelperTestSuite.hpp"
 
-#include <boost/foreach.hpp>
 #include <vector>
 
 #include "HeartConfig.hpp"

--- a/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongNumericalCvode.hpp
+++ b/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongNumericalCvode.hpp
@@ -38,7 +38,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "CodegenLongHelperTestSuite.hpp"
 
-#include <boost/foreach.hpp>
 #include <vector>
 
 #include "HeartConfig.hpp"

--- a/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongNumericalCvodeOpt.hpp
+++ b/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongNumericalCvodeOpt.hpp
@@ -38,7 +38,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "CodegenLongHelperTestSuite.hpp"
 
-#include <boost/foreach.hpp>
 #include <vector>
 
 #include "HeartConfig.hpp"

--- a/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongRushLarsen.hpp
+++ b/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongRushLarsen.hpp
@@ -38,7 +38,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "CodegenLongHelperTestSuite.hpp"
 
-#include <boost/foreach.hpp>
 #include <vector>
 
 #include "HeartConfig.hpp"

--- a/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongRushLarsenOpt.hpp
+++ b/heart/test/ionicmodels/TestCodegenLong/TestCodegenLongRushLarsenOpt.hpp
@@ -38,7 +38,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "CodegenLongHelperTestSuite.hpp"
 
-#include <boost/foreach.hpp>
 #include <vector>
 
 #include "HeartConfig.hpp"

--- a/lung/src/airway_generation/MultiLobeAirwayGenerator.cpp
+++ b/lung/src/airway_generation/MultiLobeAirwayGenerator.cpp
@@ -34,7 +34,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 
-#include <boost/foreach.hpp>
 #include <map>
 
 #include "MultiLobeAirwayGenerator.hpp"

--- a/mesh/src/common/AbstractTetrahedralMesh.hpp
+++ b/mesh/src/common/AbstractTetrahedralMesh.hpp
@@ -46,7 +46,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 #include <string>
 #include <cassert>
-#include <boost/foreach.hpp>
 
 #include "AbstractMesh.hpp"
 #include "BoundaryElement.hpp"
@@ -160,7 +159,7 @@ private:
                     std::string mesh_leaf_name = mesh_base.GetLeafNameNoExtension();
                     std::vector<FileFinder> mesh_files = mesh_folder.FindMatches(mesh_leaf_name + ".*");
                     FileFinder dest_dir(ArchiveLocationInfo::GetArchiveDirectory());
-                    BOOST_FOREACH(const FileFinder& r_mesh_file, mesh_files)
+                    for (const FileFinder& r_mesh_file : mesh_files)
                     {
                         FileFinder dest_file(ArchiveLocationInfo::GetMeshFilename() + r_mesh_file.GetExtension(),
                                              dest_dir);

--- a/mesh/src/mutable/CylindricalHoneycombMeshGenerator.cpp
+++ b/mesh/src/mutable/CylindricalHoneycombMeshGenerator.cpp
@@ -35,7 +35,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "CylindricalHoneycombMeshGenerator.hpp"
 
-#include <boost/foreach.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/shared_ptr.hpp>
 #include "RandomNumberGenerator.hpp"

--- a/mesh/src/mutable/HoneycombMeshGenerator.cpp
+++ b/mesh/src/mutable/HoneycombMeshGenerator.cpp
@@ -36,7 +36,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "HoneycombMeshGenerator.hpp"
 
-#include <boost/foreach.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/shared_ptr.hpp>
 #include "TrianglesMeshReader.hpp"

--- a/mesh/src/mutable/ToroidalHoneycombMeshGenerator.cpp
+++ b/mesh/src/mutable/ToroidalHoneycombMeshGenerator.cpp
@@ -35,7 +35,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "ToroidalHoneycombMeshGenerator.hpp"
 
-#include <boost/foreach.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/shared_ptr.hpp>
 #include "RandomNumberGenerator.hpp"


### PR DESCRIPTION
Replaces all BOOST_FOREACH(decl, range) usages with standard range-based for (decl : range) loops and removes the #include <boost/foreach.hpp> directives. Removes BOOST_FOREACH from .clang-format ForEachMacros list.

I like this because it is removing a header use, requires less magic knowledge of obscure boost macros.