### PR TITLE
Update base image for regenerating archive

### DIFF
--- a/.github/workflows/regenerate-archive.yml
+++ b/.github/workflows/regenerate-archive.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: chaste/runner:oldest-boost
+      image: chaste/runner:portability-jammy
       env:
         RUNNER_OFF: 1
       volumes:


### PR DESCRIPTION
See #518 

@kwabenantim you're definitely the best person to review this PR. Can you check whether this is likely to work, and advise if there's a better solution?

I think the oldest supported boost will always be on an Ubuntu LTS (unless something strange happens), so it will very likely always be possible to use a portability system image for this.
