### PR TITLE
Fix python wrapper config for new forces

### DIFF
--- a/pychaste/dynamic/config.yaml
+++ b/pychaste/dynamic/config.yaml
@@ -694,7 +694,17 @@ modules:
 
       ##=== cell_based: Chaste/cell_based/src/population/forces
       - name: AbstractForce
+        template_substitutions: &full_force_template_substitutions
+          - signature: <unsigned ELEMENT_DIM, unsigned SPACE_DIM=ELEMENT_DIM>
+            replacement: [[1, 1], [1, 2], [2, 2], [1, 3], [2, 3], [3, 3]]
+
       - name: AbstractTwoBodyInteractionForce
+        template_substitutions: *full_force_template_substitutions
+        source_includes:
+          - PybindUblasTypeCaster.hpp
+
+      - name: AbstractVariableSizeTwoBodyInteractionForce
+        template_substitutions: *full_force_template_substitutions
         source_includes:
           - PybindUblasTypeCaster.hpp
 
@@ -715,14 +725,17 @@ modules:
       - name: FarhadifarForce
 
       - name: LinearSpringForce
+        template_substitutions: *full_force_template_substitutions
         source_includes:
           - PybindUblasTypeCaster.hpp
 
       - name: PathmanathanInteractionForce
+        template_substitutions: *full_force_template_substitutions
         source_includes:
           - PybindUblasTypeCaster.hpp
 
       - name: SimpleLogarithmicRepulsionForce
+        template_substitutions: *full_force_template_substitutions
         source_includes:
           - PybindUblasTypeCaster.hpp
 
@@ -732,7 +745,7 @@ modules:
       - name: ImmersedBoundaryLinearMembraneForce
       - name: ImmersedBoundaryMorseInteractionForce
       - name: ImmersedBoundaryMorseMembraneForce
-      
+
       - name: NagaiHondaForce
 
       - name: WelikyOsterForce
@@ -740,8 +753,10 @@ modules:
           - GetLineTensionParameter
 
       - name: DifferentialAdhesionLinearSpringForce
+        template_substitutions: *full_force_template_substitutions
 
       - name: DifferentialAdhesionPathmanathanInteractionForce
+        template_substitutions: *full_force_template_substitutions
 
       - name: NagaiHondaDifferentialAdhesionForce
         excluded_methods:


### PR DESCRIPTION
### Changes

This adds args in `config.yaml` to generate python wrappers for the full set of required template instantiations. For example, these instantiations:

```cpp
template class LinearSpringForce<1,1>;
template class LinearSpringForce<1,2>;
template class LinearSpringForce<2,2>;
template class LinearSpringForce<1,3>;
template class LinearSpringForce<2,3>;
template class LinearSpringForce<3,3>;
```

need this additional configuration in `config.yaml`:

```yml
- name: LinearSpringForce
  template_substitutions:
    - signature: <unsigned ELEMENT_DIM, unsigned SPACE_DIM=ELEMENT_DIM>
      replacement: [[1, 1], [1, 2], [2, 2], [1, 3], [2, 3], [3, 3]]
```

This is needed if instantiated templates go beyond the standard cases of `<2,2>`, `<3,3>`