### PR TITLE
Petsc gpu support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,7 @@ endif ()
 
 option (Chaste_USE_PETSC_PARMETIS "Prefer to compile Chaste with PARMETIS library used by PETSc" ON)
 option (Chaste_USE_PETSC_HDF5 "Prefer to compile Chaste with HDF5 library used by PETSc" ON)
+option (Chaste_ENABLE_PETSC_CUDA "Default PETSc Mat/Vec objects to CUDA types at runtime (requires a CUDA-enabled PETSc)" OFF)
 
 option (Chaste_UPDATE_PROVENANCE "Update build timestamp. Disable to prevent re-linking of all Chaste libraries" ON)
 
@@ -484,6 +485,17 @@ message(STATUS "PETSc version: ${PETSc_VERSION}")
 target_link_libraries(Chaste_COMMON_DEPS INTERFACE PETSc::PETSc)
 #list(APPEND Chaste_LINK_LIBRARIES "${PETSc_LIBRARIES}")
 list(APPEND Chaste_INCLUDES "${PETSc_INCLUDE_DIRS}")
+
+# If Chaste_ENABLE_PETSC_CUDA is ON, make PETSc mat/vec objects default to CUDA types at runtime
+if (Chaste_ENABLE_PETSC_CUDA)
+    if (NOT PETSc_HAVE_CUDA)
+        message(FATAL_ERROR "Chaste_ENABLE_PETSC_CUDA is ON, but the configured PETSc (version ${PETSc_VERSION}, ${PETSc_INCLUDE_DIRS}) was not built with CUDA support.")
+    endif()
+    set(CHASTE_PETSC_DEFAULT_OPTIONS "-mat_type aijcusparse -vec_type cuda")
+else()
+    set(CHASTE_PETSC_DEFAULT_OPTIONS "")
+endif()
+add_compile_definitions(CHASTE_PETSC_DEFAULT_OPTIONS="${CHASTE_PETSC_DEFAULT_OPTIONS}")
 
 
 ################################

--- a/cmake/Modules/FindPETSc.cmake
+++ b/cmake/Modules/FindPETSc.cmake
@@ -131,6 +131,21 @@ if(PC_PETSc_VERSION)
     unset(_petsc_version_patch)
 endif()
 
+# Detect whether the found PETSc was built with CUDA support, by inspecting petscconf.h
+set(PETSc_HAVE_CUDA FALSE)
+foreach(_petsc_include_dir ${PETSc_INCLUDE_DIRS})
+    if(EXISTS "${_petsc_include_dir}/petscconf.h")
+        file(STRINGS "${_petsc_include_dir}/petscconf.h" _petsc_have_cuda_line REGEX "^#define PETSC_HAVE_CUDA 1")
+        if(_petsc_have_cuda_line)
+            set(PETSc_HAVE_CUDA TRUE)
+        endif()
+        unset(_petsc_have_cuda_line)
+    endif()
+endforeach()
+unset(_petsc_include_dir)
+set(PETSc_HAVE_CUDA ${PETSc_HAVE_CUDA} CACHE BOOL "Whether the found PETSc was built with CUDA support")
+mark_as_advanced(PETSc_HAVE_CUDA)
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(PETSc
     REQUIRED_VARS PETSc_FOUND PETSc_INCLUDE_DIRS PETSc_LIBRARIES

--- a/global/src/ExecutableSupport.cpp
+++ b/global/src/ExecutableSupport.cpp
@@ -120,6 +120,13 @@ void ExecutableSupport::InitializePetsc(int* pArgc, char*** pArgv)
     CommandLineArguments::Instance()->p_argv = pArgv;
     // Initialise PETSc
     PETSCEXCEPT(PetscInitialize(pArgc, pArgv, CHASTE_PETSC_NULLPTR, CHASTE_PETSC_NULLPTR));
+
+    // Configure mat/vec types to use if requested
+    if (CHASTE_PETSC_DEFAULT_OPTIONS[0] != '\0')
+    {
+        // Set by the Chaste_ENABLE_PETSC_CUDA CMake option; makes Mat/Vec objects default to CUDA types.
+        PetscOptionsInsertString(CHASTE_PETSC_NULLPTR, CHASTE_PETSC_DEFAULT_OPTIONS);
+    }
     // Set default output folder
     if (!mOutputDirectory.IsPathSet())
     {

--- a/global/src/fortests/PetscSetupUtils.cpp
+++ b/global/src/fortests/PetscSetupUtils.cpp
@@ -78,6 +78,13 @@ void PetscSetupUtils::InitialisePetsc()
     // The CommandLineArguments instance is filled in by the cxxtest test suite runner.
     CommandLineArguments* p_args = CommandLineArguments::Instance();
     PETSCEXCEPT(PetscInitialize(p_args->p_argc, p_args->p_argv, CHASTE_PETSC_NULLPTR, CHASTE_PETSC_NULLPTR));
+
+    // Configure mat/vec types to use if requested
+    if (CHASTE_PETSC_DEFAULT_OPTIONS[0] != '\0')
+    {
+        // Set by the Chaste_ENABLE_PETSC_CUDA CMake option; makes Mat/Vec objects default to CUDA types.
+        PetscOptionsInsertString(CHASTE_PETSC_NULLPTR, CHASTE_PETSC_DEFAULT_OPTIONS);
+    }
     // Work around what seems to be an Intel compiler bug/quirk that makes the cache stale,
     // by using an explicit reset to ensure all code is aware we're running in parallel.
     PetscTools::ResetCache();

--- a/global/src/parallel/DistributedVectorFactory.cpp
+++ b/global/src/parallel/DistributedVectorFactory.cpp
@@ -167,6 +167,7 @@ Vec DistributedVectorFactory::CreateVec(unsigned stride)
     VecSetBlockSize(vec, stride);
     VecSetSizes(vec, stride*(mHi-mLo), stride*mProblemSize);
     VecSetType(vec,VECMPI);
+    VecSetFromOptions(vec);
     //VecCreateMPIWithArray(PETSC_COMM_WORLD, stride, stride*(mHi-mLo), stride*mProblemSize, CHASTE_PETSC_NULLPTR/*No array*/, &vec);
 #else
     VecCreateMPI(PETSC_COMM_WORLD, stride*(mHi-mLo), stride*mProblemSize, &vec);


### PR DESCRIPTION
Adds support for CUDA-aware PETSc builds. Tested with GTX1070, CUDA 11.3, PETSc 3.19.6

## Usage

- Point chaste to a CUDA enabled PETSc installation
- Configure chaste with the `Chaste_ENABLE_PETSC_CUDA` flag set to `ON`
- CUDA types will be used by default if this flag is set