### PR TITLE
Speed up memtest ci by running continuous test pack across multiple runners

### DIFF
--- a/.github/workflows/memory-testing.yml
+++ b/.github/workflows/memory-testing.yml
@@ -9,6 +9,15 @@ on:
     branches:
       - develop
 
+env:
+  # Read by cmake/process_valgrind_output.py to label the generated report. head_ref and
+  # pull_request.head.sha are only set for pull_request events, so they fall back to the
+  # push/workflow_dispatch equivalents.
+  Chaste_GH_WORKFLOW_BRANCH: ${{ github.head_ref || github.ref_name }}
+  Chaste_GH_WORKFLOW_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  # Core count of the runners used below, for cmake, make and ctest.
+  CHASTE_NUM_CPUS: 4
+
 jobs:
 
   build-and-test:
@@ -17,29 +26,13 @@ jobs:
 
     runs-on: ubuntu-26.04
 
-    # Split the Continuous memory test pack across parallel runners. Each component
-    # builds only the component(s) it needs and runs only the matching tests,
-    # selected via the per-test ctest labels (Continuous_<component>, plus the
-    # Continuous_core label shared by all core components).
+    # Split the Continuous test pack across parallel runners. Each leg builds and
+    # runs exactly one component's Continuous tests, selected by the Continuous_<component>
+    # build target and the matching ctest label.
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - component: cell_based
-            build_target: cell_based
-            label: Continuous_cell_based
-          - component: heart
-            build_target: heart
-            label: Continuous_heart
-          - component: crypt
-            build_target: crypt
-            label: Continuous_crypt
-          - component: lung
-            build_target: lung
-            label: Continuous_lung
-          - component: core
-            build_target: core
-            label: Continuous_core
+        component: [cell_based, heart, crypt, lung, core]
 
     env:
       CHASTE_DIR: ${{ github.workspace }}/Chaste
@@ -48,22 +41,9 @@ jobs:
 
     steps:
 
-      - name: set environment for pull request
-        run: |
-          echo "Chaste_GH_WORKFLOW_BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV
-          echo "Chaste_GH_WORKFLOW_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
-        if: github.event_name == 'pull_request'
-
-      - name: set environment for push or workflow dispatch
-        run: |
-          echo "Chaste_GH_WORKFLOW_BRANCH=${{ github.ref_name }}" >> $GITHUB_ENV
-          echo "Chaste_GH_WORKFLOW_SHA=${{ github.sha }}" >> $GITHUB_ENV
-        if: (github.event_name == 'push') || (github.event_name == 'workflow_dispatch')
-
       - name: checkout Chaste
         uses: actions/checkout@v7
         with:
-          repository: Chaste/Chaste
           path: Chaste
 
       - name: install dependencies
@@ -79,11 +59,11 @@ jobs:
           mkdir -p ${CHASTE_TEST_OUTPUT}
 
       - name: cmake configure
-        run: cmake -DCMAKE_BUILD_TYPE=Debug -DChaste_MEMORY_TESTING_CPUS=4 ..
+        run: cmake -DCMAKE_BUILD_TYPE=Debug -DChaste_MEMORY_TESTING_CPUS=${CHASTE_NUM_CPUS} ..
         working-directory: ${{ env.CHASTE_BUILD_DIR }}
 
-      - name: build component
-        run: cmake --build . --target ${{ matrix.build_target }} --parallel 4
+      - name: build component test pack
+        run: cmake --build . --target Continuous_${{ matrix.component }} --parallel ${CHASTE_NUM_CPUS}
         working-directory: ${{ env.CHASTE_BUILD_DIR }}
 
       - name: run TestChasteBuildInfo
@@ -92,20 +72,10 @@ jobs:
         if: matrix.component == 'core'
 
       - name: run memtest for component
-        # Run this component's tests with valgrind, then process the output. A
-        # non-zero exit from either ctest (a test failed/crashed) or the valgrind
-        # processing (a memory problem was found) fails this component's job.
-        # The raw *_valgrind.txt logs are always produced by ctest and are uploaded
-        # regardless of the outcome below.
-        run: |
-          set +e
-          ctest -j4 -L "${{ matrix.label }}" --output-on-failure
-          ctest_rc=$?
-          python "${CHASTE_DIR}/cmake/process_valgrind_output.py" "${CHASTE_BUILD_DIR}/memtest"
-          process_rc=$?
-          if [ "${ctest_rc}" -ne 0 ] || [ "${process_rc}" -ne 0 ]; then
-            exit 1
-          fi
+        # Run this component's tests under valgrind. This fails the leg only if a test
+        # itself fails or crashes; memory problems are found by the aggregate job below,
+        # which processes the raw logs uploaded here.
+        run: ctest -j${CHASTE_NUM_CPUS} -L Continuous_${{ matrix.component }} --output-on-failure
         working-directory: ${{ env.CHASTE_BUILD_DIR }}
 
       - name: upload component valgrind logs
@@ -139,23 +109,12 @@ jobs:
         id: get-datetime
         run: echo "datetime=$(date +%Y-%m-%d_%H-%M-%S)" >> $GITHUB_OUTPUT
 
-      - name: set environment for pull request
-        run: |
-          echo "Chaste_GH_WORKFLOW_BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV
-          echo "Chaste_GH_WORKFLOW_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
-        if: github.event_name == 'pull_request'
-
-      - name: set environment for push or workflow dispatch
-        run: |
-          echo "Chaste_GH_WORKFLOW_BRANCH=${{ github.ref_name }}" >> $GITHUB_ENV
-          echo "Chaste_GH_WORKFLOW_SHA=${{ github.sha }}" >> $GITHUB_ENV
-        if: (github.event_name == 'push') || (github.event_name == 'workflow_dispatch')
-
-      - name: checkout Chaste
+      - name: checkout valgrind output processor
         uses: actions/checkout@v7
         with:
-          repository: Chaste/Chaste
           path: Chaste
+          sparse-checkout: cmake/process_valgrind_output.py
+          sparse-checkout-cone-mode: false
 
       - name: download all component logs
         uses: actions/download-artifact@v8
@@ -165,10 +124,10 @@ jobs:
           merge-multiple: true
 
       - name: process combined valgrind output
-        # Regenerate the combined index/summaries over the merged logs from every
-        # component. This is the authoritative pass/fail: a non-zero exit here (a
-        # memory problem in any component) fails the workflow.
-        run: python "${{ github.workspace }}/Chaste/cmake/process_valgrind_output.py" "${MEMTEST_DIR}"
+        # Generate the index/summaries over the merged logs from every component. This is
+        # the authoritative pass/fail: a non-zero exit here (a memory problem in any
+        # component) fails the workflow.
+        run: python3 "${{ github.workspace }}/Chaste/cmake/process_valgrind_output.py" "${MEMTEST_DIR}"
 
       - name: check if index file successfully created
         id: index-exists
@@ -206,9 +165,11 @@ jobs:
 
     name: Publish results (non-fork PRs only)
     needs: aggregate
-    runs-on: ubuntu-latest
-    # only when index exists AND it's being run from the primary repo (Chaste/Chaste)
-    if: ${{ needs.aggregate.outputs.index == 'True' && github.repository == 'Chaste/Chaste' }}
+    runs-on: ubuntu-26.04
+    # Publish whenever a report was produced, including when the aggregate job failed
+    # because a memory problem was found - those are the results most worth publishing.
+    # Only from the primary repo (Chaste/Chaste), which holds the push token.
+    if: ${{ !cancelled() && needs.aggregate.outputs.index == 'True' && github.repository == 'Chaste/Chaste' }}
 
     env:
       MEMTEST_DIR: ${{ github.workspace }}/memory-testing

--- a/.github/workflows/memory-testing.yml
+++ b/.github/workflows/memory-testing.yml
@@ -15,7 +15,7 @@ jobs:
 
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:off') }}
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
 
     # Split the Continuous memory test pack across parallel runners. Each component
     # builds only the component(s) it needs and runs only the matching tests,
@@ -61,24 +61,17 @@ jobs:
         if: (github.event_name == 'push') || (github.event_name == 'workflow_dispatch')
 
       - name: checkout Chaste
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: Chaste/Chaste
           path: Chaste
 
       - name: install dependencies
         run: |
-          echo 'deb [signed-by=/usr/share/keyrings/chaste.asc] https://chaste.github.io/ubuntu jammy/' | sudo tee -a /etc/apt/sources.list.d/chaste.list
+          echo 'deb [signed-by=/usr/share/keyrings/chaste.asc] https://chaste.github.io/ubuntu resolute/' | sudo tee -a /etc/apt/sources.list.d/chaste.list
           sudo wget -O /usr/share/keyrings/chaste.asc https://chaste.github.io/chaste.asc
           sudo apt update
           sudo apt install chaste-dependencies
-
-      - name: Downgrade libexpat1 (native ubuntu-22.04 only)
-        # if: ${{ matrix.os == 'ubuntu-22.04' }}
-        run: |
-          if dpkg -l | grep libexpat1-dev | grep 2.4.7-1ubuntu; then
-            sudo apt-get install -y --allow-downgrades libexpat1=2.4.7-1 libexpat1-dev=2.4.7-1
-          fi
 
       - name: make build and test directories
         run: |
@@ -127,7 +120,7 @@ jobs:
 
     name: Aggregate memtest results
     needs: build-and-test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     # Run even if one or more components failed (e.g. found a leak), so the combined
     # report is always produced. Skip only if the whole run was cancelled or CI
     # is disabled for this PR.
@@ -159,7 +152,7 @@ jobs:
         if: (github.event_name == 'push') || (github.event_name == 'workflow_dispatch')
 
       - name: checkout Chaste
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: Chaste/Chaste
           path: Chaste
@@ -229,7 +222,7 @@ jobs:
           path: ./memtest
 
       - name: checkout memory-testing
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: Chaste/memory-testing
           path: memory-testing
@@ -242,7 +235,7 @@ jobs:
           cp ./memtest/* ${MEMTEST_DIR}/log-files/${{ needs.aggregate.outputs.datetime }}/
 
       - name: setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.x'
 

--- a/.github/workflows/memory-testing.yml
+++ b/.github/workflows/memory-testing.yml
@@ -17,20 +17,36 @@ jobs:
 
     runs-on: ubuntu-22.04
 
+    # Split the Continuous memory test pack across parallel runners. Each component
+    # builds only the component(s) it needs and runs only the matching tests,
+    # selected via the per-test ctest labels (Continuous_<component>, plus the
+    # Continuous_core label shared by all core components).
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - component: cell_based
+            build_target: cell_based
+            label: Continuous_cell_based
+          - component: heart
+            build_target: heart
+            label: Continuous_heart
+          - component: crypt
+            build_target: crypt
+            label: Continuous_crypt
+          - component: lung
+            build_target: lung
+            label: Continuous_lung
+          - component: core
+            build_target: core
+            label: Continuous_core
+
     env:
       CHASTE_DIR: ${{ github.workspace }}/Chaste
       CHASTE_TEST_OUTPUT: ${{ github.workspace }}/chaste-test-dir
       CHASTE_BUILD_DIR: ${{ github.workspace }}/Chaste/chaste-build-dir
 
-    outputs:
-      index: ${{ steps.index-exists.outputs.index }}
-      datetime: ${{ steps.get-datetime.outputs.datetime }}
-
     steps:
-
-      - name: get current datetime
-        id: get-datetime
-        run: echo "datetime=$(date +%Y-%m-%d_%H-%M-%S)" >> $GITHUB_OUTPUT
 
       - name: set environment for pull request
         run: |
@@ -73,64 +89,133 @@ jobs:
         run: cmake -DCMAKE_BUILD_TYPE=Debug -DChaste_MEMORY_TESTING_CPUS=4 ..
         working-directory: ${{ env.CHASTE_BUILD_DIR }}
 
-      - name: build continuous test pack
-        run: cmake --build . --target Continuous --parallel 4
+      - name: build component
+        run: cmake --build . --target ${{ matrix.build_target }} --parallel 4
         working-directory: ${{ env.CHASTE_BUILD_DIR }}
 
       - name: run TestChasteBuildInfo
+        run: ctest -V -R TestChasteBuildInfo
+        working-directory: ${{ env.CHASTE_BUILD_DIR }}
+        if: matrix.component == 'core'
+
+      - name: run memtest for component
+        # Run this component's tests with valgrind, then process the output. A
+        # non-zero exit from either ctest (a test failed/crashed) or the valgrind
+        # processing (a memory problem was found) fails this component's job.
+        # The raw *_valgrind.txt logs are always produced by ctest and are uploaded
+        # regardless of the outcome below.
         run: |
-          ctest -V -R TestChasteBuildInfo
+          set +e
+          ctest -j4 -L "${{ matrix.label }}" --output-on-failure
+          ctest_rc=$?
+          python "${CHASTE_DIR}/cmake/process_valgrind_output.py" "${CHASTE_BUILD_DIR}/memtest"
+          process_rc=$?
+          if [ "${ctest_rc}" -ne 0 ] || [ "${process_rc}" -ne 0 ]; then
+            exit 1
+          fi
         working-directory: ${{ env.CHASTE_BUILD_DIR }}
 
-      - name: run memtest
-        run: cmake --build . --target memtest --parallel 4
-        working-directory: ${{ env.CHASTE_BUILD_DIR }}
+      - name: upload component valgrind logs
+        uses: actions/upload-artifact@v7
+        with:
+          name: memtest-logs-${{ matrix.component }}
+          path: ${{ env.CHASTE_BUILD_DIR }}/memtest/*_valgrind.txt
+        if: always()
+
+
+  aggregate:
+
+    name: Aggregate memtest results
+    needs: build-and-test
+    runs-on: ubuntu-22.04
+    # Run even if one or more components failed (e.g. found a leak), so the combined
+    # report is always produced. Skip only if the whole run was cancelled or CI
+    # is disabled for this PR.
+    if: ${{ !cancelled() && !contains(github.event.pull_request.labels.*.name, 'ci:off') }}
+
+    env:
+      MEMTEST_DIR: ${{ github.workspace }}/memtest
+
+    outputs:
+      index: ${{ steps.index-exists.outputs.index }}
+      datetime: ${{ steps.get-datetime.outputs.datetime }}
+
+    steps:
+
+      - name: get current datetime
+        id: get-datetime
+        run: echo "datetime=$(date +%Y-%m-%d_%H-%M-%S)" >> $GITHUB_OUTPUT
+
+      - name: set environment for pull request
+        run: |
+          echo "Chaste_GH_WORKFLOW_BRANCH=${{ github.head_ref }}" >> $GITHUB_ENV
+          echo "Chaste_GH_WORKFLOW_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+        if: github.event_name == 'pull_request'
+
+      - name: set environment for push or workflow dispatch
+        run: |
+          echo "Chaste_GH_WORKFLOW_BRANCH=${{ github.ref_name }}" >> $GITHUB_ENV
+          echo "Chaste_GH_WORKFLOW_SHA=${{ github.sha }}" >> $GITHUB_ENV
+        if: (github.event_name == 'push') || (github.event_name == 'workflow_dispatch')
+
+      - name: checkout Chaste
+        uses: actions/checkout@v6
+        with:
+          repository: Chaste/Chaste
+          path: Chaste
+
+      - name: download all component logs
+        uses: actions/download-artifact@v8
+        with:
+          pattern: memtest-logs-*
+          path: ${{ env.MEMTEST_DIR }}
+          merge-multiple: true
+
+      - name: process combined valgrind output
+        # Regenerate the combined index/summaries over the merged logs from every
+        # component. This is the authoritative pass/fail: a non-zero exit here (a
+        # memory problem in any component) fails the workflow.
+        run: python "${{ github.workspace }}/Chaste/cmake/process_valgrind_output.py" "${MEMTEST_DIR}"
 
       - name: check if index file successfully created
         id: index-exists
         run: |
-          if [ -e ${CHASTE_BUILD_DIR}/memtest/index.html ]; then
-            echo "Index file exists"
+          if [ -e ${MEMTEST_DIR}/index.html ]; then
             echo "index=True"  >> $GITHUB_OUTPUT
           else
-            echo "Index file does not exist"
             echo "index=False"  >> $GITHUB_OUTPUT
           fi
-          if [ -e ${CHASTE_BUILD_DIR}/memtest/github_summary.md ]; then
+          if [ -e ${MEMTEST_DIR}/github_summary.md ]; then
             echo "github_summary=True"  >> $GITHUB_OUTPUT
           fi
-          if [ -e ${CHASTE_BUILD_DIR}/memtest/txt_summary.txt ]; then
+          if [ -e ${MEMTEST_DIR}/txt_summary.txt ]; then
             echo "txt_summary=True"  >> $GITHUB_OUTPUT
           fi
         if: always()
 
       - name: display memtest summary in terminal
-        working-directory: ${{ env.CHASTE_BUILD_DIR }}
-        run: |
-          cat memtest/txt_summary.txt
+        run: cat ${MEMTEST_DIR}/txt_summary.txt
         if: always() && steps.index-exists.outputs.txt_summary == 'True'
 
       - name: display memtest summary in job summary
-        working-directory: ${{ env.CHASTE_BUILD_DIR }}
-        run: |
-          cat memtest/github_summary.md >> $GITHUB_STEP_SUMMARY
+        run: cat ${MEMTEST_DIR}/github_summary.md >> $GITHUB_STEP_SUMMARY
         if: always() && steps.index-exists.outputs.github_summary == 'True'
 
       - name: upload memtest artifact
         uses: actions/upload-artifact@v7
         with:
           name: memtest-files
-          path: ${{ env.CHASTE_BUILD_DIR }}/memtest
+          path: ${{ env.MEMTEST_DIR }}
         if: always() && steps.index-exists.outputs.index == 'True'
 
 
   publish-results:
 
     name: Publish results (non-fork PRs only)
-    needs: build-and-test
+    needs: aggregate
     runs-on: ubuntu-latest
     # only when index exists AND it's being run from the primary repo (Chaste/Chaste)
-    if: ${{ needs.build-and-test.outputs.index == 'True' && github.repository == 'Chaste/Chaste' }}
+    if: ${{ needs.aggregate.outputs.index == 'True' && github.repository == 'Chaste/Chaste' }}
 
     env:
       MEMTEST_DIR: ${{ github.workspace }}/memory-testing
@@ -153,8 +238,8 @@ jobs:
 
       - name: copy results
         run: |
-          mkdir ${MEMTEST_DIR}/log-files/${{ needs.build-and-test.outputs.datetime }}
-          cp ./memtest/* ${MEMTEST_DIR}/log-files/${{ needs.build-and-test.outputs.datetime }}/
+          mkdir ${MEMTEST_DIR}/log-files/${{ needs.aggregate.outputs.datetime }}
+          cp ./memtest/* ${MEMTEST_DIR}/log-files/${{ needs.aggregate.outputs.datetime }}/
 
       - name: setup python
         uses: actions/setup-python@v6
@@ -179,4 +264,4 @@ jobs:
 
       - name: results URL on chaste.github.io
         run: |
-          echo https://chaste.github.io/memory-testing/${{ steps.get-datetime.outputs.datetime }}/index.html
+          echo https://chaste.github.io/memory-testing/${{ needs.aggregate.outputs.datetime }}/index.html

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -614,6 +614,12 @@ endforeach ()
 foreach (component ${Chaste_COMPONENTS})
     # ${component} target will build library and tests
     add_custom_target (${component})
+    # ${type}_${component} targets build only one test pack of one component, e.g.
+    # Continuous_cell_based. This lets CI build exactly the tests it is about to run,
+    # rather than every test pack of that component via the ${component} target.
+    foreach (type ${TestPackTypes})
+        add_custom_target (${type}_${component})
+    endforeach ()
     # chaste_${component} is the actual library target
     list (APPEND Chaste_ALL_LIBRARIES chaste_${component})
 endforeach ()
@@ -663,6 +669,16 @@ set (Chaste_DEPENDS_all_components ${Chaste_COMPONENTS})
 # Set dependencies for custom targets
 add_dependencies (core ${Chaste_DEPENDS_core})
 add_dependencies (all_components ${Chaste_DEPENDS_all_components})
+
+# Per-test-pack equivalents of the core target, e.g. Continuous_core builds the Continuous
+# tests of every core component. These match the ${type}_core test labels, so CI can use the
+# same name for the build target and the ctest label.
+foreach (type ${TestPackTypes})
+    add_custom_target (${type}_core)
+    foreach (component ${Chaste_DEPENDS_core})
+        add_dependencies (${type}_core ${type}_${component})
+    endforeach ()
+endforeach ()
 
 foreach (component ${Chaste_COMPONENTS})
     set (Chaste_${component}_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/${component}/src")

--- a/chaste.supp
+++ b/chaste.supp
@@ -47,6 +47,30 @@
    ...
    fun:orte_init
 }
+# OpenMPI 5 replaced ORTE with PRRTE/PMIx. The PMIx client caches attribute strings on its
+# own progress thread; they are children of an allocation that is itself suppressed above,
+# so they are reported as an indirect loss with no parent. Note this requires 'indirect' to
+# be in --errors-for-leak-kinds (see cmake/Modules/ChasteMacros.cmake), as valgrind only
+# consults the suppression files for leak kinds that it treats as errors.
+{
+   PMIx progress thread attribute strings
+   Memcheck:Leak
+   match-leak-kinds: indirect
+   fun:malloc
+   fun:strdup
+   fun:pmix_bfrops_base_value_load
+}
+# OpenMPI 5 selects its byte-transport layer through UCX, which probes every installed
+# transport including ROCm. The ROCm probe leaks whether or not any GPU is present.
+# The existing PetscInitialize rules below cover malloc/calloc/realloc but not operator new.
+{
+   PetscInitialize    mpi_init (operator new)
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   ...
+   fun:PetscInitialize
+}
 # HDF5
 ######
 {
@@ -138,6 +162,19 @@
    socketcall.getsockopt(optlen_out)
    ...
    fun:PetscInitialize
+}
+# VTK / oneTBB
+##############
+# VTK 9.5 uses oneTBB as the backend for vtkSMPTools. Its worker threads are still running
+# at exit, so valgrind reports their stacks and TLS blocks as possibly lost.
+{
+   VTK oneTBB worker thread stacks
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   ...
+   fun:pthread_create*
+   obj:*/libtbb.so*
 }
 # Tetgen
 ########

--- a/cmake/Modules/ChasteMacros.cmake
+++ b/cmake/Modules/ChasteMacros.cmake
@@ -583,6 +583,10 @@ macro(Chaste_DO_TEST_COMMON component)
                     # if the test has already been defined, add it to this test pack
                     get_property(test_labels TEST ${testTargetName} PROPERTY LABELS)
                     list(APPEND test_labels ${type}_${component})
+                    list(FIND Chaste_DEPENDS_core ${component} _core_component_index)
+                    if (NOT _core_component_index EQUAL -1)
+                        list(APPEND test_labels ${type}_core)
+                    endif ()
                     set_property(TEST ${testTargetName} PROPERTY LABELS "${test_labels}")
 
                 else()
@@ -598,7 +602,16 @@ macro(Chaste_DO_TEST_COMMON component)
                     endif()
 
 
-                    set_property(TEST ${testTargetName} PROPERTY LABELS ${type}_${component})
+                    # Every test is labelled <testpack>_<component>. Tests belonging to a
+                    # "core" component (see Chaste_DEPENDS_core) additionally get a
+                    # <testpack>_core label, so that e.g. `ctest -L Continuous_core` selects
+                    # all core-component tests in one go.
+                    set (_test_labels ${type}_${component})
+                    list (FIND Chaste_DEPENDS_core ${component} _core_component_index)
+                    if (NOT _core_component_index EQUAL -1)
+                        list (APPEND _test_labels ${type}_core)
+                    endif ()
+                    set_property(TEST ${testTargetName} PROPERTY LABELS ${_test_labels})
 
                     if (Chaste_INSTALL_TESTS AND NOT(${component} MATCHES "^project"))
                         install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${old_testTargetName}.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/${filename}"

--- a/cmake/Modules/ChasteMacros.cmake
+++ b/cmake/Modules/ChasteMacros.cmake
@@ -661,6 +661,11 @@ macro(Chaste_DO_TEST_COMMON component)
                 if ((NOT ${component} STREQUAL python) AND (NOT (${filename} MATCHES ".py$")))
                     add_dependencies(${component} ${exeTargetName})
                     add_dependencies(${type} ${exeTargetName})
+                    # ...and to the combined target for this test pack of this component,
+                    # so that e.g. Continuous_cell_based builds only what it will run.
+                    if (TARGET ${type}_${component})
+                        add_dependencies(${type}_${component} ${exeTargetName})
+                    endif()
                 endif()
             endforeach(filename ${testpack})
         endif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${type}TestPack.txt")

--- a/cmake/Modules/ChasteMacros.cmake
+++ b/cmake/Modules/ChasteMacros.cmake
@@ -185,6 +185,10 @@ macro(Chaste_ADD_TEST _testTargetName _filename)
         set(test_command ${VALGRIND_COMMAND})
         set(test_args "--tool=memcheck --log-file=${Chaste_MEMORY_TESTING_OUTPUT_DIR}/${_testname}_valgrind.txt")
         set(test_args "${test_args} --track-fds=yes --leak-check=yes --num-callers=50 ${Chaste_MEMORY_TESTING_SUPPS}")
+        # By default valgrind neither shows indirect losses nor treats them as errors, which
+        # means they can never be matched against the suppression files but are still counted
+        # in the leak summary. Including them here makes them both visible and suppressible.
+        set(test_args "${test_args} --show-leak-kinds=definite,indirect,possible --errors-for-leak-kinds=definite,indirect,possible")
         set(test_args "${test_args} --gen-suppressions=all $<TARGET_FILE:${exeTargetName}> -malloc_debug -malloc_dump -memory_info")
         set(num_cpus 1)
     elseif (Chaste_PROFILE_GPROF OR Chaste_PROFILE_GPERFTOOLS)

--- a/cmake/process_valgrind_output.py
+++ b/cmake/process_valgrind_output.py
@@ -86,8 +86,14 @@ class ProcessValgrind:
         uninit = re.compile(
             r'==\d+== (Conditional jump or move depends on uninitialised value\(s\)|Use of uninitialised value)')
         open_files = re.compile(
-            r'==(\d+)== Open (?:file descriptor|AF_UNIX socket) (?![012])(\d+): (?!(?:/home/bob/eclipse/lockfile|/dev/urandom))(.*)')
-        orte_init = re.compile(r'==(\d+)==    (?:by|at) .*(: orte_init)?.*')
+            r'==(\d+)== Open (?:file descriptor|AF_UNIX socket) (\d+):\s*(.*)')
+        ignored_files = ('/home/bob/eclipse/lockfile', '/dev/urandom')
+        # Frames indicating that an open file descriptor belongs to MPI/PETSc start-up rather
+        # than to Chaste. OpenMPI 4 and earlier went through orte_init; OpenMPI 5 replaced
+        # ORTE with PRRTE/PMIx, so match the surrounding init frames as well.
+        mpi_init = re.compile(
+            r'==\d+==\s+(?:by|at) .*(?:orte_init|opal_init|ompi_mpi_init|ompi_mpi_instance_init'
+            r'|ompi_rte_init|PMPI_Init_thread|PetscInitialize)')
         test_killed = 'Test killed due to exceeding time limit'
 
         if output_lines is None:
@@ -138,13 +144,13 @@ class ProcessValgrind:
                 break
 
             m = open_files.match(output_lines[lineno])
-            if m:
+            if m and int(m.group(2)) > 2 and m.group(3).strip() not in ignored_files:
                 # There's a file open that shouldn't be.
                 # Descriptors 0, 1 and 2 are ok, as are names /dev/urandom
                 # and /home/bob/eclipse/lockfile, and the log files.
                 # All these OK files are inherited from the parent process.
                 if (not output_lines[lineno + 1].strip().endswith("<inherited from parent>")
-                        and not self._check_openmpi_file(output_lines, lineno + 1, orte_init)):
+                        and not self._check_openmpi_file(output_lines, lineno + 1, mpi_init)):
                     _status = 'Openfile'
                     break
         if _status == 'Unknown':
@@ -153,18 +159,20 @@ class ProcessValgrind:
 
     @staticmethod
     def _check_openmpi_file(output_lines, lineno, regexp):
-        """Check whether a purported open file is actually something from OpenMPI."""
-        result = False
-        m = regexp.match(output_lines[lineno])
-        while m:
-            if m and m.group(1):
-                result = True
-                break
-            if not m:
-                break
+        """
+        Check whether a purported open file is actually something from OpenMPI.
+
+        Walks the stack trace starting at lineno, looking for a frame matching regexp. Note
+        that the previous implementation tested the pid group of its match rather than the
+        frame name, so it returned True for any stack at all and no open file was ever
+        reported.
+        """
+        frame = re.compile(r'==\d+==\s+(?:by|at) ')
+        while lineno < len(output_lines) and frame.match(output_lines[lineno]):
+            if regexp.match(output_lines[lineno]):
+                return True
             lineno += 1
-            m = regexp.match(output_lines[lineno])
-        return result
+        return False
 
     @staticmethod
     def get_html_head():

--- a/ode/src/common/AbstractCvodeSystem.cpp
+++ b/ode/src/common/AbstractCvodeSystem.cpp
@@ -176,6 +176,9 @@ AbstractCvodeSystem::AbstractCvodeSystem(unsigned numberOfStateVariables)
           mHasAnalyticJacobian(false),
           mUseAnalyticJacobian(false),
           mpCvodeMem(nullptr),
+#if CHASTE_SUNDIALS_VERSION >= 60000
+          mpSundialsContextManager(CvodeContextManager::Instance()),
+#endif
           mMaxSteps(0),
           mLastInternalStepSize(0)
 {

--- a/ode/src/common/AbstractCvodeSystem.hpp
+++ b/ode/src/common/AbstractCvodeSystem.hpp
@@ -38,6 +38,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define _ABSTRACTCVODESYSTEM_HPP_
 
 #include <algorithm>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -46,6 +47,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // Chaste includes
 #include "AbstractParameterisedSystem.hpp"
+#include "CvodeContextManager.hpp"
 #include "Exception.hpp"
 #include "OdeSolution.hpp"
 #include "VectorHelperFunctions.hpp"
@@ -299,6 +301,14 @@ protected:
 
     /** CVODE's internal data. */
     void* mpCvodeMem;
+
+#if CHASTE_SUNDIALS_VERSION >= 60000
+    /**
+     * Shared ownership of the SUNContext this system's Sundials objects were created
+     * against, to guarantee the context outlives them. See CvodeContextManager.
+     */
+    std::shared_ptr<CvodeContextManager> mpSundialsContextManager;
+#endif
 
     /**
      * The maximum number of steps to be taken by the solver

--- a/ode/src/common/CvodeContextManager.cpp
+++ b/ode/src/common/CvodeContextManager.cpp
@@ -56,11 +56,18 @@ CvodeContextManager::~CvodeContextManager()
     SUNContext_Free(&mSundialsContext);
 }
 
-CvodeContextManager* CvodeContextManager::Instance()
+std::shared_ptr<CvodeContextManager> CvodeContextManager::Instance()
 {
-    // Single instance per thread
-    static thread_local std::unique_ptr<CvodeContextManager> instance = std::unique_ptr<CvodeContextManager>(new CvodeContextManager());
-    return instance.get();
+    // Single instance per thread. Ownership is shared rather than exclusive because the
+    // context has to outlive everything created against it: thread-local destructors run at
+    // the start of exit(), before the destructors of static objects in shared libraries, and
+    // some of those statics (e.g. CellCycleModelOdeSolver's mpInstance) still hold a
+    // CvodeAdaptor whose destructor calls CVodeFree(). Freeing the context when the thread
+    // goes away would therefore be a use-after-free at exit, which Sundials 7 detects via
+    // SUNContext_PeekLastError. Note that make_shared cannot be used here as the constructor
+    // is private.
+    static thread_local std::shared_ptr<CvodeContextManager> p_instance(new CvodeContextManager());
+    return p_instance;
 }
 
 SUNContext& CvodeContextManager::GetSundialsContext()

--- a/ode/src/common/CvodeContextManager.hpp
+++ b/ode/src/common/CvodeContextManager.hpp
@@ -47,8 +47,15 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * by Sundials 6.0 and above.
  *
  * This class is a singleton and an instance should be retrieved with:
- * CvodeContextManager* ctx = CvodeContextManager::Instance();
+ * std::shared_ptr<CvodeContextManager> ctx = CvodeContextManager::Instance();
  *
+ * There is one instance per thread, since a SUNContext may not be shared between threads.
+ * Ownership is shared: Sundials requires that every object created against a context is
+ * freed before the context itself, but the context is created lazily on first use and so
+ * would otherwise be torn down before the longer-lived objects that refer to it. Any class
+ * holding Sundials resources should therefore keep a copy of the pointer returned here for
+ * as long as it holds those resources, which keeps the context alive until the last user
+ * has gone.
  */
 class CvodeContextManager
 {
@@ -73,13 +80,16 @@ public:
     SUNContext& GetSundialsContext();
 
     /**
-     * @return a pointer to the context manager object.
-     * The object is created the first time this method is called.
+     * @return a shared pointer to the context manager object for the calling thread.
+     * The object is created the first time this method is called on that thread, and is
+     * destroyed once the thread has exited and every holder of the returned pointer has
+     * released it.
      */
-    static CvodeContextManager* Instance();
+    static std::shared_ptr<CvodeContextManager> Instance();
 
     /**
-     * Public destructor is only called when singleton goes out of scope (e.g. end of test-suite)
+     * Public destructor is only called when the last holder of the shared pointer returned
+     * by Instance() releases it.
      */
     ~CvodeContextManager();
 };

--- a/ode/src/solver/CvodeAdaptor.cpp
+++ b/ode/src/solver/CvodeAdaptor.cpp
@@ -575,6 +575,9 @@ void CvodeAdaptor::Solve(AbstractOdeSystem* pOdeSystem,
 CvodeAdaptor::CvodeAdaptor(double relTol, double absTol)
         : AbstractIvpOdeSolver(),
           mpCvodeMem(nullptr),
+#if CHASTE_SUNDIALS_VERSION >= 60000
+          mpSundialsContextManager(CvodeContextManager::Instance()),
+#endif
           mRelTol(relTol),
           mAbsTol(absTol),
           mLastInternalStepSize(-0.0),

--- a/ode/src/solver/CvodeAdaptor.hpp
+++ b/ode/src/solver/CvodeAdaptor.hpp
@@ -37,12 +37,14 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef _CVODEADAPTOR_HPP_
 #define _CVODEADAPTOR_HPP_
 
+#include <memory>
 #include <vector>
 
 #include <boost/serialization/base_object.hpp>
 #include "ChasteSerialization.hpp"
 
 #include "AbstractIvpOdeSolver.hpp"
+#include "CvodeContextManager.hpp"
 #include "OdeSolution.hpp"
 
 // CVODE headers
@@ -137,6 +139,14 @@ private:
 
     /** Pointer to the CVODE memory block. */
     void* mpCvodeMem;
+
+#if CHASTE_SUNDIALS_VERSION >= 60000
+    /**
+     * Shared ownership of the SUNContext this solver's Sundials objects were created
+     * against, to guarantee the context outlives them. See CvodeContextManager.
+     */
+    std::shared_ptr<CvodeContextManager> mpSundialsContextManager;
+#endif
 
     /** The CVODE data structure. */
     CvodeData mData;


### PR DESCRIPTION
See #584 

Split up the memory testing into `[cell_based, heart, crypt, lung, core]` and combine the results at the end. This should reduce runtime substantially.

Note that I've cherrypicked some commits from #581 as part of this work.