### PR TITLE
Disable branch coverage

### DIFF
--- a/cmake/Config/lcovrc
+++ b/cmake/Config/lcovrc
@@ -80,9 +80,17 @@ genhtml_sort = 1
 # --no-func-coverage option of genhtml)
 genhtml_function_coverage = 1
 
-# Include branch coverage data display (can be disabled by the
-# --no-branch-coverage option of genhtml)
-genhtml_branch_coverage = 1
+# Report line coverage only, not branch coverage.
+#
+# This must be spelled `branch_coverage`, not the old `genhtml_branch_coverage`. Under
+# lcov 1.x the latter affected genhtml alone, so `lcov --capture` emitted no BRDA records.
+# lcov 2.x consolidated the per-tool settings and aliases the old name onto this global
+# one (see %deprecated_rc in lcov's lib/lcovutil.pm), so setting it to 1 also switched on
+# branch capture: BRDA records then appear in coverage.info and codecov reports lines
+# whose branches are not all taken as "partial".
+#
+# Turning this off also reduces lcov's memory and CPU use and the size of coverage.info.
+branch_coverage = 0
 
 # Location of the gcov tool (same as --gcov-info option of geninfo)
 #geninfo_gcov_tool = gcov


### PR DESCRIPTION
New lcov defaults meant we were uploading branch coverage rather than just line coverage.

A discussion for another day about whether this is a better metric, but for now this change should mean we're comparable to prior coverage info.

Minor fix on top of #599 