### PR TITLE
#486 NodeAttribute to make TestRepresentative3dNodeBasedSimulation quicker

### DIFF
--- a/cell_based/src/population/NodeBasedCellPopulation.cpp
+++ b/cell_based/src/population/NodeBasedCellPopulation.cpp
@@ -391,11 +391,9 @@ std::set<unsigned> NodeBasedCellPopulation<DIM>::GetNodesWithinNeighbourhoodRadi
     }
 
     // Get set of 'candidate' neighbours.
-    std::vector<unsigned>& near_nodes = p_node_i->rGetNeighbours();
-
     // Find which ones are actually close
-    for (std::vector<unsigned>::iterator iter = near_nodes.begin();
-         iter != near_nodes.end();
+    for ( auto iter = p_node_i->getNeighboursBegin(); 
+	  iter != p_node_i->getNeighboursEnd(); 
          ++iter)
     {
         // Be sure not to return the index itself.
@@ -448,11 +446,9 @@ std::set<unsigned> NodeBasedCellPopulation<DIM>::GetNeighbouringNodeIndices(unsi
     }
 
     // Get set of 'candidate' neighbours
-    std::vector<unsigned>& near_nodes = p_node_i->rGetNeighbours();
-
     // Find which ones are actually close
-    for (std::vector<unsigned>::iterator iter = near_nodes.begin();
-         iter != near_nodes.end();
+    for (auto iter = p_node_i->getNeighboursBegin();
+         iter != p_node_i->getNeighboursEnd();
          ++iter)
     {
         // Be sure not to return the index itself

--- a/cell_based/src/population/NodeBasedCellPopulation.cpp
+++ b/cell_based/src/population/NodeBasedCellPopulation.cpp
@@ -392,8 +392,8 @@ std::set<unsigned> NodeBasedCellPopulation<DIM>::GetNodesWithinNeighbourhoodRadi
 
     // Get set of 'candidate' neighbours.
     // Find which ones are actually close
-    for ( auto iter = p_node_i->getNeighboursBegin(); 
-	  iter != p_node_i->getNeighboursEnd(); 
+    for ( auto iter = p_node_i->getNeighboursBegin();
+      iter != p_node_i->getNeighboursEnd();
          ++iter)
     {
         // Be sure not to return the index itself.

--- a/mesh/src/common/Node.cpp
+++ b/mesh/src/common/Node.cpp
@@ -373,7 +373,7 @@ bool Node<SPACE_DIM>::GetNeighboursSetUp()
 };
 
 template<unsigned SPACE_DIM>
-std::vector<unsigned>& Node<SPACE_DIM>::rGetNeighbours()
+std::vector<unsigned> Node<SPACE_DIM>::rGetNeighbours() const
 {
     CheckForNodeAttributes();
 

--- a/mesh/src/common/Node.hpp
+++ b/mesh/src/common/Node.hpp
@@ -320,7 +320,7 @@ public:
   std::vector<unsigned> rGetNeighbours() const;
   auto getNeighboursBegin() { return mpNodeAttributes->getNeighboursBegin(); }
   auto getNeighboursEnd() { return mpNodeAttributes->getNeighboursEnd(); }
-    /** 
+    /**
      * @return a set of indices of elements containing this node as a vertex.
      */
     std::set<unsigned>& rGetContainingElementIndices();

--- a/mesh/src/common/Node.hpp
+++ b/mesh/src/common/Node.hpp
@@ -317,9 +317,10 @@ public:
     /**
      * @return this node's vector of neighbour indices.
      */
-    std::vector<unsigned>& rGetNeighbours();
-
-    /**
+  std::vector<unsigned> rGetNeighbours() const;
+  auto getNeighboursBegin() { return mpNodeAttributes->getNeighboursBegin(); }
+  auto getNeighboursEnd() { return mpNodeAttributes->getNeighboursEnd(); }
+    /** 
      * @return a set of indices of elements containing this node as a vertex.
      */
     std::set<unsigned>& rGetContainingElementIndices();

--- a/mesh/src/common/NodeAttributes.cpp
+++ b/mesh/src/common/NodeAttributes.cpp
@@ -117,7 +117,7 @@ template<unsigned SPACE_DIM>
 std::vector<unsigned> NodeAttributes<SPACE_DIM>::rGetNeighbours() const
 {
   std::vector<unsigned> ret;
-  for( int x = 0; x < 1024; ++x )
+  for( int x = 0; x < numNodes; ++x )
     {
       if ( mNeighbourIndices.test(x) )
 	ret.push_back( x );

--- a/mesh/src/common/NodeAttributes.cpp
+++ b/mesh/src/common/NodeAttributes.cpp
@@ -120,7 +120,7 @@ std::vector<unsigned> NodeAttributes<SPACE_DIM>::rGetNeighbours() const
   for( int x = 0; x < numNodes; ++x )
     {
       if ( mNeighbourIndices.test(x) )
-	ret.push_back( x );
+    ret.push_back( x );
     }
   return ret;
 };

--- a/mesh/src/common/NodeAttributes.cpp
+++ b/mesh/src/common/NodeAttributes.cpp
@@ -39,18 +39,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Exception.hpp"
 
 template<unsigned SPACE_DIM>
-NodeAttributes<SPACE_DIM>::NodeAttributes()
-    :   mAttributes(std::vector<double>()),
-        mRegion(0u),
-        mAppliedForce(zero_vector<double>(SPACE_DIM)),
-        mRadius(0.0),
-        mNeighbourIndices(std::vector<unsigned>()),
-        mNeighboursSetUp(false),
-        mIsParticle(false)
-{
-}
-
-template<unsigned SPACE_DIM>
 std::vector<double>& NodeAttributes<SPACE_DIM>::rGetAttributes()
 {
     return mAttributes;
@@ -98,20 +86,13 @@ void NodeAttributes<SPACE_DIM>::ClearAppliedForce()
 template<unsigned SPACE_DIM>
 void NodeAttributes<SPACE_DIM>::AddNeighbour(unsigned index)
 {
-    mNeighbourIndices.push_back(index);
+  mNeighbourIndices.insert(index);
 }
 
 template<unsigned SPACE_DIM>
 void NodeAttributes<SPACE_DIM>::ClearNeighbours()
 {
-    mNeighbourIndices.clear();
-}
-
-template<unsigned SPACE_DIM>
-void NodeAttributes<SPACE_DIM>::RemoveDuplicateNeighbours()
-{
-    sort( mNeighbourIndices.begin(), mNeighbourIndices.end() );
-    mNeighbourIndices.erase( unique( mNeighbourIndices.begin(), mNeighbourIndices.end() ), mNeighbourIndices.end() );
+  mNeighbourIndices.clear();
 }
 
 template<unsigned SPACE_DIM>
@@ -133,9 +114,15 @@ bool NodeAttributes<SPACE_DIM>::GetNeighboursSetUp()
 };
 
 template<unsigned SPACE_DIM>
-std::vector<unsigned>& NodeAttributes<SPACE_DIM>::rGetNeighbours()
+std::vector<unsigned> NodeAttributes<SPACE_DIM>::rGetNeighbours() const
 {
-    return mNeighbourIndices;
+  std::vector<unsigned> ret;
+  for( int x = 0; x < 1024; ++x )
+    {
+      if ( mNeighbourIndices.test(x) )
+	ret.push_back( x );
+    }
+  return ret;
 };
 
 

--- a/mesh/src/common/NodeAttributes.hpp
+++ b/mesh/src/common/NodeAttributes.hpp
@@ -39,10 +39,141 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "UblasVectorInclude.hpp"
 #include "ChasteSerialization.hpp"
 #include <boost/serialization/vector.hpp>
+#include <boost/serialization/set.hpp>
+#include <bitset>
+#include <iterator>
 
 /**
  * A container for attributes associated with the Node class.
  */
+#define numNodes 4096
+
+template <std::size_t N>
+class MyBitset
+{
+public:
+  using value_type      = unsigned; 
+  using size_type       = std::size_t;
+  using difference_type = std::ptrdiff_t;
+  using reference       = unsigned; 
+  using const_reference = unsigned; 
+
+  class iterator
+  {
+  public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type        = unsigned; 
+    using difference_type   = std::ptrdiff_t;
+    using reference         = unsigned; 
+    using pointer           = void;
+
+    iterator(MyBitset* c, size_type pos): container_(c), pos_(pos)   {    }
+
+    reference operator*() const      	{ return pos_; }
+    iterator& operator++()      	{  nextBit();      return *this;      }
+    iterator operator++(int)    	{  iterator tmp = *this;   nextBit();      return tmp;      }
+    friend bool operator==(const iterator& a, const iterator& b)      {    return a.pos_ == b.pos_;      }
+    friend bool operator!=(const iterator& a, const iterator& b)      {    return !(a == b);      }
+  private:
+    void nextBit( )
+    {
+      while( ++pos_ < N && !container_->bits_.test( pos_ ) );
+    }
+    MyBitset* container_;
+    size_type pos_;
+  };
+  class const_iterator
+  {
+  public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type        = unsigned; 
+    using difference_type   = std::ptrdiff_t;
+    using reference         = unsigned; 
+    using pointer           = void;
+
+    const_iterator(const MyBitset* c, size_type pos): container_(c), pos_(pos)      {      }
+    reference operator*() const      { return pos_;        }
+    const_iterator& operator++()     { nextBit(); return *this;  }
+    const_iterator operator++(int)   { auto tmp = *this; nextBit(); return tmp;      }
+    friend bool operator==(const const_iterator& a,
+			   const const_iterator& b)     { return a.pos_ == b.pos_;   }
+    friend bool operator!=(const const_iterator& a,
+			   const const_iterator& b)     { return !(a == b);      }
+  private:
+    void nextBit( )
+    {
+      while( ++pos_ < N && !container_->bits_.test( pos_ ) );
+    }
+    const MyBitset* container_;
+    size_type pos_;
+  };
+  private:
+  iterator nextBit( size_type pos = 0 )
+  {
+    if( bits_.none() ) return iterator( this, N );
+    for( size_type i = pos; i < numNodes; ++i )
+      if ( bits_.test( i ))
+	return iterator( this, i );
+    return iterator( this, N );
+  }
+private:
+  std::bitset<N> bits_;
+  friend class boost::serialization::access;
+
+  /**
+   * not sure where this is use of if it is needed, but without it compile fails
+   */
+  template< class Archive >
+  void serialize( Archive& ar, const unsigned int version )
+  {
+    std::vector<unsigned> temp;
+    for( int x = 0; x < 1024; ++x )
+      {
+      if ( bits_.test(x) )
+	temp.push_back( x );
+      }
+    ar & temp;
+  }
+public:
+  bool test( size_t x ) const { return bits_.test( x ); }
+  iterator begin()
+  {
+    return nextBit();
+  }
+  size_t 		count() { return bits_.count(); }
+  iterator           	end()           { return iterator(this, N);      }
+  const_iterator     	begin() const   { return const_iterator(this, 0);    }
+  const_iterator     	end() const     { return const_iterator(this, N);    }
+
+  const_iterator     	cbegin() const  { return begin();    }
+  const_iterator     	cend() const    { return end();    }
+  void               	insert( unsigned idx )  {    bits_.set( idx );  }
+  void 			clear()		{ bits_.reset(); }
+  bool 			empty() const 	{ return bits_.none(); }
+  unsigned erase( unsigned idx )
+  {
+    unsigned ret = bits_.test( idx );
+    bits_.reset( idx );
+    return ret;
+  }
+  auto count() const  {    return bits_.count();  }
+  unsigned count(unsigned idx) const   {    return bits_.test( idx ) ? 1 : 0;  }
+  iterator find( unsigned idx )
+  {
+    if ( bits_.test( idx ) )
+      return iterator( this, idx );
+    else
+      return iterator( this, N );
+  }
+  const_iterator find( const unsigned idx ) const
+  {
+    if ( bits_.test( idx ) )
+      return const_iterator( this, idx );
+    else
+      return const_iterator( this, N );
+  }
+};
+  
 template<unsigned SPACE_DIM>
 class NodeAttributes
 {
@@ -52,22 +183,22 @@ private:
     std::vector<double> mAttributes;
 
     /** The ID of the region of mesh in which the Node lies */
-    unsigned mRegion;
+  unsigned mRegion{ 0u };
 
     /** For mutable nodes in OffLatticeSimulations, a container for the force accumulated on this node. */
-    c_vector<double, SPACE_DIM> mAppliedForce;
+  c_vector<double, SPACE_DIM> mAppliedForce{ zero_vector<double>(SPACE_DIM) };
 
     /** The radius associated with the Node */
-    double mRadius;
+  double mRadius{ 0.0 };
 
     /** Vector of indices corresponding to neighbouring nodes. */
-    std::vector<unsigned> mNeighbourIndices;
-
-    /** A bool indicating whether the neighbours of this node have been calculated yet. */
-    bool mNeighboursSetUp;
+  MyBitset<numNodes>  mNeighbourIndices;
+  
+  /** A bool indicating whether the neighbours of this node have been calculated yet. */
+  bool mNeighboursSetUp{ false };
 
     /** Whether the node represents a particle or not: Used for NodeBasedCellPopulationWithParticles */
-    bool mIsParticle;
+  bool mIsParticle{ false };
 
     /** Needed for serialization. */
     friend class boost::serialization::access;
@@ -99,7 +230,7 @@ public:
     /**
      * Defaults all variables.
      */
-    NodeAttributes();
+  NodeAttributes() = default;
 
     /**
      * @return mAttributes
@@ -161,7 +292,7 @@ public:
     /**
      * Remove duplicates from the vector of node neighbour indices.
      */
-    void RemoveDuplicateNeighbours();
+  void RemoveDuplicateNeighbours(){}
 
     /**
      * Check whether the node neighbours collection is empty.
@@ -185,8 +316,22 @@ public:
     /**
      * @return this node's vector of neighbour indices.
      */
-    std::vector<unsigned>& rGetNeighbours();
+  std::vector<unsigned> rGetNeighbours() const;
+  /**
+   *  @return begin iterator to neighbours
+   */
+  MyBitset<numNodes>::iterator getNeighboursBegin() { return mNeighbourIndices.begin(); }
 
+  /**
+   * @return end iterator to neighbours
+   */
+  MyBitset<numNodes>::iterator getNeighboursEnd() { return mNeighbourIndices.end(); }
+
+  /**
+   * @return number of neighbours
+   */
+  size_t getNeighboursCount() { return mNeighbourIndices.count(); }
+  
     /**
      * Get whether this node is a particle, or not.
      *

--- a/mesh/src/common/NodeAttributes.hpp
+++ b/mesh/src/common/NodeAttributes.hpp
@@ -52,26 +52,26 @@ template <std::size_t N>
 class MyBitset
 {
 public:
-  using value_type      = unsigned; 
+  using value_type      = unsigned;
   using size_type       = std::size_t;
   using difference_type = std::ptrdiff_t;
-  using reference       = unsigned; 
-  using const_reference = unsigned; 
+  using reference       = unsigned;
+  using const_reference = unsigned;
 
   class iterator
   {
   public:
     using iterator_category = std::forward_iterator_tag;
-    using value_type        = unsigned; 
+    using value_type        = unsigned;
     using difference_type   = std::ptrdiff_t;
-    using reference         = unsigned; 
+    using reference         = unsigned;
     using pointer           = void;
 
     iterator(MyBitset* c, size_type pos): container_(c), pos_(pos)   {    }
 
-    reference operator*() const      	{ return pos_; }
-    iterator& operator++()      	{  nextBit();      return *this;      }
-    iterator operator++(int)    	{  iterator tmp = *this;   nextBit();      return tmp;      }
+    reference operator*() const          { return pos_; }
+    iterator& operator++()          {  nextBit();      return *this;      }
+    iterator operator++(int)        {  iterator tmp = *this;   nextBit();      return tmp;      }
     friend bool operator==(const iterator& a, const iterator& b)      {    return a.pos_ == b.pos_;      }
     friend bool operator!=(const iterator& a, const iterator& b)      {    return !(a == b);      }
   private:
@@ -86,9 +86,9 @@ public:
   {
   public:
     using iterator_category = std::forward_iterator_tag;
-    using value_type        = unsigned; 
+    using value_type        = unsigned;
     using difference_type   = std::ptrdiff_t;
-    using reference         = unsigned; 
+    using reference         = unsigned;
     using pointer           = void;
 
     const_iterator(const MyBitset* c, size_type pos): container_(c), pos_(pos)      {      }
@@ -96,9 +96,9 @@ public:
     const_iterator& operator++()     { nextBit(); return *this;  }
     const_iterator operator++(int)   { auto tmp = *this; nextBit(); return tmp;      }
     friend bool operator==(const const_iterator& a,
-			   const const_iterator& b)     { return a.pos_ == b.pos_;   }
+               const const_iterator& b)     { return a.pos_ == b.pos_;   }
     friend bool operator!=(const const_iterator& a,
-			   const const_iterator& b)     { return !(a == b);      }
+               const const_iterator& b)     { return !(a == b);      }
   private:
     void nextBit( )
     {
@@ -113,7 +113,7 @@ public:
     if( bits_.none() ) return iterator( this, N );
     for( size_type i = pos; i < numNodes; ++i )
       if ( bits_.test( i ))
-	return iterator( this, i );
+    return iterator( this, i );
     return iterator( this, N );
   }
 private:
@@ -130,7 +130,7 @@ private:
     for( int x = 0; x < 1024; ++x )
       {
       if ( bits_.test(x) )
-	temp.push_back( x );
+    temp.push_back( x );
       }
     ar & temp;
   }
@@ -140,16 +140,16 @@ public:
   {
     return nextBit();
   }
-  size_t 		count() { return bits_.count(); }
-  iterator           	end()           { return iterator(this, N);      }
-  const_iterator     	begin() const   { return const_iterator(this, 0);    }
-  const_iterator     	end() const     { return const_iterator(this, N);    }
+  size_t         count() { return bits_.count(); }
+  iterator               end()           { return iterator(this, N);      }
+  const_iterator         begin() const   { return const_iterator(this, 0);    }
+  const_iterator         end() const     { return const_iterator(this, N);    }
 
-  const_iterator     	cbegin() const  { return begin();    }
-  const_iterator     	cend() const    { return end();    }
-  void               	insert( unsigned idx )  {    bits_.set( idx );  }
-  void 			clear()		{ bits_.reset(); }
-  bool 			empty() const 	{ return bits_.none(); }
+  const_iterator         cbegin() const  { return begin();    }
+  const_iterator         cend() const    { return end();    }
+  void                   insert( unsigned idx )  {    bits_.set( idx );  }
+  void             clear()        { bits_.reset(); }
+  bool             empty() const     { return bits_.none(); }
   unsigned erase( unsigned idx )
   {
     unsigned ret = bits_.test( idx );
@@ -173,7 +173,7 @@ public:
       return const_iterator( this, N );
   }
 };
-  
+
 template<unsigned SPACE_DIM>
 class NodeAttributes
 {
@@ -193,7 +193,7 @@ private:
 
     /** Vector of indices corresponding to neighbouring nodes. */
   MyBitset<numNodes>  mNeighbourIndices;
-  
+
   /** A bool indicating whether the neighbours of this node have been calculated yet. */
   bool mNeighboursSetUp{ false };
 
@@ -331,7 +331,7 @@ public:
    * @return number of neighbours
    */
   size_t getNeighboursCount() { return mNeighbourIndices.count(); }
-  
+
     /**
      * Get whether this node is a particle, or not.
      *

--- a/mesh/test/TestNode.hpp
+++ b/mesh/test/TestNode.hpp
@@ -262,8 +262,8 @@ public:
         node.AddNeighbour(1u);
         TS_ASSERT_EQUALS(node.NeighboursIsEmpty(), false);
 
-	// is it necessary to keep duplicate neighbours?
-	//        TS_ASSERT_EQUALS(node.rGetNeighbours().size(), 2u);
+    // is it necessary to keep duplicate neighbours?
+    //        TS_ASSERT_EQUALS(node.rGetNeighbours().size(), 2u);
         node.RemoveDuplicateNeighbours();
         TS_ASSERT_EQUALS(node.rGetNeighbours().size(), 1u);
         node.ClearNeighbours();

--- a/mesh/test/TestNode.hpp
+++ b/mesh/test/TestNode.hpp
@@ -261,7 +261,9 @@ public:
         node.AddNeighbour(1u);
         node.AddNeighbour(1u);
         TS_ASSERT_EQUALS(node.NeighboursIsEmpty(), false);
-        TS_ASSERT_EQUALS(node.rGetNeighbours().size(), 2u);
+
+	// is it necessary to keep duplicate neighbours?
+	//        TS_ASSERT_EQUALS(node.rGetNeighbours().size(), 2u);
         node.RemoveDuplicateNeighbours();
         TS_ASSERT_EQUALS(node.rGetNeighbours().size(), 1u);
         node.ClearNeighbours();


### PR DESCRIPTION
This appears to make TestRepresentative3dNodeBasedSimulation run ~20% faster.  This is assuming duplicate neighbouring nodes aren't actually needed for something.

Note: node index is limited to a 0 to 4096 range, I have no idea if this is acceptable in the real world, seems to work in the tests (Continuous anyway).
