### PR TITLE
#607 Join statements split over two lines and use auto to shorten them

### DIFF
--- a/cell_based/src/cell/cycle/AbstractSimpleGenerationalCellCycleModel.cpp
+++ b/cell_based/src/cell/cycle/AbstractSimpleGenerationalCellCycleModel.cpp
@@ -91,8 +91,7 @@ void AbstractSimpleGenerationalCellCycleModel::ResetForDivision()
          * would be incorrect. We must therefore access the CellProliferativeType via the cell's
          * CellPropertyCollection.
          */
-        boost::shared_ptr<AbstractCellProperty> p_diff_type =
-            mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<DifferentiatedCellProliferativeType>();
+        auto p_diff_type = mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<DifferentiatedCellProliferativeType>();
         mpCell->SetCellProliferativeType(p_diff_type);
     }
     AbstractSimplePhaseBasedCellCycleModel::ResetForDivision();
@@ -113,14 +112,12 @@ void AbstractSimpleGenerationalCellCycleModel::InitialiseDaughterCell()
      * In generation-based cell-cycle models, the daughter cell
      * is always of type transit or differentiated.
      */
-    boost::shared_ptr<AbstractCellProperty> p_transit_type =
-        mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<TransitCellProliferativeType>();
+    auto p_transit_type = mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<TransitCellProliferativeType>();
     mpCell->SetCellProliferativeType(p_transit_type);
 
     if (mGeneration > mMaxTransitGenerations)
     {
-        boost::shared_ptr<AbstractCellProperty> p_diff_type =
-            mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<DifferentiatedCellProliferativeType>();
+        auto p_diff_type = mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<DifferentiatedCellProliferativeType>();
         mpCell->SetCellProliferativeType(p_diff_type);
     }
     AbstractSimplePhaseBasedCellCycleModel::InitialiseDaughterCell();

--- a/cell_based/src/cell/cycle/ContactInhibitionCellCycleModel.cpp
+++ b/cell_based/src/cell/cycle/ContactInhibitionCellCycleModel.cpp
@@ -101,8 +101,7 @@ void ContactInhibitionCellCycleModel::UpdateCellCyclePhase()
              * a new CellPropertyRegistry. In this case the CellLabel's cell count would be incorrect.
              * We must therefore access the CellLabel via the cell's CellPropertyCollection.
              */
-            boost::shared_ptr<AbstractCellProperty> p_label =
-                mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<CellLabel>();
+            auto p_label = mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<CellLabel>();
             mpCell->AddCellProperty(p_label);
         }
         else

--- a/cell_based/src/cell/cycle/SimpleOxygenBasedCellCycleModel.cpp
+++ b/cell_based/src/cell/cycle/SimpleOxygenBasedCellCycleModel.cpp
@@ -138,8 +138,7 @@ void SimpleOxygenBasedCellCycleModel::UpdateHypoxicDuration()
              * count would be incorrect. We must therefore access the ApoptoticCellProperty via the
              * cell's CellPropertyCollection.
              */
-            boost::shared_ptr<AbstractCellProperty> p_apoptotic_property =
-                mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<ApoptoticCellProperty>();
+            auto p_apoptotic_property = mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<ApoptoticCellProperty>();
             mpCell->AddCellProperty(p_apoptotic_property);
         }
     }

--- a/cell_based/src/cell/cycle/TysonNovakCellCycleModel.cpp
+++ b/cell_based/src/cell/cycle/TysonNovakCellCycleModel.cpp
@@ -127,8 +127,7 @@ void TysonNovakCellCycleModel::InitialiseDaughterCell()
          * would be incorrect. We must therefore access the CellProliferativeType via the cell's
          * CellPropertyCollection.
          */
-        boost::shared_ptr<AbstractCellProperty> p_transit_type =
-        mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<TransitCellProliferativeType>();
+        auto p_transit_type = mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<TransitCellProliferativeType>();
         mpCell->SetCellProliferativeType(p_transit_type);
     }
 }

--- a/cell_based/src/cell/properties/CellPropertyRegistry.cpp
+++ b/cell_based/src/cell/properties/CellPropertyRegistry.cpp
@@ -81,8 +81,7 @@ void CellPropertyRegistry::SpecifyOrdering(const std::vector<boost::shared_ptr<A
     std::vector<boost::shared_ptr<AbstractCellProperty> > temp_vector = rOrdering;
     for (unsigned i=0; i<mCellProperties.size(); i++)
     {
-        std::vector<boost::shared_ptr<AbstractCellProperty> >::const_iterator it
-            = find(rOrdering.begin(), rOrdering.end(), mCellProperties[i]);
+        auto it = find(rOrdering.begin(), rOrdering.end(), mCellProperties[i]);
         if (it == rOrdering.end())
         {
             temp_vector.push_back(mCellProperties[i]);

--- a/cell_based/src/population/AbstractCellPopulation.cpp
+++ b/cell_based/src/population/AbstractCellPopulation.cpp
@@ -196,8 +196,7 @@ template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
 std::vector<unsigned> AbstractCellPopulation<ELEMENT_DIM, SPACE_DIM>::GetCellMutationStateCount()
 {
     std::vector<unsigned> mutation_state_count;
-    const std::vector<boost::shared_ptr<AbstractCellProperty> >& r_cell_properties
-        = mpCellPropertyRegistry->rGetAllCellProperties();
+    const auto& r_cell_properties = mpCellPropertyRegistry->rGetAllCellProperties();
 
     // Calculate mutation states count
     for (unsigned i=0; i<r_cell_properties.size(); i++)
@@ -230,8 +229,7 @@ template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
 std::vector<unsigned> AbstractCellPopulation<ELEMENT_DIM, SPACE_DIM>::GetCellProliferativeTypeCount()
 {
     std::vector<unsigned> proliferative_type_count;
-    const std::vector<boost::shared_ptr<AbstractCellProperty> >& r_cell_properties
-        = mpCellPropertyRegistry->rGetAllCellProperties();
+    const auto& r_cell_properties = mpCellPropertyRegistry->rGetAllCellProperties();
 
     // Calculate proliferative types count
     for (unsigned i=0; i<r_cell_properties.size(); i++)

--- a/cell_based/src/population/boundary_conditions/SphereGeometryBoundaryCondition.cpp
+++ b/cell_based/src/population/boundary_conditions/SphereGeometryBoundaryCondition.cpp
@@ -88,8 +88,7 @@ void SphereGeometryBoundaryCondition<DIM>::ImposeBoundaryCondition(const std::ma
         if (fabs(radius - mRadiusOfSphere) > mMaximumDistance)
         {
             // ...move the cell back onto the surface of the sphere
-            c_vector<double, DIM> location_on_sphere =
-                mCentreOfSphere + mRadiusOfSphere*(cell_location - mCentreOfSphere)/radius;
+            c_vector<double, DIM> location_on_sphere = mCentreOfSphere + mRadiusOfSphere*(cell_location - mCentreOfSphere)/radius;
 
             unsigned node_index = this->mpCellPopulation->GetLocationIndexUsingCell(*cell_iter);
             Node<DIM>* p_node = this->mpCellPopulation->GetNode(node_index);

--- a/cell_based/src/population/forces/FarhadifarForce.cpp
+++ b/cell_based/src/population/forces/FarhadifarForce.cpp
@@ -133,8 +133,7 @@ void FarhadifarForce<DIM>::AddForceContribution(AbstractCellPopulation<DIM>& rCe
             unsigned local_index = p_element->GetNodeLocalIndex(node_index);
 
             // Add the force contribution from this cell's area elasticity (note the minus sign)
-            c_vector<double, DIM> element_area_gradient =
-                    p_cell_population->rGetMesh().GetAreaGradientOfElementAtNode(p_element, local_index);
+            c_vector<double, DIM> element_area_gradient = p_cell_population->rGetMesh().GetAreaGradientOfElementAtNode(p_element, local_index);
             area_elasticity_contribution -= GetAreaElasticityParameter()*(element_areas[elem_index] -
                     target_areas[elem_index])*element_area_gradient;
 
@@ -151,8 +150,7 @@ void FarhadifarForce<DIM>::AddForceContribution(AbstractCellPopulation<DIM>& rCe
             double next_edge_line_tension_parameter = GetLineTensionParameter(p_this_node, p_next_node, *p_cell_population);
 
             // Compute the gradient of each these edges, computed at the present node
-            c_vector<double, DIM> previous_edge_gradient =
-                    -p_cell_population->rGetMesh().GetNextEdgeGradientOfElementAtNode(p_element, previous_node_local_index);
+            c_vector<double, DIM> previous_edge_gradient = -p_cell_population->rGetMesh().GetNextEdgeGradientOfElementAtNode(p_element, previous_node_local_index);
             c_vector<double, DIM> next_edge_gradient = p_cell_population->rGetMesh().GetNextEdgeGradientOfElementAtNode(p_element, local_index);
 
             // Add the force contribution from cell-cell and cell-boundary line tension (note the minus sign)

--- a/cell_based/src/simulation/OnLatticeSimulation.cpp
+++ b/cell_based/src/simulation/OnLatticeSimulation.cpp
@@ -90,8 +90,7 @@ void OnLatticeSimulation<DIM>::OutputAdditionalSimulationSetup(out_stream& rPara
     *rParamsFile << "\n\t<UpdateRules>\n";
 
     // This static_cast is fine, since otherwise an exception would have been thrown in the constructor
-    std::vector<boost::shared_ptr<AbstractUpdateRule<DIM> > > collection =
-            static_cast<AbstractOnLatticeCellPopulation<DIM>*>(&(this->mrCellPopulation))->GetUpdateRuleCollection();
+    auto collection = static_cast<AbstractOnLatticeCellPopulation<DIM>*>(&(this->mrCellPopulation))->GetUpdateRuleCollection();
 
     for (typename std::vector<boost::shared_ptr<AbstractUpdateRule<DIM> > >::iterator iter = collection.begin();
          iter != collection.end();

--- a/cell_based/src/simulation/modifiers/DeltaNotchEdgeInteriorTrackingModifier.cpp
+++ b/cell_based/src/simulation/modifiers/DeltaNotchEdgeInteriorTrackingModifier.cpp
@@ -83,8 +83,7 @@ void DeltaNotchEdgeInteriorTrackingModifier<DIM>::UpdateCellData(AbstractCellPop
 
         for (unsigned i = 0 ; i  < p_cell_edge_model->GetNumEdgeSrn(); i++)
         {
-            boost::shared_ptr<DeltaNotchEdgeSrnModel> p_model
-                    = boost::static_pointer_cast<DeltaNotchEdgeSrnModel>(p_cell_edge_model->GetEdgeSrn(i));
+            auto p_model = boost::static_pointer_cast<DeltaNotchEdgeSrnModel>(p_cell_edge_model->GetEdgeSrn(i));
             double edge_delta = p_model->GetDelta();
             double edge_notch = p_model->GetNotch();
 
@@ -98,8 +97,7 @@ void DeltaNotchEdgeInteriorTrackingModifier<DIM>::UpdateCellData(AbstractCellPop
         /* Interior delta notch collection */
         //Filling interior delta/notch value, interior model must be specified for this edge-interior example
         assert(p_cell_edge_model->GetInteriorSrn() != nullptr);
-        boost::shared_ptr<DeltaNotchInteriorSrnModel> p_interior_model
-                = boost::static_pointer_cast<DeltaNotchInteriorSrnModel>(p_cell_edge_model->GetInteriorSrn());
+        auto p_interior_model = boost::static_pointer_cast<DeltaNotchInteriorSrnModel>(p_cell_edge_model->GetInteriorSrn());
 
         // Note that the state variables must be in the same order as listed in DeltaNotchOdeSystem
         cell_iter->GetCellData()->SetItem("interior delta", p_interior_model->GetDelta());

--- a/cell_based/src/simulation/modifiers/DeltaNotchEdgeTrackingModifier.cpp
+++ b/cell_based/src/simulation/modifiers/DeltaNotchEdgeTrackingModifier.cpp
@@ -82,8 +82,7 @@ void DeltaNotchEdgeTrackingModifier<DIM>::UpdateCellData(AbstractCellPopulation<
         std::vector<double> delta_vec;
         for (unsigned i = 0 ; i  < p_cell_edge_model->GetNumEdgeSrn(); i++)
         {
-            boost::shared_ptr<DeltaNotchEdgeSrnModel> p_model
-            = boost::static_pointer_cast<DeltaNotchEdgeSrnModel>(p_cell_edge_model->GetEdgeSrn(i));
+            auto p_model = boost::static_pointer_cast<DeltaNotchEdgeSrnModel>(p_cell_edge_model->GetEdgeSrn(i));
             double this_delta = p_model->GetDelta();
             double this_notch = p_model->GetNotch();
             delta_vec.push_back(this_delta);

--- a/cell_based/src/writers/population_count_writers/CellMutationStatesCountWriter.cpp
+++ b/cell_based/src/writers/population_count_writers/CellMutationStatesCountWriter.cpp
@@ -58,8 +58,7 @@ void CellMutationStatesCountWriter<ELEMENT_DIM, SPACE_DIM>::WriteHeader(Abstract
 
         *this->mpOutStream << "Time\t ";
 
-        const std::vector<boost::shared_ptr<AbstractCellProperty> >& r_cell_properties =
-            pCellPopulation->GetCellPropertyRegistry()->rGetAllCellProperties();
+        const auto& r_cell_properties = pCellPopulation->GetCellPropertyRegistry()->rGetAllCellProperties();
 
         for (unsigned i=0; i<r_cell_properties.size(); i++)
         {

--- a/cell_based/src/writers/population_count_writers/CellMutationStatesCountWriter.cpp
+++ b/cell_based/src/writers/population_count_writers/CellMutationStatesCountWriter.cpp
@@ -58,7 +58,7 @@ void CellMutationStatesCountWriter<ELEMENT_DIM, SPACE_DIM>::WriteHeader(Abstract
 
         *this->mpOutStream << "Time\t ";
 
-        const auto& r_cell_properties = pCellPopulation->GetCellPropertyRegistry()->rGetAllCellProperties();
+        const std::vector<boost::shared_ptr<AbstractCellProperty> >& r_cell_properties = pCellPopulation->GetCellPropertyRegistry()->rGetAllCellProperties();
 
         for (unsigned i=0; i<r_cell_properties.size(); i++)
         {

--- a/cell_based/src/writers/population_writers/VertexT1SwapLocationsWriter.cpp
+++ b/cell_based/src/writers/population_writers/VertexT1SwapLocationsWriter.cpp
@@ -71,8 +71,7 @@ void VertexT1SwapLocationsWriter<ELEMENT_DIM, SPACE_DIM>::Visit(PottsBasedCellPo
 template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
 void VertexT1SwapLocationsWriter<ELEMENT_DIM, SPACE_DIM>::Visit(VertexBasedCellPopulation<SPACE_DIM>* pCellPopulation)
 {
-    std::vector<T1SwapInfo<SPACE_DIM> > t1_swap_info
-    = pCellPopulation->rGetMesh().GetOperationRecorder()->GetT1SwapsInfo();
+    std::vector<T1SwapInfo<SPACE_DIM> > t1_swap_info = pCellPopulation->rGetMesh().GetOperationRecorder()->GetT1SwapsInfo();
     *this->mpOutStream << t1_swap_info.size() << "\t";
     for (unsigned index = 0;  index < t1_swap_info.size(); index++)
     {

--- a/cell_based/src/writers/population_writers/VertexT2SwapLocationsWriter.cpp
+++ b/cell_based/src/writers/population_writers/VertexT2SwapLocationsWriter.cpp
@@ -71,8 +71,7 @@ void VertexT2SwapLocationsWriter<ELEMENT_DIM, SPACE_DIM>::Visit(PottsBasedCellPo
 template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
 void VertexT2SwapLocationsWriter<ELEMENT_DIM, SPACE_DIM>::Visit(VertexBasedCellPopulation<SPACE_DIM>* pCellPopulation)
 {
-    std::vector<T2SwapInfo<SPACE_DIM> > t2_swap_info
-        = pCellPopulation->rGetMesh().GetOperationRecorder()->GetT2SwapsInfo();
+    std::vector<T2SwapInfo<SPACE_DIM> > t2_swap_info = pCellPopulation->rGetMesh().GetOperationRecorder()->GetT2SwapsInfo();
 
     *this->mpOutStream << t2_swap_info.size() << "\t";
 

--- a/cell_based/src/writers/population_writers/VertexT3SwapLocationsWriter.cpp
+++ b/cell_based/src/writers/population_writers/VertexT3SwapLocationsWriter.cpp
@@ -71,8 +71,7 @@ void VertexT3SwapLocationsWriter<ELEMENT_DIM, SPACE_DIM>::Visit(PottsBasedCellPo
 template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
 void VertexT3SwapLocationsWriter<ELEMENT_DIM, SPACE_DIM>::Visit(VertexBasedCellPopulation<SPACE_DIM>* pCellPopulation)
 {
-    std::vector<T3SwapInfo<SPACE_DIM> > t3_swap_info
-            = pCellPopulation->rGetMesh().GetOperationRecorder()->GetT3SwapsInfo();
+    std::vector<T3SwapInfo<SPACE_DIM> > t3_swap_info = pCellPopulation->rGetMesh().GetOperationRecorder()->GetT3SwapsInfo();
 
     *this->mpOutStream << t3_swap_info.size() << "\t";
     for (unsigned index = 0;  index < t3_swap_info.size(); index++)

--- a/continuum_mechanics/src/solver/AbstractContinuumMechanicsAssembler.hpp
+++ b/continuum_mechanics/src/solver/AbstractContinuumMechanicsAssembler.hpp
@@ -491,8 +491,7 @@ void AbstractContinuumMechanicsAssembler<DIM,CAN_ASSEMBLE_VECTOR,CAN_ASSEMBLE_MA
 
         if (this->mAssembleVector)
         {
-            c_vector<double,SPATIAL_BLOCK_SIZE_ELEMENTAL> b_spatial
-                = ComputeSpatialVectorTerm(quad_phi, grad_quad_phi, X, &rElement);
+            c_vector<double,SPATIAL_BLOCK_SIZE_ELEMENTAL> b_spatial = ComputeSpatialVectorTerm(quad_phi, grad_quad_phi, X, &rElement);
             c_vector<double,PRESSURE_BLOCK_SIZE_ELEMENTAL> b_pressure = ComputePressureVectorTerm(linear_phi, grad_linear_phi, X, &rElement);
 
             for (unsigned i=0; i<SPATIAL_BLOCK_SIZE_ELEMENTAL; i++)
@@ -508,11 +507,9 @@ void AbstractContinuumMechanicsAssembler<DIM,CAN_ASSEMBLE_VECTOR,CAN_ASSEMBLE_MA
 
         if (this->mAssembleMatrix)
         {
-            c_matrix<double,SPATIAL_BLOCK_SIZE_ELEMENTAL,SPATIAL_BLOCK_SIZE_ELEMENTAL> a_spatial_spatial
-                = ComputeSpatialSpatialMatrixTerm(quad_phi, grad_quad_phi, X, &rElement);
+            c_matrix<double,SPATIAL_BLOCK_SIZE_ELEMENTAL,SPATIAL_BLOCK_SIZE_ELEMENTAL> a_spatial_spatial = ComputeSpatialSpatialMatrixTerm(quad_phi, grad_quad_phi, X, &rElement);
 
-            c_matrix<double,SPATIAL_BLOCK_SIZE_ELEMENTAL,PRESSURE_BLOCK_SIZE_ELEMENTAL> a_spatial_pressure
-                = ComputeSpatialPressureMatrixTerm(quad_phi, grad_quad_phi, linear_phi, grad_linear_phi, X, &rElement);
+            c_matrix<double,SPATIAL_BLOCK_SIZE_ELEMENTAL,PRESSURE_BLOCK_SIZE_ELEMENTAL> a_spatial_pressure = ComputeSpatialPressureMatrixTerm(quad_phi, grad_quad_phi, linear_phi, grad_linear_phi, X, &rElement);
 
             c_matrix<double,PRESSURE_BLOCK_SIZE_ELEMENTAL,SPATIAL_BLOCK_SIZE_ELEMENTAL> a_pressure_spatial;
             if (!BLOCK_SYMMETRIC_MATRIX)
@@ -521,8 +518,7 @@ void AbstractContinuumMechanicsAssembler<DIM,CAN_ASSEMBLE_VECTOR,CAN_ASSEMBLE_MA
                 //a_pressure_spatial = ComputeSpatialPressureMatrixTerm(quad_phi, grad_quad_phi, lin_phi, grad_lin_phi, x, &rElement);
             }
 
-            c_matrix<double,PRESSURE_BLOCK_SIZE_ELEMENTAL,PRESSURE_BLOCK_SIZE_ELEMENTAL> a_pressure_pressure
-                = ComputePressurePressureMatrixTerm(linear_phi, grad_linear_phi, X, &rElement);
+            c_matrix<double,PRESSURE_BLOCK_SIZE_ELEMENTAL,PRESSURE_BLOCK_SIZE_ELEMENTAL> a_pressure_pressure = ComputePressurePressureMatrixTerm(linear_phi, grad_linear_phi, X, &rElement);
 
             for (unsigned i=0; i<SPATIAL_BLOCK_SIZE_ELEMENTAL; i++)
             {

--- a/continuum_mechanics/src/solver/CompressibleNonlinearElasticitySolver.cpp
+++ b/continuum_mechanics/src/solver/CompressibleNonlinearElasticitySolver.cpp
@@ -214,8 +214,7 @@ void CompressibleNonlinearElasticitySolver<DIM>::AssembleOnElement(
     static c_matrix<double, NUM_NODES_PER_ELEMENT, DIM> trans_grad_quad_phi;
 
     // Get the material law
-    AbstractCompressibleMaterialLaw<DIM>* p_material_law
-       = this->mrProblemDefinition.GetCompressibleMaterialLaw(rElement.GetIndex());
+    AbstractCompressibleMaterialLaw<DIM>* p_material_law = this->mrProblemDefinition.GetCompressibleMaterialLaw(rElement.GetIndex());
 
 
     static c_matrix<double,DIM,DIM> grad_u; // grad_u = (du_i/dX_M)

--- a/continuum_mechanics/src/solver/IncompressibleNonlinearElasticitySolver.cpp
+++ b/continuum_mechanics/src/solver/IncompressibleNonlinearElasticitySolver.cpp
@@ -262,8 +262,7 @@ void IncompressibleNonlinearElasticitySolver<DIM>::AssembleOnElement(
     static c_matrix<double, NUM_NODES_PER_ELEMENT, DIM> trans_grad_quad_phi;
 
     // Get the material law
-    AbstractIncompressibleMaterialLaw<DIM>* p_material_law
-        = this->mrProblemDefinition.GetIncompressibleMaterialLaw(rElement.GetIndex());
+    AbstractIncompressibleMaterialLaw<DIM>* p_material_law = this->mrProblemDefinition.GetIncompressibleMaterialLaw(rElement.GetIndex());
 
     static c_matrix<double,DIM,DIM> grad_u; // grad_u = (du_i/dX_M)
 
@@ -595,8 +594,7 @@ void IncompressibleNonlinearElasticitySolver<DIM>::FormInitialGuess()
          ++iter)
     {
         ///\todo #2223 This is unlikely to work using DistributedQuadraticMesh with Non-homogeneous material laws
-        double zero_strain_pressure
-           = this->mrProblemDefinition.GetIncompressibleMaterialLaw(iter->GetIndex())->GetZeroStrainPressure();
+        double zero_strain_pressure = this->mrProblemDefinition.GetIncompressibleMaterialLaw(iter->GetIndex())->GetZeroStrainPressure();
 
 
         // Loop over vertices and set pressure solution to be zero-strain-pressure

--- a/crypt/src/cell/cycle/AbstractVanLeeuwen2009WntSwatCellCycleModel.cpp
+++ b/crypt/src/cell/cycle/AbstractVanLeeuwen2009WntSwatCellCycleModel.cpp
@@ -82,14 +82,12 @@ void AbstractVanLeeuwen2009WntSwatCellCycleModel::ChangeCellProliferativeTypeDue
          * would be incorrect. We must therefore access the CellProliferativeType via the cell's
          * CellPropertyCollection.
          */
-        boost::shared_ptr<AbstractCellProperty> p_diff_type =
-            mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<DifferentiatedCellProliferativeType>();
+        auto p_diff_type = mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<DifferentiatedCellProliferativeType>();
         mpCell->SetCellProliferativeType(p_diff_type);
     }
     else
     {
-        boost::shared_ptr<AbstractCellProperty> p_transit_type =
-            mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<TransitCellProliferativeType>();
+        auto p_transit_type = mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<TransitCellProliferativeType>();
         mpCell->SetCellProliferativeType(p_transit_type);
     }
 }

--- a/crypt/src/cell/cycle/SimpleWntCellCycleModel.cpp
+++ b/crypt/src/cell/cycle/SimpleWntCellCycleModel.cpp
@@ -247,22 +247,19 @@ void SimpleWntCellCycleModel::UpdateCellCyclePhase()
              * would be incorrect. We must therefore access the CellProliferativeType via the cell's
              * CellPropertyCollection.
              */
-            boost::shared_ptr<AbstractCellProperty> p_stem_type =
-                mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<StemCellProliferativeType>();
+            auto p_stem_type = mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<StemCellProliferativeType>();
             mpCell->SetCellProliferativeType(p_stem_type);
         }
         else
         {
-            boost::shared_ptr<AbstractCellProperty> p_transit_type =
-                mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<TransitCellProliferativeType>();
+            auto p_transit_type = mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<TransitCellProliferativeType>();
             mpCell->SetCellProliferativeType(p_transit_type);
         }
     }
     else
     {
         // The cell is set to have DifferentiatedCellProliferativeType and so in G0 phase
-        boost::shared_ptr<AbstractCellProperty> p_diff_type =
-            mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<DifferentiatedCellProliferativeType>();
+        auto p_diff_type = mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<DifferentiatedCellProliferativeType>();
         mpCell->SetCellProliferativeType(p_diff_type);
     }
     AbstractSimplePhaseBasedCellCycleModel::UpdateCellCyclePhase();
@@ -274,8 +271,7 @@ void SimpleWntCellCycleModel::InitialiseDaughterCell()
 
     if (wnt_type == RADIAL)
     {
-        boost::shared_ptr<AbstractCellProperty> p_transit_type =
-            mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<TransitCellProliferativeType>();
+        auto p_transit_type = mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<TransitCellProliferativeType>();
         mpCell->SetCellProliferativeType(p_transit_type);
     }
 

--- a/crypt/src/cell/cycle/SingleOdeWntCellCycleModel.cpp
+++ b/crypt/src/cell/cycle/SingleOdeWntCellCycleModel.cpp
@@ -144,14 +144,12 @@ void SingleOdeWntCellCycleModel::ChangeCellProliferativeTypeDueToCurrentBetaCate
          * would be incorrect. We must therefore access the CellProliferativeType via the cell's
          * CellPropertyCollection.
          */
-        boost::shared_ptr<AbstractCellProperty> p_diff_type =
-            mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<DifferentiatedCellProliferativeType>();
+        auto p_diff_type = mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<DifferentiatedCellProliferativeType>();
         mpCell->SetCellProliferativeType(p_diff_type);
     }
     else
     {
-        boost::shared_ptr<AbstractCellProperty> p_transit_type =
-            mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<TransitCellProliferativeType>();
+        auto p_transit_type = mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<TransitCellProliferativeType>();
         mpCell->SetCellProliferativeType(p_transit_type);
     }
 }

--- a/crypt/src/cell/cycle/WntCellCycleModel.cpp
+++ b/crypt/src/cell/cycle/WntCellCycleModel.cpp
@@ -109,14 +109,12 @@ void WntCellCycleModel::ChangeCellProliferativeTypeDueToCurrentBetaCateninLevel(
          * would be incorrect. We must therefore access the CellProliferativeType via the cell's
          * CellPropertyCollection.
          */
-        boost::shared_ptr<AbstractCellProperty> p_diff_type =
-            mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<DifferentiatedCellProliferativeType>();
+        auto p_diff_type = mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<DifferentiatedCellProliferativeType>();
         mpCell->SetCellProliferativeType(p_diff_type);
     }
     else
     {
-        boost::shared_ptr<AbstractCellProperty> p_transit_type =
-            mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<TransitCellProliferativeType>();
+        auto p_transit_type = mpCell->rGetCellPropertyCollection().GetCellPropertyRegistry()->Get<TransitCellProliferativeType>();
         mpCell->SetCellProliferativeType(p_transit_type);
     }
 }

--- a/global/src/checkpointing/Identifiable.cpp
+++ b/global/src/checkpointing/Identifiable.cpp
@@ -95,8 +95,7 @@ std::string Identifiable::GetIdentifier() const
 {
     std::string id;
 #if BOOST_VERSION >= 103700
-    const boost::serialization::extended_type_info* p_type_info =
-            boost::serialization::type_info_implementation<Identifiable>::type::get_const_instance().get_derived_extended_type_info(*this);
+    const boost::serialization::extended_type_info* p_type_info = boost::serialization::type_info_implementation<Identifiable>::type::get_const_instance().get_derived_extended_type_info(*this);
     if(p_type_info!=nullptr)
     {
         id = p_type_info->get_key();

--- a/heart/src/odes/AbstractCvodeCellWithDataClamp.cpp
+++ b/heart/src/odes/AbstractCvodeCellWithDataClamp.cpp
@@ -83,8 +83,7 @@ double AbstractCvodeCellWithDataClamp::GetExperimentalVoltageAtTimeT(const doubl
         EXCEPTION("The requested time " << rTime << " is outside the times stored in the data clamp.");
     }
 
-    std::vector<double>::iterator upper_vec =
-            std::upper_bound(mExperimentalTimes.begin(), mExperimentalTimes.end(), rTime);
+    auto upper_vec = std::upper_bound(mExperimentalTimes.begin(), mExperimentalTimes.end(), rTime);
     // upper_vec points to first element that is (strictly) > rTime (so it can't be first one if rTime is in range)
 
     // Special case - here the lower bound is equal to upper bound and both are pointing to end!

--- a/heart/src/postprocessing/Hdf5ToCmguiConverter.cpp
+++ b/heart/src/postprocessing/Hdf5ToCmguiConverter.cpp
@@ -178,8 +178,7 @@ Hdf5ToCmguiConverter<ELEMENT_DIM,SPACE_DIM>::Hdf5ToCmguiConverter(const FileFind
         ///\todo What if the mesh has been scaled, translated or rotated?
         // Note that the next line will throw if the mesh has not been read from file
         std::string original_file=this->mpMesh->GetMeshFileBaseName();
-        std::shared_ptr<AbstractMeshReader<ELEMENT_DIM, SPACE_DIM> > p_original_mesh_reader
-            = GenericMeshReader<ELEMENT_DIM, SPACE_DIM>(original_file);
+        auto p_original_mesh_reader = GenericMeshReader<ELEMENT_DIM, SPACE_DIM>(original_file);
         cmgui_mesh_writer.WriteFilesUsingMeshReader(*p_original_mesh_reader);
     }
 

--- a/heart/src/problem/AbstractCardiacProblem.cpp
+++ b/heart/src/problem/AbstractCardiacProblem.cpp
@@ -132,8 +132,7 @@ void AbstractCardiacProblem<ELEMENT_DIM, SPACE_DIM, PROBLEM_DIM>::Initialise()
             if (HeartConfig::Instance()->GetLoadMesh())
             {
                 CreateMeshFromHeartConfig();
-                std::shared_ptr<AbstractMeshReader<ELEMENT_DIM, SPACE_DIM> > p_mesh_reader
-                    = GenericMeshReader<ELEMENT_DIM, SPACE_DIM>(HeartConfig::Instance()->GetMeshName());
+                auto p_mesh_reader = GenericMeshReader<ELEMENT_DIM, SPACE_DIM>(HeartConfig::Instance()->GetMeshName());
                 mpMesh->ConstructFromMeshReader(*p_mesh_reader);
             }
             else if (HeartConfig::Instance()->GetCreateMesh())

--- a/heart/src/problem/CardiacElectroMechanicsProblem.cpp
+++ b/heart/src/problem/CardiacElectroMechanicsProblem.cpp
@@ -508,8 +508,7 @@ void CardiacElectroMechanicsProblem<DIM,ELEC_PROB_DIM>::Solve()
 
     // get an electrics solver from the problem. Note that we don't call
     // Solve() on the CardiacProblem class, we do the looping here.
-    AbstractDynamicLinearPdeSolver<DIM,DIM,ELEC_PROB_DIM>* p_electrics_solver
-       = mpElectricsProblem->CreateSolver();
+    AbstractDynamicLinearPdeSolver<DIM,DIM,ELEC_PROB_DIM>* p_electrics_solver = mpElectricsProblem->CreateSolver();
 
     // set up initial voltage etc
     Vec electrics_solution=NULL; //This will be set and used later

--- a/heart/src/problem/Electrodes.cpp
+++ b/heart/src/problem/Electrodes.cpp
@@ -88,8 +88,7 @@ Electrodes<DIM>::Electrodes(AbstractTetrahedralMesh<DIM,DIM>& rMesh)
 
     // loop over boundary elements and add a non-zero phi_e boundary condition (ie extracellular
     // stimulus) if (assuming axis_index=0, etc) x=lowerValue (where x is the x-value of the centroid)
-    for (typename AbstractTetrahedralMesh<DIM,DIM>::BoundaryElementIterator iter
-            = mpMesh->GetBoundaryElementIteratorBegin();
+    for (auto iter = mpMesh->GetBoundaryElementIteratorBegin();
        iter != mpMesh->GetBoundaryElementIteratorEnd();
        iter++)
     {
@@ -179,8 +178,7 @@ void Electrodes<DIM>::ComputeElectrodesAreasAndCheckEquality(unsigned dimensionI
     c_vector<double,DIM> weighted_direction;
     double jacobian_determinant;
 
-    for (typename AbstractTetrahedralMesh<DIM,DIM>::BoundaryElementIterator iter
-             = mpMesh->GetBoundaryElementIteratorBegin();
+    for (auto iter = mpMesh->GetBoundaryElementIteratorBegin();
          iter != mpMesh->GetBoundaryElementIteratorEnd();
          iter++)
     {

--- a/heart/src/problem/HeartConfig.cpp
+++ b/heart/src/problem/HeartConfig.cpp
@@ -1130,9 +1130,7 @@ void HeartConfig::GetCellHeterogeneities(std::vector<boost::shared_ptr<AbstractC
         // finding no heterogeneities defined is allowed
         return;
     }
-    XSD_SEQUENCE_TYPE(cp::cell_heterogeneities_type::CellHeterogeneity)
-    cell_heterogeneity
-        = mpParameters->Simulation()->CellHeterogeneities()->CellHeterogeneity();
+    auto cell_heterogeneity = mpParameters->Simulation()->CellHeterogeneities()->CellHeterogeneity();
 
     bool user_supplied_negative_value = false;
     mUserAskedForCellularTransmuralHeterogeneities = false; // overwritten with true below if necessary
@@ -1443,8 +1441,7 @@ HeartFileFinder HeartConfig::GetArchivedSimulationDir() const
 void HeartConfig::GetIntracellularConductivities(c_vector<double, 3>& rIntraConductivities) const
 {
     CHECK_EXISTS(mpParameters->Physiological().IntracellularConductivities().present(), "Physiological/IntracellularConductivities");
-    cp::conductivities_type intra_conductivities
-        = mpParameters->Physiological().IntracellularConductivities().get();
+    cp::conductivities_type intra_conductivities = mpParameters->Physiological().IntracellularConductivities().get();
     double intra_x_cond = intra_conductivities.longi();
     double intra_y_cond = intra_conductivities.trans();
     double intra_z_cond = intra_conductivities.normal();
@@ -1461,8 +1458,7 @@ void HeartConfig::GetIntracellularConductivities(c_vector<double, 3>& rIntraCond
 void HeartConfig::GetIntracellularConductivities(c_vector<double, 2>& rIntraConductivities) const
 {
     CHECK_EXISTS(mpParameters->Physiological().IntracellularConductivities().present(), "Physiological/IntracellularConductivities");
-    cp::conductivities_type intra_conductivities
-        = mpParameters->Physiological().IntracellularConductivities().get();
+    cp::conductivities_type intra_conductivities = mpParameters->Physiological().IntracellularConductivities().get();
     double intra_x_cond = intra_conductivities.longi();
     double intra_y_cond = intra_conductivities.trans();
 
@@ -1475,8 +1471,7 @@ void HeartConfig::GetIntracellularConductivities(c_vector<double, 2>& rIntraCond
 void HeartConfig::GetIntracellularConductivities(c_vector<double, 1>& rIntraConductivities) const
 {
     CHECK_EXISTS(mpParameters->Physiological().IntracellularConductivities().present(), "Physiological/IntracellularConductivities");
-    cp::conductivities_type intra_conductivities
-        = mpParameters->Physiological().IntracellularConductivities().get();
+    cp::conductivities_type intra_conductivities = mpParameters->Physiological().IntracellularConductivities().get();
     double intra_x_cond = intra_conductivities.longi();
 
     rIntraConductivities[0] = intra_x_cond;
@@ -1485,8 +1480,7 @@ void HeartConfig::GetIntracellularConductivities(c_vector<double, 1>& rIntraCond
 void HeartConfig::GetExtracellularConductivities(c_vector<double, 3>& rExtraConductivities) const
 {
     CHECK_EXISTS(mpParameters->Physiological().ExtracellularConductivities().present(), "Physiological/ExtracellularConductivities");
-    cp::conductivities_type extra_conductivities
-        = mpParameters->Physiological().ExtracellularConductivities().get();
+    cp::conductivities_type extra_conductivities = mpParameters->Physiological().ExtracellularConductivities().get();
     double extra_x_cond = extra_conductivities.longi();
     double extra_y_cond = extra_conductivities.trans();
     double extra_z_cond = extra_conductivities.normal();
@@ -1503,8 +1497,7 @@ void HeartConfig::GetExtracellularConductivities(c_vector<double, 3>& rExtraCond
 void HeartConfig::GetExtracellularConductivities(c_vector<double, 2>& rExtraConductivities) const
 {
     CHECK_EXISTS(mpParameters->Physiological().ExtracellularConductivities().present(), "Physiological/ExtracellularConductivities");
-    cp::conductivities_type extra_conductivities
-        = mpParameters->Physiological().ExtracellularConductivities().get();
+    cp::conductivities_type extra_conductivities = mpParameters->Physiological().ExtracellularConductivities().get();
     double extra_x_cond = extra_conductivities.longi();
     double extra_y_cond = extra_conductivities.trans();
 
@@ -1517,8 +1510,7 @@ void HeartConfig::GetExtracellularConductivities(c_vector<double, 2>& rExtraCond
 void HeartConfig::GetExtracellularConductivities(c_vector<double, 1>& rExtraConductivities) const
 {
     CHECK_EXISTS(mpParameters->Physiological().ExtracellularConductivities().present(), "Physiological/ExtracellularConductivities");
-    cp::conductivities_type extra_conductivities
-        = mpParameters->Physiological().ExtracellularConductivities().get();
+    cp::conductivities_type extra_conductivities = mpParameters->Physiological().ExtracellularConductivities().get();
     double extra_x_cond = extra_conductivities.longi();
 
     rExtraConductivities[0] = extra_x_cond;
@@ -1738,7 +1730,7 @@ bool HeartConfig::IsApdMapsRequested() const
     bool result = false;
     if (IsPostProcessingSectionPresent())
     {
-        XSD_SEQUENCE_TYPE(cp::postprocessing_type::ActionPotentialDurationMap)& apd_maps = mpParameters->PostProcessing()->ActionPotentialDurationMap();
+        auto& apd_maps = mpParameters->PostProcessing()->ActionPotentialDurationMap();
         result = (apd_maps.begin() != apd_maps.end());
     }
     return result;
@@ -1749,7 +1741,7 @@ void HeartConfig::GetApdMaps(std::vector<std::pair<double, double> >& apd_maps) 
     CHECK_EXISTS(IsApdMapsRequested(), "PostProcessing/ActionPotentialDurationMap");
     apd_maps.clear();
 
-    XSD_SEQUENCE_TYPE(cp::postprocessing_type::ActionPotentialDurationMap)& apd_maps_sequence = mpParameters->PostProcessing()->ActionPotentialDurationMap();
+    auto& apd_maps_sequence = mpParameters->PostProcessing()->ActionPotentialDurationMap();
 
     for (XSD_ITERATOR_TYPE(cp::postprocessing_type::ActionPotentialDurationMap) i = apd_maps_sequence.begin();
          i != apd_maps_sequence.end();
@@ -1766,7 +1758,7 @@ bool HeartConfig::IsUpstrokeTimeMapsRequested() const
     bool result = false;
     if (IsPostProcessingSectionPresent())
     {
-        XSD_SEQUENCE_TYPE(cp::postprocessing_type::UpstrokeTimeMap)& upstroke_map = mpParameters->PostProcessing()->UpstrokeTimeMap();
+        auto& upstroke_map = mpParameters->PostProcessing()->UpstrokeTimeMap();
         result = (upstroke_map.begin() != upstroke_map.end());
     }
     return result;
@@ -1776,7 +1768,7 @@ void HeartConfig::GetUpstrokeTimeMaps(std::vector<double>& upstroke_time_maps) c
     CHECK_EXISTS(IsUpstrokeTimeMapsRequested(), "PostProcessing/UpstrokeTimeMap");
     assert(upstroke_time_maps.size() == 0);
 
-    XSD_SEQUENCE_TYPE(cp::postprocessing_type::UpstrokeTimeMap)& upstroke_maps_sequence = mpParameters->PostProcessing()->UpstrokeTimeMap();
+    auto& upstroke_maps_sequence = mpParameters->PostProcessing()->UpstrokeTimeMap();
 
     for (XSD_ITERATOR_TYPE(cp::postprocessing_type::UpstrokeTimeMap) i = upstroke_maps_sequence.begin();
          i != upstroke_maps_sequence.end();
@@ -1791,7 +1783,7 @@ bool HeartConfig::IsMaxUpstrokeVelocityMapRequested() const
     bool result = false;
     if (IsPostProcessingSectionPresent())
     {
-        XSD_SEQUENCE_TYPE(cp::postprocessing_type::MaxUpstrokeVelocityMap)& max_upstroke_velocity_map = mpParameters->PostProcessing()->MaxUpstrokeVelocityMap();
+        auto& max_upstroke_velocity_map = mpParameters->PostProcessing()->MaxUpstrokeVelocityMap();
         result = (max_upstroke_velocity_map.begin() != max_upstroke_velocity_map.end());
     }
     return result;
@@ -1802,7 +1794,7 @@ void HeartConfig::GetMaxUpstrokeVelocityMaps(std::vector<double>& upstroke_veloc
     CHECK_EXISTS(IsMaxUpstrokeVelocityMapRequested(), "PostProcessing/MaxUpstrokeVelocityMap");
     assert(upstroke_velocity_maps.size() == 0);
 
-    XSD_SEQUENCE_TYPE(cp::postprocessing_type::MaxUpstrokeVelocityMap)& max_upstroke_velocity_maps_sequence = mpParameters->PostProcessing()->MaxUpstrokeVelocityMap();
+    auto& max_upstroke_velocity_maps_sequence = mpParameters->PostProcessing()->MaxUpstrokeVelocityMap();
 
     for (XSD_ITERATOR_TYPE(cp::postprocessing_type::MaxUpstrokeVelocityMap) i = max_upstroke_velocity_maps_sequence.begin();
          i != max_upstroke_velocity_maps_sequence.end();
@@ -1817,7 +1809,7 @@ bool HeartConfig::IsConductionVelocityMapsRequested() const
     bool result = false;
     if (IsPostProcessingSectionPresent())
     {
-        XSD_SEQUENCE_TYPE(cp::postprocessing_type::ConductionVelocityMap)& cond_vel_maps = mpParameters->PostProcessing()->ConductionVelocityMap();
+        auto& cond_vel_maps = mpParameters->PostProcessing()->ConductionVelocityMap();
         result = (cond_vel_maps.begin() != cond_vel_maps.end());
     }
     return result;
@@ -1828,7 +1820,7 @@ void HeartConfig::GetConductionVelocityMaps(std::vector<unsigned>& conduction_ve
     CHECK_EXISTS(IsConductionVelocityMapsRequested(), "PostProcessing/ConductionVelocityMap");
     assert(conduction_velocity_maps.size() == 0);
 
-    XSD_SEQUENCE_TYPE(cp::postprocessing_type::ConductionVelocityMap)& cond_vel_maps_sequence = mpParameters->PostProcessing()->ConductionVelocityMap();
+    auto& cond_vel_maps_sequence = mpParameters->PostProcessing()->ConductionVelocityMap();
 
     for (XSD_ITERATOR_TYPE(cp::postprocessing_type::ConductionVelocityMap) i = cond_vel_maps_sequence.begin();
          i != cond_vel_maps_sequence.end();
@@ -1843,7 +1835,7 @@ bool HeartConfig::IsAnyNodalTimeTraceRequested() const
     bool result = false;
     if (IsPostProcessingSectionPresent())
     {
-        XSD_SEQUENCE_TYPE(cp::postprocessing_type::TimeTraceAtNode)& requested_nodes = mpParameters->PostProcessing()->TimeTraceAtNode();
+        auto& requested_nodes = mpParameters->PostProcessing()->TimeTraceAtNode();
         result = (requested_nodes.begin() != requested_nodes.end());
     }
     return result;
@@ -1854,7 +1846,7 @@ void HeartConfig::GetNodalTimeTraceRequested(std::vector<unsigned>& rRequestedNo
     CHECK_EXISTS(IsAnyNodalTimeTraceRequested(), "PostProcessing/TimeTraceAtNode");
     assert(rRequestedNodes.size() == 0);
 
-    XSD_SEQUENCE_TYPE(cp::postprocessing_type::TimeTraceAtNode)& req_nodes = mpParameters->PostProcessing()->TimeTraceAtNode();
+    auto& req_nodes = mpParameters->PostProcessing()->TimeTraceAtNode();
 
     for (XSD_ITERATOR_TYPE(cp::postprocessing_type::TimeTraceAtNode) i = req_nodes.begin();
          i != req_nodes.end();
@@ -1869,7 +1861,7 @@ bool HeartConfig::IsPseudoEcgCalculationRequested() const
     bool result = false;
     if (IsPostProcessingSectionPresent())
     {
-        XSD_SEQUENCE_TYPE(cp::postprocessing_type::PseudoEcgElectrodePosition)& electrodes = mpParameters->PostProcessing()->PseudoEcgElectrodePosition();
+        auto& electrodes = mpParameters->PostProcessing()->PseudoEcgElectrodePosition();
         result = (electrodes.begin() != electrodes.end());
     }
     return result;
@@ -1879,7 +1871,7 @@ template <unsigned SPACE_DIM>
 void HeartConfig::GetPseudoEcgElectrodePositions(std::vector<ChastePoint<SPACE_DIM> >& rPseudoEcgElectrodePositions) const
 {
     rPseudoEcgElectrodePositions.clear();
-    XSD_SEQUENCE_TYPE(cp::postprocessing_type::PseudoEcgElectrodePosition)& electrodes = mpParameters->PostProcessing()->PseudoEcgElectrodePosition();
+    auto& electrodes = mpParameters->PostProcessing()->PseudoEcgElectrodePosition();
     for (XSD_ITERATOR_TYPE(cp::postprocessing_type::PseudoEcgElectrodePosition) i = electrodes.begin();
          i != electrodes.end();
          ++i)
@@ -2536,8 +2528,7 @@ void HeartConfig::SetMeshPartitioning(const char* meshPartioningMethod)
 void HeartConfig::SetApdMaps(const std::vector<std::pair<double, double> >& apdMaps)
 {
     EnsurePostProcessingSectionPresent();
-    XSD_SEQUENCE_TYPE(cp::postprocessing_type::ActionPotentialDurationMap)& apd_maps_sequence
-        = mpParameters->PostProcessing()->ActionPotentialDurationMap();
+    auto& apd_maps_sequence = mpParameters->PostProcessing()->ActionPotentialDurationMap();
     //Erase or create a sequence
     apd_maps_sequence.clear();
 
@@ -2553,8 +2544,7 @@ void HeartConfig::SetApdMaps(const std::vector<std::pair<double, double> >& apdM
 void HeartConfig::SetUpstrokeTimeMaps(std::vector<double>& upstrokeTimeMaps)
 {
     EnsurePostProcessingSectionPresent();
-    XSD_SEQUENCE_TYPE(cp::postprocessing_type::UpstrokeTimeMap)& var_type_sequence
-        = mpParameters->PostProcessing()->UpstrokeTimeMap();
+    auto& var_type_sequence = mpParameters->PostProcessing()->UpstrokeTimeMap();
 
     //Erase or create a sequence
     var_type_sequence.clear();
@@ -2571,8 +2561,7 @@ void HeartConfig::SetUpstrokeTimeMaps(std::vector<double>& upstrokeTimeMaps)
 void HeartConfig::SetMaxUpstrokeVelocityMaps(std::vector<double>& maxUpstrokeVelocityMaps)
 {
     EnsurePostProcessingSectionPresent();
-    XSD_SEQUENCE_TYPE(cp::postprocessing_type::MaxUpstrokeVelocityMap)& max_upstroke_velocity_maps_sequence
-        = mpParameters->PostProcessing()->MaxUpstrokeVelocityMap();
+    auto& max_upstroke_velocity_maps_sequence = mpParameters->PostProcessing()->MaxUpstrokeVelocityMap();
 
     //Erase or create a sequence
     max_upstroke_velocity_maps_sequence.clear();
@@ -2590,8 +2579,7 @@ void HeartConfig::SetMaxUpstrokeVelocityMaps(std::vector<double>& maxUpstrokeVel
 void HeartConfig::SetConductionVelocityMaps(std::vector<unsigned>& conductionVelocityMaps)
 {
     EnsurePostProcessingSectionPresent();
-    XSD_SEQUENCE_TYPE(cp::postprocessing_type::ConductionVelocityMap)& conduction_velocity_maps_sequence
-        = mpParameters->PostProcessing()->ConductionVelocityMap();
+    auto& conduction_velocity_maps_sequence = mpParameters->PostProcessing()->ConductionVelocityMap();
 
     //Erase or create a sequence
     conduction_velocity_maps_sequence.clear();
@@ -2606,8 +2594,7 @@ void HeartConfig::SetConductionVelocityMaps(std::vector<unsigned>& conductionVel
 void HeartConfig::SetRequestedNodalTimeTraces(std::vector<unsigned>& requestedNodes)
 {
     EnsurePostProcessingSectionPresent();
-    XSD_SEQUENCE_TYPE(cp::postprocessing_type::TimeTraceAtNode)& requested_nodes_sequence
-        = mpParameters->PostProcessing()->TimeTraceAtNode();
+    auto& requested_nodes_sequence = mpParameters->PostProcessing()->TimeTraceAtNode();
 
     //Erase or create a sequence
     requested_nodes_sequence.clear();
@@ -2623,8 +2610,7 @@ template <unsigned SPACE_DIM>
 void HeartConfig::SetPseudoEcgElectrodePositions(const std::vector<ChastePoint<SPACE_DIM> >& rPseudoEcgElectrodePositions)
 {
     EnsurePostProcessingSectionPresent();
-    XSD_SEQUENCE_TYPE(cp::postprocessing_type::PseudoEcgElectrodePosition)& electrodes_sequence
-        = mpParameters->PostProcessing()->PseudoEcgElectrodePosition();
+    auto& electrodes_sequence = mpParameters->PostProcessing()->PseudoEcgElectrodePosition();
 
     //Erase or create a sequence
     electrodes_sequence.clear();

--- a/heart/src/solver/electrics/bidomain/AbstractBidomainSolver.cpp
+++ b/heart/src/solver/electrics/bidomain/AbstractBidomainSolver.cpp
@@ -279,8 +279,7 @@ void AbstractBidomainSolver<ELEMENT_DIM,SPACE_DIM>::SetFixedExtracellularPotenti
     {
         if (this->mpMesh->GetDistributedVectorFactory()->IsGlobalIndexLocal(mFixedExtracellularPotentialNodes[i]))
         {
-            ConstBoundaryCondition<SPACE_DIM>* p_boundary_condition
-                 = new ConstBoundaryCondition<SPACE_DIM>(0.0);
+            auto* p_boundary_condition = new ConstBoundaryCondition<SPACE_DIM>(0.0);
 
             //Throws if node is not owned locally
             Node<SPACE_DIM>* p_node = this->mpMesh->GetNode(mFixedExtracellularPotentialNodes[i]);

--- a/heart/src/solver/electrics/bidomain/BidomainAssembler.cpp
+++ b/heart/src/solver/electrics/bidomain/BidomainAssembler.cpp
@@ -58,15 +58,12 @@ c_matrix<double,2*(ELEMENT_DIM+1),2*(ELEMENT_DIM+1)>
 
 
     c_matrix<double, SPACE_DIM, ELEMENT_DIM+1> temp = prod(sigma_i, rGradPhi);
-    c_matrix<double, ELEMENT_DIM+1, ELEMENT_DIM+1> grad_phi_sigma_i_grad_phi =
-        prod(trans(rGradPhi), temp);
+    c_matrix<double, ELEMENT_DIM+1, ELEMENT_DIM+1> grad_phi_sigma_i_grad_phi = prod(trans(rGradPhi), temp);
 
-    c_matrix<double, ELEMENT_DIM+1, ELEMENT_DIM+1> basis_outer_prod =
-        outer_prod(rPhi, rPhi);
+    c_matrix<double, ELEMENT_DIM+1, ELEMENT_DIM+1> basis_outer_prod = outer_prod(rPhi, rPhi);
 
     c_matrix<double, SPACE_DIM, ELEMENT_DIM+1> temp2 = prod(sigma_e, rGradPhi);
-    c_matrix<double, ELEMENT_DIM+1, ELEMENT_DIM+1> grad_phi_sigma_e_grad_phi =
-        prod(trans(rGradPhi), temp2);
+    c_matrix<double, ELEMENT_DIM+1, ELEMENT_DIM+1> grad_phi_sigma_e_grad_phi = prod(trans(rGradPhi), temp2);
 
 
     c_matrix<double,2*(ELEMENT_DIM+1),2*(ELEMENT_DIM+1)> ret;

--- a/heart/src/solver/electrics/bidomain/BidomainSolver.cpp
+++ b/heart/src/solver/electrics/bidomain/BidomainSolver.cpp
@@ -223,8 +223,7 @@ BidomainSolver<ELEMENT_DIM,SPACE_DIM>::BidomainSolver(
 
     if (HeartConfig::Instance()->GetUseStateVariableInterpolation())
     {
-        mpBidomainCorrectionTermAssembler
-            = new BidomainCorrectionTermAssembler<ELEMENT_DIM,SPACE_DIM>(this->mpMesh,this->mpBidomainTissue);
+        mpBidomainCorrectionTermAssembler = new BidomainCorrectionTermAssembler<ELEMENT_DIM,SPACE_DIM>(this->mpMesh,this->mpBidomainTissue);
         //We are going to need those caches after all
         pTissue->SetCacheReplication(true);
     }

--- a/heart/src/solver/electrics/bidomain/BidomainWithBathAssembler.cpp
+++ b/heart/src/solver/electrics/bidomain/BidomainWithBathAssembler.cpp
@@ -54,8 +54,7 @@ c_matrix<double,2*(ELEMENT_DIM+1),2*(ELEMENT_DIM+1)>
     {
         double bath_cond=HeartConfig::Instance()->GetBathConductivity(pElement->GetUnsignedAttribute());
 
-        c_matrix<double, ELEMENT_DIM+1, ELEMENT_DIM+1> grad_phi_sigma_b_grad_phi =
-            bath_cond * prod(trans(rGradPhi), rGradPhi);
+        c_matrix<double, ELEMENT_DIM+1, ELEMENT_DIM+1> grad_phi_sigma_b_grad_phi = bath_cond * prod(trans(rGradPhi), rGradPhi);
 
         c_matrix<double,2*(ELEMENT_DIM+1),2*(ELEMENT_DIM+1)> ret = zero_matrix<double>(2*(ELEMENT_DIM+1));
 

--- a/heart/src/solver/electrics/extended_bidomain/ExtendedBidomainAssembler.cpp
+++ b/heart/src/solver/electrics/extended_bidomain/ExtendedBidomainAssembler.cpp
@@ -63,19 +63,15 @@ c_matrix<double,3*(ELEMENT_DIM+1),3*(ELEMENT_DIM+1)>
     double delta_t = PdeSimulationTime::GetPdeTimeStep();
 
     c_matrix<double, SPACE_DIM, ELEMENT_DIM+1> temp_1 = prod(sigma_i_first_cell, rGradPhi);
-    c_matrix<double, ELEMENT_DIM+1, ELEMENT_DIM+1> grad_phi_sigma_i_first_cell_grad_phi =
-        prod(trans(rGradPhi), temp_1);
+    c_matrix<double, ELEMENT_DIM+1, ELEMENT_DIM+1> grad_phi_sigma_i_first_cell_grad_phi = prod(trans(rGradPhi), temp_1);
 
     c_matrix<double, SPACE_DIM, ELEMENT_DIM+1> temp_2 = prod(sigma_i_second_cell, rGradPhi);
-    c_matrix<double, ELEMENT_DIM+1, ELEMENT_DIM+1> grad_phi_sigma_i_second_cell_grad_phi =
-        prod(trans(rGradPhi), temp_2);
+    c_matrix<double, ELEMENT_DIM+1, ELEMENT_DIM+1> grad_phi_sigma_i_second_cell_grad_phi = prod(trans(rGradPhi), temp_2);
 
-    c_matrix<double, ELEMENT_DIM+1, ELEMENT_DIM+1> basis_outer_prod =
-        outer_prod(rPhi, rPhi);
+    c_matrix<double, ELEMENT_DIM+1, ELEMENT_DIM+1> basis_outer_prod = outer_prod(rPhi, rPhi);
 
     c_matrix<double, SPACE_DIM, ELEMENT_DIM+1> temp_ext = prod(sigma_e, rGradPhi);
-    c_matrix<double, ELEMENT_DIM+1, ELEMENT_DIM+1> grad_phi_sigma_e_grad_phi =
-        prod(trans(rGradPhi), temp_ext);
+    c_matrix<double, ELEMENT_DIM+1, ELEMENT_DIM+1> grad_phi_sigma_e_grad_phi = prod(trans(rGradPhi), temp_ext);
 
 
     c_matrix<double,3*(ELEMENT_DIM+1),3*(ELEMENT_DIM+1)> ret;

--- a/heart/src/solver/electrics/monodomain/MonodomainPurkinjeVolumeAssembler.cpp
+++ b/heart/src/solver/electrics/monodomain/MonodomainPurkinjeVolumeAssembler.cpp
@@ -53,11 +53,9 @@ c_matrix<double,2*(ELEMENT_DIM+1),2*(ELEMENT_DIM+1)> MonodomainPurkinjeVolumeAss
     c_vector<double,1> empty_u; /* should pass in rU(1) here, but it won't be used */
     c_matrix<double,1,SPACE_DIM> empty_grad_u; /* ditto above */
 
-    c_matrix<double,ELEMENT_DIM+1,ELEMENT_DIM+1> normal_monodomain_mat
-        = mMonodomainAssembler.ComputeMatrixTerm(rPhi,rGradPhi,rX,empty_u,empty_grad_u,pElement);
+    c_matrix<double,ELEMENT_DIM+1,ELEMENT_DIM+1> normal_monodomain_mat = mMonodomainAssembler.ComputeMatrixTerm(rPhi,rGradPhi,rX,empty_u,empty_grad_u,pElement);
 
-    c_matrix<double,2*(ELEMENT_DIM+1),2*(ELEMENT_DIM+1)> ret
-        = zero_matrix<double>(2*(ELEMENT_DIM+1),2*(ELEMENT_DIM+1));
+    c_matrix<double,2*(ELEMENT_DIM+1),2*(ELEMENT_DIM+1)> ret = zero_matrix<double>(2*(ELEMENT_DIM+1),2*(ELEMENT_DIM+1));
 
     // even rows, even columns
     matrix_slice<c_matrix<double, 2*ELEMENT_DIM+2, 2*ELEMENT_DIM+2> >

--- a/heart/src/solver/electrics/monodomain/MonodomainPurkinjeVolumeMassMatrixAssembler.hpp
+++ b/heart/src/solver/electrics/monodomain/MonodomainPurkinjeVolumeMassMatrixAssembler.hpp
@@ -105,8 +105,7 @@ public:
 //            }
         }
 
-        c_matrix<double,2*(ELEMENT_DIM+1),2*(ELEMENT_DIM+1)> ret
-                = zero_matrix<double>(2*(ELEMENT_DIM+1),2*(ELEMENT_DIM+1));
+        c_matrix<double,2*(ELEMENT_DIM+1),2*(ELEMENT_DIM+1)> ret = zero_matrix<double>(2*(ELEMENT_DIM+1),2*(ELEMENT_DIM+1));
         // even rows, even columns
         matrix_slice<c_matrix<double, 2*ELEMENT_DIM+2, 2*ELEMENT_DIM+2> >
         slice00(ret, slice(0, 2, ELEMENT_DIM+1), slice(0, 2, ELEMENT_DIM+1));

--- a/heart/src/solver/electrics/monodomain/MonodomainSolver.cpp
+++ b/heart/src/solver/electrics/monodomain/MonodomainSolver.cpp
@@ -199,8 +199,7 @@ MonodomainSolver<ELEMENT_DIM,SPACE_DIM>::MonodomainSolver(
 
     if (HeartConfig::Instance()->GetUseStateVariableInterpolation())
     {
-        mpMonodomainCorrectionTermAssembler
-            = new MonodomainCorrectionTermAssembler<ELEMENT_DIM,SPACE_DIM>(this->mpMesh,this->mpMonodomainTissue);
+        mpMonodomainCorrectionTermAssembler = new MonodomainCorrectionTermAssembler<ELEMENT_DIM,SPACE_DIM>(this->mpMesh,this->mpMonodomainTissue);
         //We are going to need those caches after all
         pTissue->SetCacheReplication(true);
     }

--- a/heart/src/solver/electrics/monodomain/MonodomainStiffnessMatrixAssembler.hpp
+++ b/heart/src/solver/electrics/monodomain/MonodomainStiffnessMatrixAssembler.hpp
@@ -77,8 +77,7 @@ public:
         const c_matrix<double, SPACE_DIM, SPACE_DIM>& sigma_i = this->mpCardiacTissue->rGetIntracellularConductivityTensor(pElement->GetIndex());
 
         c_matrix<double, SPACE_DIM, ELEMENT_DIM+1> temp = prod(sigma_i, rGradPhi);
-        c_matrix<double, ELEMENT_DIM+1, ELEMENT_DIM+1> grad_phi_sigma_i_grad_phi =
-            prod(trans(rGradPhi), temp);
+        c_matrix<double, ELEMENT_DIM+1, ELEMENT_DIM+1> grad_phi_sigma_i_grad_phi = prod(trans(rGradPhi), temp);
 
         return grad_phi_sigma_i_grad_phi;
     }

--- a/heart/src/tissue/AbstractCardiacTissue.cpp
+++ b/heart/src/tissue/AbstractCardiacTissue.cpp
@@ -89,8 +89,7 @@ AbstractCardiacTissue<ELEMENT_DIM,SPACE_DIM>::AbstractCardiacTissue(
     mCellsDistributed.resize(num_local_nodes);
 
     // Figure out if we're dealing with Purkinje
-    AbstractPurkinjeCellFactory<ELEMENT_DIM,SPACE_DIM>* p_purkinje_cell_factory
-       = dynamic_cast<AbstractPurkinjeCellFactory<ELEMENT_DIM,SPACE_DIM>*>(pCellFactory);
+    auto* p_purkinje_cell_factory = dynamic_cast<AbstractPurkinjeCellFactory<ELEMENT_DIM,SPACE_DIM>*>(pCellFactory);
     if (p_purkinje_cell_factory)
     {
         mHasPurkinje = true;
@@ -111,8 +110,7 @@ AbstractCardiacTissue<ELEMENT_DIM,SPACE_DIM>::AbstractCardiacTissue(
 
             if (mHasPurkinje)
             {
-                mPurkinjeCellsDistributed[local_index]
-                    = p_purkinje_cell_factory->CreatePurkinjeCellForNode(p_node, mCellsDistributed[local_index]);
+                mPurkinjeCellsDistributed[local_index] = p_purkinje_cell_factory->CreatePurkinjeCellForNode(p_node, mCellsDistributed[local_index]);
                 mPurkinjeCellsDistributed[local_index]->SetUsedInTissueSimulation();
             }
         }

--- a/lung/src/ventilation/AbstractVentilationProblem.cpp
+++ b/lung/src/ventilation/AbstractVentilationProblem.cpp
@@ -364,8 +364,7 @@ void AbstractVentilationProblem::SetPerGenerationDynamicResistance()
      * Generation: 0     1     2     3     4     5     6     7     >7
      * Gamma:      0.162 0.239 0.244 0.295 0.175 0.303 0.356 0.566 0.327
      */
-    double per_generation_pedley[9] =
-            {0.162, 0.239, 0.244, 0.295, 0.175, 0.303, 0.356, 0.566, 0.327};
+    double per_generation_pedley[9] = {0.162, 0.239, 0.244, 0.295, 0.175, 0.303, 0.356, 0.566, 0.327};
 
     // Convert from gamma to C
     for (unsigned i=0; i<9; i++)

--- a/mesh/src/common/AbstractTetrahedralMesh.hpp
+++ b/mesh/src/common/AbstractTetrahedralMesh.hpp
@@ -146,8 +146,7 @@ private:
 
             // Mesh in disc, copy it to the archiving folder
             std::string original_file=this->GetMeshFileBaseName();
-            std::shared_ptr<AbstractMeshReader<ELEMENT_DIM, SPACE_DIM> > p_original_mesh_reader
-                = GenericMeshReader<ELEMENT_DIM, SPACE_DIM>(original_file, order_of_element, order_of_boundary_element);
+            auto p_original_mesh_reader = GenericMeshReader<ELEMENT_DIM, SPACE_DIM>(original_file, order_of_element, order_of_boundary_element);
 
             if (p_original_mesh_reader->IsFileFormatBinary())
             {

--- a/mesh/src/common/DistributedTetrahedralMesh.cpp
+++ b/mesh/src/common/DistributedTetrahedralMesh.cpp
@@ -315,8 +315,7 @@ void DistributedTetrahedralMesh<ELEMENT_DIM, SPACE_DIM>::ConstructFromMeshReader
         }
     }
 
-    for (typename AbstractMeshReader<ELEMENT_DIM, SPACE_DIM>::ElementIterator elem_it
-             = rMeshReader.GetElementIteratorBegin(elements_owned);
+    for (auto elem_it = rMeshReader.GetElementIteratorBegin(elements_owned);
          elem_it != rMeshReader.GetElementIteratorEnd();
          ++elem_it)
     {

--- a/mesh/src/common/MutableMesh.cpp
+++ b/mesh/src/common/MutableMesh.cpp
@@ -385,8 +385,7 @@ void MutableMesh<ELEMENT_DIM, SPACE_DIM>::MoveMergeNode(unsigned index,
         }
     }
 
-    for (std::set<unsigned>::const_iterator boundary_element_iter=
-                 unshared_boundary_element_indices.begin();
+    for (auto boundary_element_iter = unshared_boundary_element_indices.begin();
              boundary_element_iter != unshared_boundary_element_indices.end();
              boundary_element_iter++)
     {
@@ -487,8 +486,7 @@ unsigned MutableMesh<ELEMENT_DIM, SPACE_DIM>::RefineElement(
             mDeletedElementIndices.pop_back();
         }
 
-        Element<ELEMENT_DIM,SPACE_DIM>* p_new_element=
-            new Element<ELEMENT_DIM,SPACE_DIM>(*pElement, new_elt_index);
+        auto* p_new_element = new Element<ELEMENT_DIM,SPACE_DIM>(*pElement, new_elt_index);
 
         // Second, update the node in the element with the new one
         p_new_element->UpdateNode(ELEMENT_DIM-1-i, this->mNodes[new_node_index]);
@@ -523,8 +521,7 @@ void MutableMesh<ELEMENT_DIM, SPACE_DIM>::DeleteBoundaryNodeAt(unsigned index)
     mDeletedNodeIndices.push_back(index);
 
     // Update the boundary node vector
-    typename std::vector<Node<SPACE_DIM>*>::iterator b_node_iter
-    = std::find(this->mBoundaryNodes.begin(), this->mBoundaryNodes.end(), this->mNodes[index]);
+    auto b_node_iter = std::find(this->mBoundaryNodes.begin(), this->mBoundaryNodes.end(), this->mNodes[index]);
     this->mBoundaryNodes.erase(b_node_iter);
 
     // Remove boundary elements containing this node
@@ -940,7 +937,7 @@ c_vector<unsigned, 3> MutableMesh<ELEMENT_DIM, SPACE_DIM>::SplitEdge(Node<SPACE_
         Element<ELEMENT_DIM,SPACE_DIM>* p_original_element = this->GetElement(elementIndex);
 
         // First, make a copy of the current element and assign an unused index
-        Element<ELEMENT_DIM,SPACE_DIM>* p_new_element = new Element<ELEMENT_DIM,SPACE_DIM>(*p_original_element, UINT_MAX);
+        auto* p_new_element = new Element<ELEMENT_DIM,SPACE_DIM>(*p_original_element, UINT_MAX);
 
         // Second, add the new element to the set of existing elements. This method will assign a proper index to the element.
         AddElement(p_new_element);

--- a/mesh/src/common/QuadraticMeshHelper.cpp
+++ b/mesh/src/common/QuadraticMeshHelper.cpp
@@ -149,8 +149,7 @@ void QuadraticMeshHelper<DIM>::AddNodesToBoundaryElements(AbstractTetrahedralMes
         // This counter keeps track of our position in the file.
         unsigned next_face_on_file = 0u;
 
-        for (typename AbstractTetrahedralMesh<DIM,DIM>::BoundaryElementIterator iter
-                 = pMesh->GetBoundaryElementIteratorBegin();
+        for (auto iter = pMesh->GetBoundaryElementIteratorBegin();
              iter != pMesh->GetBoundaryElementIteratorEnd();
              ++iter)
         {
@@ -247,8 +246,7 @@ void QuadraticMeshHelper<DIM>::CheckBoundaryElements(AbstractTetrahedralMesh<DIM
 {
 #ifndef NDEBUG
     unsigned expected_num_nodes = DIM*(DIM+1)/2;
-    for (typename AbstractTetrahedralMesh<DIM,DIM>::BoundaryElementIterator iter
-             = pMesh->GetBoundaryElementIteratorBegin();
+    for (auto iter = pMesh->GetBoundaryElementIteratorBegin();
          iter != pMesh->GetBoundaryElementIteratorEnd();
          ++iter)
     {

--- a/mesh/src/immersed_boundary/ImmersedBoundaryPalisadeMeshGenerator.cpp
+++ b/mesh/src/immersed_boundary/ImmersedBoundaryPalisadeMeshGenerator.cpp
@@ -171,8 +171,7 @@ ImmersedBoundaryPalisadeMeshGenerator::ImmersedBoundaryPalisadeMeshGenerator(uns
         EXCEPTION("Something went wrong when tagging corner locations"); //LCOV_EXCL_LINE
     }
 
-    if ( corner_indices[LEFT_APICAL_CORNER] - corner_indices[RIGHT_APICAL_CORNER] !=
-         corner_indices[RIGHT_BASAL_CORNER] - corner_indices[LEFT_BASAL_CORNER] )
+    if ( corner_indices[LEFT_APICAL_CORNER] - corner_indices[RIGHT_APICAL_CORNER] != corner_indices[RIGHT_BASAL_CORNER] - corner_indices[LEFT_BASAL_CORNER] )
     {
         EXCEPTION("Apical and basal surfaces are different sizes"); //LCOV_EXCL_LINE
     }

--- a/mesh/src/vertex/MutableVertexMesh.cpp
+++ b/mesh/src/vertex/MutableVertexMesh.cpp
@@ -2234,10 +2234,8 @@ void MutableVertexMesh<ELEMENT_DIM, SPACE_DIM>::PerformIntersectionSwap(
                     mOperationRecorder.RecordNewEdgeOperation(this->mElements[element_1_index], node_A_local_index_in_1);
             }
             this->mElements[element_3_index]->AddNode(this->mNodes[node_A_index], node_B_local_index_in_3);
-            c_vector<double, SPACE_DIM> vector_B_to_node
-                = this->GetVectorFromAtoB(this->GetElement(elementIndex)->GetNode(intersected_edge)->rGetLocation(), this->mNodes[node_B_index]->rGetLocation());
-            c_vector<double, SPACE_DIM> vector_A_to_B
-                = this->GetVectorFromAtoB(this->mNodes[node_B_index]->rGetLocation(), this->mNodes[node_A_index]->rGetLocation());
+            c_vector<double, SPACE_DIM> vector_B_to_node = this->GetVectorFromAtoB(this->GetElement(elementIndex)->GetNode(intersected_edge)->rGetLocation(), this->mNodes[node_B_index]->rGetLocation());
+            c_vector<double, SPACE_DIM> vector_A_to_B = this->GetVectorFromAtoB(this->mNodes[node_B_index]->rGetLocation(), this->mNodes[node_A_index]->rGetLocation());
             // Insertion of node A splits the intersected edge
             if (mTrackMeshOperations)
                 mOperationRecorder.RecordEdgeSplitOperation(this->GetElement(elementIndex), intersected_edge,
@@ -2276,10 +2274,8 @@ void MutableVertexMesh<ELEMENT_DIM, SPACE_DIM>::PerformIntersectionSwap(
 
             unsigned node_before_B_in_3 = (node_B_local_index_in_3 + this->GetElement(element_3_index)->GetNumNodes() - 1) % this->GetElement(element_3_index)->GetNumNodes();
             this->mElements[element_3_index]->AddNode(this->mNodes[node_A_index], node_before_B_in_3);
-            c_vector<double, SPACE_DIM> vector_B_to_node
-                = this->GetVectorFromAtoB(this->GetElement(elementIndex)->GetNode(intersected_edge)->rGetLocation(), this->mNodes[node_B_index]->rGetLocation());
-            c_vector<double, SPACE_DIM> vector_A_to_B
-                = this->GetVectorFromAtoB(this->mNodes[node_B_index]->rGetLocation(), this->mNodes[node_A_index]->rGetLocation());
+            c_vector<double, SPACE_DIM> vector_B_to_node = this->GetVectorFromAtoB(this->GetElement(elementIndex)->GetNode(intersected_edge)->rGetLocation(), this->mNodes[node_B_index]->rGetLocation());
+            c_vector<double, SPACE_DIM> vector_A_to_B = this->GetVectorFromAtoB(this->mNodes[node_B_index]->rGetLocation(), this->mNodes[node_A_index]->rGetLocation());
             // Insertion of node A splits the intersected edge
             if (mTrackMeshOperations)
                 mOperationRecorder.RecordEdgeSplitOperation(this->GetElement(elementIndex), intersected_edge,
@@ -3386,14 +3382,11 @@ void MutableVertexMesh<ELEMENT_DIM, SPACE_DIM>::PerformT3Swap(
 
                     // Add the moved and new nodes to the element (this also updates the node)
                     const double a_to_b_length = norm_2(vector_a_to_b);
-                    const c_vector<double, SPACE_DIM> a_to_node2_vector
-                        = this->GetVectorFromAtoB(new_node_2_location, vertexA);
+                    const c_vector<double, SPACE_DIM> a_to_node2_vector = this->GetVectorFromAtoB(new_node_2_location, vertexA);
                     const double a_to_node2_length = norm_2(a_to_node2_vector);
-                    const c_vector<double, SPACE_DIM> a_to_nodeP_vector
-                        = this->GetVectorFromAtoB(intersection, vertexA);
+                    const c_vector<double, SPACE_DIM> a_to_nodeP_vector = this->GetVectorFromAtoB(intersection, vertexA);
                     const double a_to_nodeP_length = norm_2(a_to_nodeP_vector);
-                    const c_vector<double, SPACE_DIM> a_to_node1_vector
-                        = this->GetVectorFromAtoB(new_node_1_location, vertexA);
+                    const c_vector<double, SPACE_DIM> a_to_node1_vector = this->GetVectorFromAtoB(new_node_1_location, vertexA);
                     const double a_to_node1_length = norm_2(a_to_node1_vector);
 
                     this->GetElement(elementIndex)->AddNode(this->mNodes[new_node_2_global_index], node_A_local_index);

--- a/ode/src/solver/BackwardEulerIvpOdeSolver.cpp
+++ b/ode/src/solver/BackwardEulerIvpOdeSolver.cpp
@@ -68,8 +68,7 @@ void BackwardEulerIvpOdeSolver::ComputeJacobian(AbstractOdeSystem* pAbstractOdeS
     if (pAbstractOdeSystem->GetUseAnalyticJacobian() && !mForceUseOfNumericalJacobian)
     {
         // The ODE system has an analytic jacobian, so use that
-        AbstractOdeSystemWithAnalyticJacobian* p_ode_system
-            = static_cast<AbstractOdeSystemWithAnalyticJacobian*>(pAbstractOdeSystem);
+        auto* p_ode_system = static_cast<AbstractOdeSystemWithAnalyticJacobian*>(pAbstractOdeSystem);
         p_ode_system->AnalyticJacobian(rCurrentGuess, mJacobian, time, timeStep);
     }
     else

--- a/pde/src/common/AbstractBoundaryConditionsContainer.hpp
+++ b/pde/src/common/AbstractBoundaryConditionsContainer.hpp
@@ -100,8 +100,7 @@ protected:
      * @param alreadyDeletedConditions  This is a set of BCs that have already been deleted that we should avoid trying
      *  to delete inside this method. (defaults to empty = delete everything)
      */
-    void DeleteDirichletBoundaryConditions(std::set<const AbstractBoundaryCondition<SPACE_DIM>*> alreadyDeletedConditions
-                                            = std::set<const AbstractBoundaryCondition<SPACE_DIM>*>());
+    void DeleteDirichletBoundaryConditions(std::set<const AbstractBoundaryCondition<SPACE_DIM>*> alreadyDeletedConditions = {});
 
 public:
 

--- a/pde/src/common/BoundaryConditionsContainerImplementation.hpp
+++ b/pde/src/common/BoundaryConditionsContainerImplementation.hpp
@@ -554,8 +554,7 @@ bool BoundaryConditionsContainer<ELEMENT_DIM,SPACE_DIM,PROBLEM_DIM>::Validate(Ab
     for (unsigned index_of_unknown=0; index_of_unknown<PROBLEM_DIM; index_of_unknown++)
     {
         // Iterate over surface elements
-        typename AbstractTetrahedralMesh<ELEMENT_DIM,SPACE_DIM>::BoundaryElementIterator elt_iter
-        = pMesh->GetBoundaryElementIteratorBegin();
+        auto elt_iter = pMesh->GetBoundaryElementIteratorBegin();
         while (valid && elt_iter != pMesh->GetBoundaryElementIteratorEnd())
         {
             if (!HasNeumannBoundaryCondition(*elt_iter, index_of_unknown))

--- a/pde/src/postprocessing/Hdf5ToMeshalyzerConverter.cpp
+++ b/pde/src/postprocessing/Hdf5ToMeshalyzerConverter.cpp
@@ -139,8 +139,7 @@ Hdf5ToMeshalyzerConverter<ELEMENT_DIM,SPACE_DIM>::Hdf5ToMeshalyzerConverter(cons
             ///\todo What if the mesh has been scaled, translated or rotated?
             // Note that the next line will throw if the mesh has not been read from file
             std::string original_file = this->mpMesh->GetMeshFileBaseName();
-            std::shared_ptr<AbstractMeshReader<ELEMENT_DIM, SPACE_DIM> > p_original_mesh_reader
-                = GenericMeshReader<ELEMENT_DIM, SPACE_DIM>(original_file);
+            auto p_original_mesh_reader = GenericMeshReader<ELEMENT_DIM, SPACE_DIM>(original_file);
             mesh_writer.WriteFilesUsingMeshReader(*p_original_mesh_reader);
         }
     }

--- a/pde/src/postprocessing/Hdf5ToVtkConverter.cpp
+++ b/pde/src/postprocessing/Hdf5ToVtkConverter.cpp
@@ -159,8 +159,7 @@ Hdf5ToVtkConverter<ELEMENT_DIM, SPACE_DIM>::Hdf5ToVtkConverter(const FileFinder&
         ///\todo What if the mesh has been scaled, translated or rotated?
         // Note that the next line will throw if the mesh has not been read from file
         std::string original_file = this->mpMesh->GetMeshFileBaseName();
-        std::shared_ptr<AbstractMeshReader<ELEMENT_DIM, SPACE_DIM> > p_original_mesh_reader
-            = GenericMeshReader<ELEMENT_DIM, SPACE_DIM>(original_file);
+        auto p_original_mesh_reader = GenericMeshReader<ELEMENT_DIM, SPACE_DIM>(original_file);
         vtk_writer.WriteFilesUsingMeshReader(*p_original_mesh_reader);
     }
 #endif //CHASTE_VTK

--- a/pde/src/solver/AbstractNonlinearAssemblerSolverHybrid.hpp
+++ b/pde/src/solver/AbstractNonlinearAssemblerSolverHybrid.hpp
@@ -475,8 +475,7 @@ PetscErrorCode AbstractNonlinearAssemblerSolverHybrid_ComputeResidual(SNES snes,
                                                                       void* pContext)
 {
     // Extract the solver from the void*
-    AbstractNonlinearAssemblerSolverHybrid<ELEMENT_DIM, SPACE_DIM, PROBLEM_DIM>* p_solver =
-        (AbstractNonlinearAssemblerSolverHybrid<ELEMENT_DIM, SPACE_DIM, PROBLEM_DIM>*) pContext;
+    auto* p_solver = (AbstractNonlinearAssemblerSolverHybrid<ELEMENT_DIM, SPACE_DIM, PROBLEM_DIM>*) pContext;
 
     p_solver->ComputeResidual(currentGuess, residualVector);
 
@@ -492,8 +491,7 @@ PetscErrorCode AbstractNonlinearAssemblerSolverHybrid_ComputeJacobian(SNES snes,
                                                                       void* pContext)
 {
     // Extract the solver from the void*
-    AbstractNonlinearAssemblerSolverHybrid<ELEMENT_DIM, SPACE_DIM, PROBLEM_DIM>* p_solver =
-        (AbstractNonlinearAssemblerSolverHybrid<ELEMENT_DIM, SPACE_DIM, PROBLEM_DIM>*) pContext;
+    auto* p_solver = (AbstractNonlinearAssemblerSolverHybrid<ELEMENT_DIM, SPACE_DIM, PROBLEM_DIM>*) pContext;
 
     p_solver->ComputeJacobian(currentGuess, &globalJacobian);
 
@@ -508,8 +506,7 @@ PetscErrorCode AbstractNonlinearAssemblerSolverHybrid_ComputeJacobian(SNES snes,
                                                                       void* pContext)
 {
     // Extract the solver from the void*
-    AbstractNonlinearAssemblerSolverHybrid<ELEMENT_DIM, SPACE_DIM, PROBLEM_DIM>* p_solver =
-        (AbstractNonlinearAssemblerSolverHybrid<ELEMENT_DIM, SPACE_DIM, PROBLEM_DIM>*) pContext;
+    auto* p_solver = (AbstractNonlinearAssemblerSolverHybrid<ELEMENT_DIM, SPACE_DIM, PROBLEM_DIM>*) pContext;
 
     p_solver->ComputeJacobian(currentGuess, pGlobalJacobian);
 

--- a/pde/src/solver/LinearParabolicPdeSystemWithCoupledOdeSystemSolver.hpp
+++ b/pde/src/solver/LinearParabolicPdeSystemWithCoupledOdeSystemSolver.hpp
@@ -264,9 +264,7 @@ c_matrix<double, PROBLEM_DIM*(ELEMENT_DIM+1), PROBLEM_DIM*(ELEMENT_DIM+1)> Linea
     {
         double this_dudt_coefficient = mpPdeSystem->ComputeDuDtCoefficientFunction(rX, pde_index);
         c_matrix<double, SPACE_DIM, SPACE_DIM> this_pde_diffusion_term = mpPdeSystem->ComputeDiffusionTerm(rX, pde_index, pElement);
-        c_matrix<double, 1*(ELEMENT_DIM+1), 1*(ELEMENT_DIM+1)> this_stiffness_matrix =
-            prod(trans(rGradPhi), c_matrix<double, SPACE_DIM, ELEMENT_DIM+1>(prod(this_pde_diffusion_term, rGradPhi)) )
-                + timestep_inverse * this_dudt_coefficient * outer_prod(rPhi, rPhi);
+        c_matrix<double, 1*(ELEMENT_DIM+1), 1*(ELEMENT_DIM+1)> this_stiffness_matrix = prod(trans(rGradPhi), c_matrix<double, SPACE_DIM, ELEMENT_DIM+1>(prod(this_pde_diffusion_term, rGradPhi)) ) + timestep_inverse * this_dudt_coefficient * outer_prod(rPhi, rPhi);
 
         for (unsigned i=0; i<ELEMENT_DIM+1; i++)
         {

--- a/pde/src/solver/SimpleNonlinearEllipticSolver.cpp
+++ b/pde/src/solver/SimpleNonlinearEllipticSolver.cpp
@@ -90,8 +90,7 @@ c_vector<double,1*(ELEMENT_DIM+1)> SimpleNonlinearEllipticSolver<ELEMENT_DIM,SPA
     // Note rGradU is a 1 by SPACE_DIM matrix, the 1 representing the dimension of
     // u (ie in this problem the unknown is a scalar). rGradU0 is rGradU as a vector.
     matrix_row< c_matrix<double, 1, SPACE_DIM> > rGradU0(rGradU, 0);
-    c_vector<double, ELEMENT_DIM+1> integrand_values1 =
-        prod(c_vector<double, ELEMENT_DIM>(prod(rGradU0, FOfU)), rGradPhi);
+    c_vector<double, ELEMENT_DIM+1> integrand_values1 = prod(c_vector<double, ELEMENT_DIM>(prod(rGradU0, FOfU)), rGradPhi);
 
     ret = integrand_values1 - (forcing_term * rPhi);
     return ret;


### PR DESCRIPTION
Partially addresses #607

Joins 100 statements that were split over two lines at `=`, which gcov/lcov mis-attributes as one covered line and one uncovered line. This is the cause of the two live coverage failures in #607, plus ~35 latent ones of the same type. 2 further three-line statements fixed by hand.

While touching these lines, replaces the declared type with `auto`/`auto*`/`auto&`/`const auto&` where it's redundant or unspellable (casts, `new`, factory calls, iterators, `XSD_SEQUENCE_TYPE(...)&`), but leaves uBLAS `c_vector` and `c_matrix` alone.
