### PR TITLE
#623 Speed up and unify lcov coverage capture

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ jobs:
     # silently under-reports coverage rather than failing. The portability-* images build
     # PETSc from source with --download-parmetis=1 --download-hypre=1.
     container:
-      image: chaste/runner:portability-dev
+      image: chaste/runner:portability-tip
       env:
         RUNNER_OFF: 1
       options: --user 0 --cpus 4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -125,22 +125,15 @@ jobs:
         working-directory: chaste-build-dir
 
       - name: Run coverage
-        # --exclude drops system and module (boost/petsc/...) headers at capture time, so
-        # geninfo never processes them and never emits their thousands of consistency
-        # warnings. These external paths are not Chaste's code and would be stripped anyway;
-        # filtering them here rather than after --capture keeps the log readable and removes
-        # the source of the fatal lcov 2.x `inconsistent`/`mismatch` errors on STL headers.
-        #
-        # lcov 2.x makes fatal several conditions 1.x only warned about (mismatch,
-        # inconsistent, unused); all are demoted back to warnings via `ignore_errors` in
-        # cmake/Config/lcovrc, which both commands below load. See there for why they are
-        # benign. Do not add a --ignore-errors flag here: on the command line it REPLACES
-        # the rc list rather than merging, which would silently re-arm the other categories.
+        # Exclude patterns and error-ignores live in cmake/Config/lcovrc (shared with the
+        # local `make coverage` target); excludes apply at capture time, so no --exclude
+        # args and no `lcov --remove` pass are needed. Pass an explicit --parallel (not 0:
+        # geninfo's auto-detect ignores the container's --cpus). Do not pass --ignore-errors
+        # here: on the command line it REPLACES the rc list instead of merging.
         run: |
           su runner << 'EOF'
           set -e
-          lcov --config-file ../cmake/Config/lcovrc --directory . --capture --exclude '/usr/*' --exclude '*/modules/*' --output-file coverage.info
-          lcov --config-file ../cmake/Config/lcovrc --remove coverage.info '/usr/*' '*/fortests/*' '*/test/*' '*/3rdparty/*' '*/global/src/random/*' 'Debug/*' 'Debug_*/*' '*/cxxtest/*' --output-file coverage.info
+          lcov --config-file ../cmake/Config/lcovrc --directory . --capture --parallel 4 --output-file coverage.info
           EOF
         working-directory: chaste-build-dir
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ jobs:
     # silently under-reports coverage rather than failing. The portability-* images build
     # PETSc from source with --download-parmetis=1 --download-hypre=1.
     container:
-      image: chaste/runner:portability-tip
+      image: chaste/runner:portability-dev
       env:
         RUNNER_OFF: 1
       options: --user 0 --cpus 4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -866,12 +866,13 @@ if (Chaste_COVERAGE)
                        COMMAND ${NICE_COMMAND} ${NICENESS} ${CTEST_COMMAND} "-j${Chaste_COVERAGE_CPUS}" "-L" "Continuous" "--output-on-failure"
                        COMMAND ${NICE_COMMAND} ${NICENESS} ${CTEST_COMMAND} "-L" "Parallel" "--output-on-failure"
 
-                       # Capturing lcov counters and generating report
-                       COMMAND ${LCOV_PATH} --config-file ${Chaste_SOURCE_DIR}/cmake/Config/lcovrc --directory . --capture --output-file ${_outputname}.info
-                       COMMAND ${LCOV_PATH} --config-file ${Chaste_SOURCE_DIR}/cmake/Config/lcovrc --remove ${_outputname}.info /home/bob/petsc* /usr/* */fortests/* */test/* */3rdparty/* */global/src/random/* Debug/* Debug_*/* cxxtest/* --output-file ${_outputname}.info.cleaned
+                       # Capture, then build the HTML. Exclude patterns live in
+                       # cmake/Config/lcovrc (shared with the CI workflow) and apply at
+                       # capture time, so no `lcov --remove` pass is needed.
+                       COMMAND ${LCOV_PATH} --config-file ${Chaste_SOURCE_DIR}/cmake/Config/lcovrc --directory . --capture --parallel ${Chaste_COVERAGE_CPUS} --output-file ${_outputname}.info
                        set (_page_title "\"Chaste Coverage Results for commit ${Chaste_REVISION}\"")
-                       COMMAND ${GENHTML_PATH} --title "${_page_title}" --config-file ${Chaste_SOURCE_DIR}/cmake/Config/lcovrc --no-function-coverage -o ${_outputname} ${_outputname}.info.cleaned
-                       COMMAND ${CMAKE_COMMAND} -E remove ${_outputname}.info ${_outputname}.info.cleaned
+                       COMMAND ${GENHTML_PATH} --title "${_page_title}" --config-file ${Chaste_SOURCE_DIR}/cmake/Config/lcovrc --no-function-coverage -o ${_outputname} ${_outputname}.info
+                       COMMAND ${CMAKE_COMMAND} -E remove ${_outputname}.info
                        COMMAND ${Python3_EXECUTABLE} "${Chaste_SOURCE_DIR}/cmake/process_coverage_output.py" "${_outputname}"
 
                        DEPENDS Continuous Parallel

--- a/cmake/Config/lcovrc
+++ b/cmake/Config/lcovrc
@@ -2,6 +2,20 @@
 # dedicated Chaste defaults for LCOV
 #
 
+# Paths excluded from coverage, in one place so both pipelines (CI codecov
+# .github/workflows/coverage.yml, local `make coverage` in root CMakeLists.txt) select the
+# same files. Applied at geninfo capture time, so `lcov --capture` needs no --exclude args
+# and no `lcov --remove` pass; also keeps system/module headers out of the merge, which is
+# what otherwise triggers the lcov 2.x `inconsistent`/`mismatch` errors (see below).
+# NB: a command-line --exclude REPLACES this list, so neither pipeline passes one.
+exclude = /usr/*
+exclude = */modules/*
+exclude = */fortests/*
+exclude = */test/*
+exclude = */3rdparty/*
+exclude = */global/src/random/*
+exclude = */cxxtest/*
+
 # Specify an external style sheet file (same as --css-file option of genhtml)
 #genhtml_css_file = gcov.css
 
@@ -106,19 +120,12 @@ branch_coverage = 0
 # of geninfo if non-zero, same as --no-compat-libtool if zero)
 #geninfo_compat_libtool = 0
 
-# Demote lcov 2.x's stricter fatal conditions back to warnings. Loaded by both the
-# --capture and --remove lcov calls in .github/workflows/coverage.yml.
-#   mismatch:     exception-tag / block metadata disagreements when merging heavily
-#                 inlined templates across many object files. Cosmetic: line hit counts
-#                 still merge correctly.
-#   inconsistent: branch-consistency false positive, e.g. a line whose only branches are
-#                 compiler-generated exception edges (a local declaration whose
-#                 constructor may throw) reading as hit-but-no-branches-evaluated. Not a
-#                 coverage-data problem.
-#   unused:       a --remove / --exclude pattern that matched no file. Harmless (a stale or
-#                 belt-and-braces pattern); not worth failing CI over.
-# NB: a command-line --ignore-errors REPLACES this list rather than merging with it, so
-# every category must live here and coverage.yml must pass no --ignore-errors of its own.
+# Demote lcov 2.x's stricter fatal conditions back to warnings (all verified benign for
+# Chaste): mismatch = exception-tag/block metadata disagreements when merging heavily
+# inlined templates (line hit counts still correct); inconsistent = a line whose only
+# branches are compiler-generated exception edges reading as hit-but-no-branches; unused =
+# an exclude pattern above that matched nothing.
+# NB: a command-line --ignore-errors REPLACES this list, so the lcov calls pass none.
 ignore_errors = mismatch,inconsistent,unused
 
 # Directory containing gcov kernel files


### PR DESCRIPTION
Addresses the configuration part of #623 

See https://github.com/Chaste/dependency-modules/issues/134 for the faster XML parser