### PR TITLE
Replace hand-written extremum loops with std::max_element and friends

### DIFF
--- a/cell_based/src/population/forces/DiscreteSystemForceCalculator.cpp
+++ b/cell_based/src/population/forces/DiscreteSystemForceCalculator.cpp
@@ -35,6 +35,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "DiscreteSystemForceCalculator.hpp"
 
+#include <algorithm>
+
 DiscreteSystemForceCalculator::DiscreteSystemForceCalculator(MeshBasedCellPopulation<2>& rCellPopulation,
                                                              std::vector<boost::shared_ptr<AbstractTwoBodyInteractionForce<2> > > forceCollection)
     : mrCellPopulation(rCellPopulation),
@@ -56,27 +58,16 @@ std::vector< std::vector<double> > DiscreteSystemForceCalculator::CalculateExtre
         std::vector<double> sampling_angles = GetSamplingAngles(i);
         std::vector<double> extremal_angles = GetExtremalAngles(i, sampling_angles);
 
-        double minimum_normal_force_for_node_i = DBL_MAX;
-        double maximum_normal_force_for_node_i = -DBL_MAX;
+        // Evaluate the normal force at each extremal angle, then take the extremes of those
+        std::vector<double> normal_forces(extremal_angles.size());
+        std::transform(extremal_angles.begin(), extremal_angles.end(), normal_forces.begin(),
+                       [&](double angle) { return CalculateFtAndFn(i, angle)[1]; });
 
-        for (unsigned j=0; j<extremal_angles.size(); j++)
-        {
-            double current_normal_force = CalculateFtAndFn(i, extremal_angles[j])[1];
+        assert(!normal_forces.empty());
+        auto minmax_normal_force = std::minmax_element(normal_forces.begin(), normal_forces.end());
 
-            if (current_normal_force > maximum_normal_force_for_node_i)
-            {
-                maximum_normal_force_for_node_i = current_normal_force;
-            }
-            if (current_normal_force < minimum_normal_force_for_node_i)
-            {
-                minimum_normal_force_for_node_i = current_normal_force;
-            }
-        }
-
-        assert( minimum_normal_force_for_node_i <= maximum_normal_force_for_node_i);
-
-        minimum_normal_forces[i] = minimum_normal_force_for_node_i;
-        maximum_normal_forces[i] = maximum_normal_force_for_node_i;
+        minimum_normal_forces[i] = *minmax_normal_force.first;
+        maximum_normal_forces[i] = *minmax_normal_force.second;
     }
 
     extremal_normal_forces.push_back(minimum_normal_forces);

--- a/heart/src/postprocessing/PropagationPropertiesCalculator.cpp
+++ b/heart/src/postprocessing/PropagationPropertiesCalculator.cpp
@@ -37,6 +37,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "PropagationPropertiesCalculator.hpp"
 #include "CellProperties.hpp"
 #include "Exception.hpp"
+#include <algorithm>
 #include <sstream>
 #include "HeartEventHandler.hpp"
 
@@ -157,15 +158,8 @@ std::vector<std::vector<double> > PropagationPropertiesCalculator::CalculateAllA
 double PropagationPropertiesCalculator::CalculatePeakMembranePotential(unsigned globalNodeIndex)
 {
     std::vector<double>& r_voltages = rGetCachedVoltages(globalNodeIndex);
-    double max = -DBL_MAX;
-    for (unsigned i=0; i<r_voltages.size(); i++)
-    {
-        if (r_voltages[i]>max)
-        {
-            max = r_voltages[i];
-        }
-    }
-    return max;
+    assert(!r_voltages.empty());
+    return *std::max_element(r_voltages.begin(), r_voltages.end());
 }
 
 double PropagationPropertiesCalculator::CalculateConductionVelocity(unsigned globalNearNodeIndex,

--- a/heart/src/problem/CardiacElectroMechanicsProblem.cpp
+++ b/heart/src/problem/CardiacElectroMechanicsProblem.cpp
@@ -35,6 +35,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "CardiacElectroMechanicsProblem.hpp"
 
+#include <algorithm>
+
 #include "OutputFileHandler.hpp"
 #include "ReplicatableVector.hpp"
 #include "HeartConfig.hpp"
@@ -793,7 +795,7 @@ void CardiacElectroMechanicsProblem<DIM,ELEC_PROB_DIM>::Solve()
             mInterpolatedVoltages[i] = interpolated_voltage;
         }
 
-        LOG(2, "  Setting Ca_I. max value = " << Max(mInterpolatedCalciumConcs));
+        LOG(2, "  Setting Ca_I. max value = " << *std::max_element(mInterpolatedCalciumConcs.begin(), mInterpolatedCalciumConcs.end()));
 
         // NOTE IF NHS: HERE WE SHOULD PERHAPS CHECK WHETHER THE CELL MODELS HAVE Ca_Trop
         // AND UPDATE FROM NHS TO CELL_MODEL, BUT NOT SURE HOW TO DO THIS.. (esp for implicit)
@@ -956,17 +958,6 @@ void CardiacElectroMechanicsProblem<DIM,ELEC_PROB_DIM>::Solve()
     delete p_electrics_solver;
 
     MechanicsEventHandler::EndEvent(MechanicsEventHandler::ALL);
-}
-
-template<unsigned DIM, unsigned ELEC_PROB_DIM>
-double CardiacElectroMechanicsProblem<DIM,ELEC_PROB_DIM>::Max(std::vector<double>& vec)
-{
-    double max = -1e200;
-    for (unsigned i=0; i<vec.size(); i++)
-    {
-        if (vec[i]>max) max=vec[i];
-    }
-    return max;
 }
 
 template<unsigned DIM, unsigned ELEC_PROB_DIM>

--- a/heart/src/problem/CardiacElectroMechanicsProblem.hpp
+++ b/heart/src/problem/CardiacElectroMechanicsProblem.hpp
@@ -240,13 +240,6 @@ public :
      */
     void Solve();
 
-    /**
-     *  Short helper function
-     *  @return the max of a std::vector
-     *  @param vec a vector of doubles
-     */
-    double Max(std::vector<double>& vec);
-
     /** Call to not write out voltages */
     void SetNoElectricsOutput();
 

--- a/lung/src/common/AirwayPropertiesCalculator.cpp
+++ b/lung/src/common/AirwayPropertiesCalculator.cpp
@@ -36,6 +36,10 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "AirwayPropertiesCalculator.hpp"
 
+#include <algorithm>
+#include <limits>
+#include <numeric>
+
 AirwayPropertiesCalculator::AirwayPropertiesCalculator(TetrahedralMesh<1,3>& rAirwaysMesh,
                                                        unsigned rootIndex,
                                                        bool radiusOnEdge) :
@@ -280,44 +284,28 @@ std::vector<double> AirwayPropertiesCalculator::GetUpstreamPoiseuilleResistances
 
 unsigned AirwayPropertiesCalculator::GetMaximumTerminalGeneration()
 {
-    unsigned max_generation = 0;
-
-    for (std::vector<AirwayBranch*>::iterator iter = mBranches.begin();
-         iter != mBranches.end();
-         ++iter)
-    {
-        if ((*iter)->IsTerminal())
-        {
-            unsigned generation = mWalker.GetElementGeneration((*iter)->GetElements().front());
-            if (generation > max_generation)
-            {
-                max_generation = generation;
-            }
-        }
-    }
-
-    return max_generation;
+    return std::accumulate(mBranches.begin(), mBranches.end(), 0u,
+                           [this](unsigned max_so_far, AirwayBranch* pBranch)
+                           {
+                               if (!pBranch->IsTerminal())
+                               {
+                                   return max_so_far;
+                               }
+                               return std::max(max_so_far, mWalker.GetElementGeneration(pBranch->GetElements().front()));
+                           });
 }
 
 unsigned AirwayPropertiesCalculator::GetMinimumTerminalGeneration()
 {
-    unsigned min_generation = std::numeric_limits<unsigned>::max();
-
-    for (std::vector<AirwayBranch*>::iterator iter = mBranches.begin();
-         iter != mBranches.end();
-         ++iter)
-    {
-        if ((*iter)->IsTerminal())
-        {
-            unsigned generation = mWalker.GetElementGeneration((*iter)->GetElements().front());
-            if (generation < min_generation)
-            {
-                min_generation = generation;
-            }
-        }
-    }
-
-    return min_generation;
+    return std::accumulate(mBranches.begin(), mBranches.end(), std::numeric_limits<unsigned>::max(),
+                           [this](unsigned min_so_far, AirwayBranch* pBranch)
+                           {
+                               if (!pBranch->IsTerminal())
+                               {
+                                   return min_so_far;
+                               }
+                               return std::min(min_so_far, mWalker.GetElementGeneration(pBranch->GetElements().front()));
+                           });
 }
 
 unsigned AirwayPropertiesCalculator::GetMeanTerminalGeneration()

--- a/mesh/src/utilities/ChasteCuboid.cpp
+++ b/mesh/src/utilities/ChasteCuboid.cpp
@@ -36,6 +36,9 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "ChasteCuboid.hpp"
 #include "Exception.hpp"
 
+#include <algorithm>
+#include <iterator>
+
 template <unsigned SPACE_DIM>
 ChasteCuboid<SPACE_DIM>::ChasteCuboid(ChastePoint<SPACE_DIM>& rLowerPoint, ChastePoint<SPACE_DIM>& rUpperPoint)
     : mLowerCorner(rLowerPoint),
@@ -86,18 +89,11 @@ double ChasteCuboid<SPACE_DIM>::GetWidth(unsigned rDimension) const
 template <unsigned SPACE_DIM>
 unsigned ChasteCuboid<SPACE_DIM>::GetLongestAxis() const
 {
-    unsigned axis = 0;
-    double max_dimension = 0.0;
-    for (unsigned i=0; i<SPACE_DIM; i++)
-    {
-        double dimension =  mUpperCorner[i] - mLowerCorner[i];
-        if (dimension > max_dimension)
-        {
-            axis=i;
-            max_dimension = dimension;
-        }
-    }
-    return axis;
+    // The widths are non-negative by construction, so the longest axis is just the widest one.
+    // Note that std::max_element returns the first maximum, matching the original loop's tie-breaking.
+    c_vector<double, SPACE_DIM> widths = mUpperCorner.rGetLocation() - mLowerCorner.rGetLocation();
+    return static_cast<unsigned>(std::distance(std::begin(widths),
+                                               std::max_element(std::begin(widths), std::end(widths))));
 }
 
 // Explicit instantiation

--- a/ode/src/solver/BackwardEulerIvpOdeSolver.cpp
+++ b/ode/src/solver/BackwardEulerIvpOdeSolver.cpp
@@ -35,6 +35,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include "BackwardEulerIvpOdeSolver.hpp"
+#include <algorithm>
 #include <cmath>
 
 void BackwardEulerIvpOdeSolver::ComputeResidual(AbstractOdeSystem* pAbstractOdeSystem,
@@ -110,15 +111,10 @@ void BackwardEulerIvpOdeSolver::SolveLinearSystem()
 
 double BackwardEulerIvpOdeSolver::ComputeNorm(double* pVector)
 {
-    double norm = 0.0;
-    for (unsigned i=0; i<mSizeOfOdeSystem; i++)
-    {
-        if (fabs(pVector[i]) > norm)
-        {
-            norm = fabs(pVector[i]);
-        }
-    }
-    return norm;
+    assert(mSizeOfOdeSystem > 0);
+    // The infinity norm: the largest magnitude of any entry
+    return fabs(*std::max_element(pVector, pVector + mSizeOfOdeSystem,
+                                  [](double a, double b) { return fabs(a) < fabs(b); }));
 }
 
 void BackwardEulerIvpOdeSolver::ComputeNumericalJacobian(AbstractOdeSystem* pAbstractOdeSystem,


### PR DESCRIPTION
Closes #643

Part of the manual-loop cleanup. Branch: `cleanup/std-minmax-element` (one commit on top of `develop`).

Six functions were entirely hand-rolled minimum/maximum searches over a real container, so each collapses to one standard algorithm call.

| Site | Replacement |
|---|---|
| `PropagationPropertiesCalculator::CalculatePeakMembranePotential` | `std::max_element` |
| `BackwardEulerIvpOdeSolver::ComputeNorm` | `std::max_element` with a `fabs` comparator (infinity norm) |
| `DiscreteSystemForceCalculator::CalculateExtremalNormalForces` | `std::transform`, then one `std::minmax_element` pass instead of two running variables |
| `AirwayPropertiesCalculator::GetMaximumTerminalGeneration` | `std::accumulate` — the search is filtered on `IsTerminal()`, which `max_element` cannot express |
| `AirwayPropertiesCalculator::GetMinimumTerminalGeneration` | as above |
| `ChasteCuboid::GetLongestAxis` | `std::max_element` + `std::distance` (argmax over the widths) |

`CardiacElectroMechanicsProblem::Max` was a private helper that duplicated `std::max_element` and had exactly one call site, so it is removed (from both the `.cpp` and the `.hpp`).

**Behaviour:** unchanged. `std::max_element` returns the first maximum, matching the strict `>` each loop used. `ChasteCuboid`'s widths are non-negative by construction (the constructor throws otherwise), so its `0.0` seed was inert. Where a loop relied on a `-DBL_MAX` seed to survive an empty range, an `assert` now documents the non-empty precondition the callers already guarantee, rather than adding an untested branch.

**Files:** 7 changed, +51 / -102.

---

### Review notes

- One commit, based on current `develop`. This is one of six sibling PRs from #650; all six were test-merged into `develop` in sequence and **do not conflict** with each other, so they can go in in any order.
- **Not yet compiled.** There was no build tree available where this was prepared, so this needs a CI run before it is trusted. See #650 for the full list of caveats that shaped these changes.
- No test reference data should need regenerating: summation order and floating-point results are unchanged throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
