### PR TITLE
Replace the duplicated per-dimension bounding-box idiom with std::transform

### DIFF
--- a/cell_based/src/cell_based_pde/AbstractBoxDomainPdeModifier.cpp
+++ b/cell_based/src/cell_based_pde/AbstractBoxDomainPdeModifier.cpp
@@ -34,6 +34,9 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "AbstractBoxDomainPdeModifier.hpp"
+
+#include <algorithm>
+
 #include "ReplicatableVector.hpp"
 #include "LinearBasisFunction.hpp"
 
@@ -130,32 +133,23 @@ void AbstractBoxDomainPdeModifier<DIM>::ConstructBoundaryConditionsContainerHelp
         if (this->mSetBcsOnBoundingSphere)
         {
             // First find the centre of the tissue by choosing the midpoint of the extrema.
-            c_vector<double, DIM> tissue_maxima = zero_vector<double>(DIM);
-            c_vector<double, DIM> tissue_minima = zero_vector<double>(DIM);
-            for (unsigned i = 0; i < DIM; i++)
-            {
-                tissue_maxima[i] = -DBL_MAX;
-                tissue_minima[i] = DBL_MAX;
-            }
-
+            c_vector<double, DIM> tissue_maxima = scalar_vector<double>(DIM, -DBL_MAX);
+            c_vector<double, DIM> tissue_minima = scalar_vector<double>(DIM, DBL_MAX);
 
             for (typename AbstractCellPopulation<DIM>::Iterator cell_iter = rCellPopulation.Begin();
                 cell_iter != rCellPopulation.End();
                 ++cell_iter)
             {
-                const ChastePoint<DIM>& r_position_of_cell = rCellPopulation.GetLocationOfCellCentre(*cell_iter);
+                // Note that GetLocationOfCellCentre returns a c_vector by value; the previous code
+                // bound it to a const ChastePoint reference, silently constructing a temporary.
+                const c_vector<double, DIM> location_of_cell = rCellPopulation.GetLocationOfCellCentre(*cell_iter);
 
-                for (unsigned i = 0; i < DIM; i++)
-                {
-                    if (r_position_of_cell[i] > tissue_maxima[i])
-                    {
-                        tissue_maxima[i] = r_position_of_cell[i];
-                    }
-                    if (r_position_of_cell[i] < tissue_minima[i])
-                    {
-                        tissue_minima[i] = r_position_of_cell[i];
-                    }
-                }
+                std::transform(std::begin(location_of_cell), std::end(location_of_cell), std::begin(tissue_maxima),
+                               std::begin(tissue_maxima),
+                               [](double a, double b) { return std::max(a, b); });
+                std::transform(std::begin(location_of_cell), std::end(location_of_cell), std::begin(tissue_minima),
+                               std::begin(tissue_minima),
+                               [](double a, double b) { return std::min(a, b); });
             }
 
             c_vector<double, DIM> tissue_centre = 0.5*(tissue_maxima + tissue_minima);
@@ -166,14 +160,9 @@ void AbstractBoxDomainPdeModifier<DIM>::ConstructBoundaryConditionsContainerHelp
                 cell_iter != rCellPopulation.End();
                 ++cell_iter)
             {
-                const ChastePoint<DIM>& r_position_of_cell = rCellPopulation.GetLocationOfCellCentre(*cell_iter);
+                double radius = norm_2(tissue_centre - rCellPopulation.GetLocationOfCellCentre(*cell_iter));
 
-                double radius = norm_2(tissue_centre - r_position_of_cell.rGetLocation());
-
-                if (tissue_radius < radius)
-                {
-                    tissue_radius = radius;
-                }
+                tissue_radius = std::max(tissue_radius, radius);
             }
 
             // Apply boundary condition to the nodes outside the tissue_radius

--- a/cell_based/src/cell_based_pde/ParabolicBoxDomainPdeModifier.cpp
+++ b/cell_based/src/cell_based_pde/ParabolicBoxDomainPdeModifier.cpp
@@ -34,6 +34,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "ParabolicBoxDomainPdeModifier.hpp"
+
+#include <algorithm>
 #include "SimpleLinearParabolicSolver.hpp"
 #include "VtkMeshWriter.hpp"
 #include "MutableMesh.hpp"
@@ -194,14 +196,9 @@ Vec ParabolicBoxDomainPdeModifier<DIM>::InterpolateSolutionFromCellMovement(Abst
         cell_iter != rCellPopulation.End();
         ++cell_iter)
     {
-        const ChastePoint<DIM>& r_position_of_cell = rCellPopulation.GetLocationOfCellCentre(*cell_iter);
+        double radius = norm_2(rCellPopulation.GetLocationOfCellCentre(*cell_iter));
 
-        double radius = norm_2(r_position_of_cell.rGetLocation());
-
-        if (max_radius < radius)
-        {
-            max_radius = radius;
-        }
+        max_radius = std::max(max_radius, radius);
     }
 
     // Create mesh from cell centres so can interpolate tissue velocity onto mpFeMesh

--- a/cell_based/src/population/AbstractCellPopulation.cpp
+++ b/cell_based/src/population/AbstractCellPopulation.cpp
@@ -915,13 +915,9 @@ c_vector<double,SPACE_DIM> AbstractCellPopulation<ELEMENT_DIM, SPACE_DIM>::GetSi
         c_vector<double,SPACE_DIM> displacement;
         displacement = centre - cell_location;
 
-        for (unsigned i=0; i<SPACE_DIM; i++)
-        {
-            if (displacement[i] > max_distance_from_centre[i])
-            {
-                max_distance_from_centre[i] = displacement[i];
-            }
-        }
+        std::transform(std::begin(displacement), std::end(displacement), std::begin(max_distance_from_centre),
+                       std::begin(max_distance_from_centre),
+                       [](double a, double b) { return std::max(a, b); });
     }
 
     return max_distance_from_centre;

--- a/cell_based/src/writers/population_writers/RadialCellDataDistributionWriter.cpp
+++ b/cell_based/src/writers/population_writers/RadialCellDataDistributionWriter.cpp
@@ -34,6 +34,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "RadialCellDataDistributionWriter.hpp"
+
+#include <algorithm>
 #include "MeshBasedCellPopulation.hpp"
 #include "CaBasedCellPopulation.hpp"
 #include "NodeBasedCellPopulation.hpp"
@@ -65,10 +67,7 @@ void RadialCellDataDistributionWriter<ELEMENT_DIM, SPACE_DIM>::VisitAnyPopulatio
         double distance = norm_2(pCellPopulation->GetLocationOfCellCentre(*cell_iter) - centre);
         radius_cell_map[distance] = *cell_iter;
 
-        if (distance > max_distance_from_centre)
-        {
-            max_distance_from_centre = distance;
-        }
+        max_distance_from_centre = std::max(max_distance_from_centre, distance);
     }
 
     // Create vector of radius intervals
@@ -121,10 +120,7 @@ void RadialCellDataDistributionWriter<ELEMENT_DIM, SPACE_DIM>::Visit(MeshBasedCe
         double distance = norm_2(pCellPopulation->GetLocationOfCellCentre(*cell_iter) - centre);
         radius_cell_map[distance] = *cell_iter;
 
-        if (distance > max_distance_from_centre)
-        {
-            max_distance_from_centre = distance;
-        }
+        max_distance_from_centre = std::max(max_distance_from_centre, distance);
     }
 
     // Create vector of radius intervals

--- a/heart/src/postprocessing/PostProcessingWriter.cpp
+++ b/heart/src/postprocessing/PostProcessingWriter.cpp
@@ -44,7 +44,9 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "HeartEventHandler.hpp"
 #include "Hdf5DataWriter.hpp"
 
+#include <algorithm>
 #include <iostream>
+#include <numeric>
 
 template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
 PostProcessingWriter<ELEMENT_DIM, SPACE_DIM>::PostProcessingWriter(AbstractTetrahedralMesh<ELEMENT_DIM,SPACE_DIM>& rMesh,
@@ -202,15 +204,12 @@ void PostProcessingWriter<ELEMENT_DIM, SPACE_DIM>::WriteOutputDataToHdf5(const s
         writer.EmptyDataset();
     }
 
-    //Determine the maximum number of paces
-    unsigned local_max_paces = 0u;
-    for (unsigned node_index = 0; node_index < rDataPayload.size(); ++node_index)
-    {
-        if (rDataPayload[node_index].size() > local_max_paces)
-        {
-             local_max_paces = rDataPayload[node_index].size();
-        }
-    }
+    //Determine the maximum number of paces (rDataPayload is empty on a process owning no nodes)
+    unsigned local_max_paces = std::accumulate(rDataPayload.begin(), rDataPayload.end(), 0u,
+                                               [](unsigned max_so_far, const std::vector<double>& rPaces)
+                                               {
+                                                   return std::max(max_so_far, static_cast<unsigned>(rPaces.size()));
+                                               });
 
     unsigned max_paces = 0u;
     MPI_Allreduce(&local_max_paces, &max_paces, 1, MPI_UNSIGNED, MPI_MAX, PETSC_COMM_WORLD);

--- a/heart/src/problem/HeartGeometryInformation.cpp
+++ b/heart/src/problem/HeartGeometryInformation.cpp
@@ -35,6 +35,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "HeartGeometryInformation.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <fstream>
 #include <sstream>
@@ -423,17 +424,12 @@ ChasteCuboid<SPACE_DIM> HeartGeometryInformation<SPACE_DIM>::CalculateBoundingBo
         {
             const c_vector<double, SPACE_DIM>& r_position = mpMesh->GetNode(global_index)->rGetLocation();
             //Update max/min
-            for (unsigned i=0; i<SPACE_DIM; i++)
-            {
-                if (r_position[i] < my_minimum_point[i])
-                {
-                    my_minimum_point[i] = r_position[i];
-                }
-                if (r_position[i] > my_maximum_point[i])
-                {
-                    my_maximum_point[i] = r_position[i];
-                }
-            }
+            std::transform(std::begin(r_position), std::end(r_position), std::begin(my_minimum_point),
+                           std::begin(my_minimum_point),
+                           [](double a, double b) { return std::min(a, b); });
+            std::transform(std::begin(r_position), std::end(r_position), std::begin(my_maximum_point),
+                           std::begin(my_maximum_point),
+                           [](double a, double b) { return std::max(a, b); });
         }
     }
 

--- a/mesh/src/common/AbstractMesh.cpp
+++ b/mesh/src/common/AbstractMesh.cpp
@@ -252,17 +252,12 @@ ChasteCuboid<SPACE_DIM> AbstractMesh<ELEMENT_DIM, SPACE_DIM>::CalculateBoundingB
                 c_vector<double, SPACE_DIM> position = rNodes[index]->rGetLocation();
 
                 // Update max/min
-                for (unsigned i = 0; i < SPACE_DIM; i++)
-                {
-                    if (position[i] < minimum_point[i])
-                    {
-                        minimum_point[i] = position[i];
-                    }
-                    if (position[i] > maximum_point[i])
-                    {
-                        maximum_point[i] = position[i];
-                    }
-                }
+                std::transform(std::begin(position), std::end(position), std::begin(minimum_point),
+                               std::begin(minimum_point),
+                               [](double a, double b) { return std::min(a, b); });
+                std::transform(std::begin(position), std::end(position), std::begin(maximum_point),
+                               std::begin(maximum_point),
+                               [](double a, double b) { return std::max(a, b); });
             }
         }
     }

--- a/mesh/src/common/AbstractTetrahedralMesh.cpp
+++ b/mesh/src/common/AbstractTetrahedralMesh.cpp
@@ -818,10 +818,7 @@ unsigned AbstractTetrahedralMesh<ELEMENT_DIM, SPACE_DIM>::CalculateMaximumNodeCo
                 forward_star_nodes.insert(p_elem->GetNodeGlobalIndex(i));
             }
         }
-        if (forward_star_nodes.size() > max_connectivity)
-        {
-            max_connectivity = forward_star_nodes.size();
-        }
+        max_connectivity = std::max(max_connectivity, static_cast<unsigned>(forward_star_nodes.size()));
     }
     return max_connectivity;
 }

--- a/mesh/src/immersed_boundary/ImmersedBoundaryMesh.cpp
+++ b/mesh/src/immersed_boundary/ImmersedBoundaryMesh.cpp
@@ -491,17 +491,14 @@ ChasteCuboid<SPACE_DIM> ImmersedBoundaryMesh<ELEMENT_DIM, SPACE_DIM>::CalculateB
     {
         c_vector<double, SPACE_DIM> vec_to_node = this->GetVectorFromAtoB(ref_point, p_elem->GetNode(node_idx)->rGetLocation());
 
-        for (unsigned dim = 0; dim < SPACE_DIM; dim++)
-        {
-            if (vec_to_node[dim] < bottom_left[dim])
-            {
-                bottom_left[dim] = vec_to_node[dim];
-            }
-            else if (vec_to_node[dim] > top_right[dim])
-            {
-                top_right[dim] = vec_to_node[dim];
-            }
-        }
+        // Note that bottom_left is never positive and top_right is never negative, so a given
+        // component can only ever update one of the two; the original "else if" was redundant.
+        std::transform(std::begin(vec_to_node), std::end(vec_to_node), std::begin(bottom_left),
+                       std::begin(bottom_left),
+                       [](double a, double b) { return std::min(a, b); });
+        std::transform(std::begin(vec_to_node), std::end(vec_to_node), std::begin(top_right),
+                       std::begin(top_right),
+                       [](double a, double b) { return std::max(a, b); });
     }
 
     // Create Chaste points, rescaled by the location of node zero

--- a/mesh/src/vertex/VertexMesh.cpp
+++ b/mesh/src/vertex/VertexMesh.cpp
@@ -34,6 +34,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "VertexMesh.hpp"
+
+#include <algorithm>
 #include "MutableMesh.hpp"
 #include "RandomNumberGenerator.hpp"
 #include "UblasCustomFunctions.hpp"
@@ -787,10 +789,7 @@ unsigned VertexMesh<ELEMENT_DIM, SPACE_DIM>::GetRosetteRankOfElement(unsigned in
     {
         unsigned num_elems_this_node = p_element->GetNode(node_idx)->rGetContainingElementIndices().size();
 
-        if (num_elems_this_node > rosette_rank)
-        {
-            rosette_rank = num_elems_this_node;
-        }
+        rosette_rank = std::max(rosette_rank, num_elems_this_node);
     }
 
     // Return the rosette rank

--- a/mesh/src/vertex/VoronoiVertexMeshGenerator.cpp
+++ b/mesh/src/vertex/VoronoiVertexMeshGenerator.cpp
@@ -34,6 +34,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "VoronoiVertexMeshGenerator.hpp"
+#include <algorithm>
+
 #include <boost/make_shared.hpp>
 #include <boost/shared_ptr.hpp>
 
@@ -273,14 +275,9 @@ boost::shared_ptr<Toroidal2dVertexMesh> VoronoiVertexMeshGenerator::GetToroidalM
     {
         const c_vector<double, 2>& r_this_node_location = mpTorMesh->GetNode(node_idx)->rGetLocation();
 
-        if (r_this_node_location[0] < min_x_y[0])
-        {
-            min_x_y[0] = r_this_node_location[0];
-        }
-        if (r_this_node_location[1] < min_x_y[1])
-        {
-            min_x_y[1] = r_this_node_location[1];
-        }
+        std::transform(std::begin(r_this_node_location), std::end(r_this_node_location), std::begin(min_x_y),
+                       std::begin(min_x_y),
+                       [](double a, double b) { return std::min(a, b); });
     }
 
     // Second loop applies the offset, min_x_y, to each node in the mesh


### PR DESCRIPTION
Closes #644

Part of the manual-loop cleanup. Branch: `cleanup/std-minmax-bounding-box` (one commit on top of `develop`).

This idiom appears **six times** across `mesh`, `heart` and `cell_based`:

```cpp
for (unsigned i = 0; i < DIM; i++)
{
    if (pos[i] < min[i]) { min[i] = pos[i]; }
    if (pos[i] > max[i]) { max[i] = pos[i]; }
}
```

Each becomes a pair of `std::transform` calls over the `c_vector`, using `std::begin`/`std::end` for ublas compatibility as established by `aa78d460f`:

- `AbstractMesh::CalculateBoundingBox`
- `AbstractBoxDomainPdeModifier::ConstructBoundaryConditionsContainerHelper`
- `HeartGeometryInformation`
- `ImmersedBoundaryMesh::CalculateBoundingBoxOfElement`
- `VoronoiVertexMeshGenerator`
- `AbstractCellPopulation::GetSizeOfCellPopulation` (max only)

Also in this branch:

- Five single-variable running maxima become `std::max`: `AbstractBoxDomainPdeModifier` (tissue radius), `ParabolicBoxDomainPdeModifier`, `RadialCellDataDistributionWriter` (both overloads), `AbstractTetrahedralMesh::CalculateMaximumNodeConnectivityPerProcess`, `VertexMesh::GetRosetteRankOfElement`.
- `PostProcessingWriter`'s per-process pace count becomes `std::accumulate`, which handles the empty payload on a process owning no nodes without adding a branch.

**Two incidental fixes in `AbstractBoxDomainPdeModifier`:** the sentinel-seeding loop becomes a `scalar_vector`, and `GetLocationOfCellCentre` (which returns a `c_vector` **by value**) is no longer bound to a `const ChastePoint<DIM>&`, which was silently constructing a temporary on every iteration.

**One behavioural note to check in review:** `ImmersedBoundaryMesh` used `else if` between the two updates. Since `bottom_left` is never positive and `top_right` never negative, no component can satisfy both conditions, so splitting them into two independent transforms is equivalent. Worth a second pair of eyes.

**Files:** 11 changed, +66 / -108.

---

### Review notes

- One commit, based on current `develop`. This is one of six sibling PRs from #650; all six were test-merged into `develop` in sequence and **do not conflict** with each other, so they can go in in any order.
- **Not yet compiled.** There was no build tree available where this was prepared, so this needs a CI run before it is trusted. See #650 for the full list of caveats that shaped these changes.
- No test reference data should need regenerating: summation order and floating-point results are unchanged throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
