### PR TITLE
Use std::clamp, std::min and std::max for bound-limiting if statements

### DIFF
--- a/cell_based/src/cell/cycle/StochasticOxygenBasedCellCycleModel.cpp
+++ b/cell_based/src/cell/cycle/StochasticOxygenBasedCellCycleModel.cpp
@@ -33,6 +33,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <algorithm>
+
 #include "StochasticOxygenBasedCellCycleModel.hpp"
 
 StochasticOxygenBasedCellCycleModel::StochasticOxygenBasedCellCycleModel()
@@ -74,10 +76,7 @@ void StochasticOxygenBasedCellCycleModel::GenerateStochasticG2Duration()
     mStochasticG2Duration = p_gen->NormalRandomDeviate(mean, standard_deviation);
 
     // Check that the normal random deviate has not returned a small or negative G2 duration
-    if (mStochasticG2Duration < mMinimumGapDuration)
-    {
-        mStochasticG2Duration = mMinimumGapDuration;
-    }
+    mStochasticG2Duration = std::max(mStochasticG2Duration, mMinimumGapDuration);
 }
 
 void StochasticOxygenBasedCellCycleModel::InitialiseDaughterCell()

--- a/continuum_mechanics/src/solver/AbstractNonlinearElasticitySolver.hpp
+++ b/continuum_mechanics/src/solver/AbstractNonlinearElasticitySolver.hpp
@@ -36,6 +36,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef ABSTRACTNONLINEARELASTICITYSOLVER_HPP_
 #define ABSTRACTNONLINEARELASTICITYSOLVER_HPP_
 
+#include <algorithm>
 #include <vector>
 #include <cmath>
 #include "AbstractContinuumMechanicsSolver.hpp"
@@ -2052,14 +2053,7 @@ void AbstractNonlinearElasticitySolver<DIM>::SolveNonSnes(double tol)
         tol = NEWTON_REL_TOL*norm_resid;
 
         // LCOV_EXCL_START // not going to have tests in cts for everything
-        if (tol > MAX_NEWTON_ABS_TOL)
-        {
-            tol = MAX_NEWTON_ABS_TOL;
-        }
-        if (tol < MIN_NEWTON_ABS_TOL)
-        {
-            tol = MIN_NEWTON_ABS_TOL;
-        }
+        tol = std::clamp(tol, MIN_NEWTON_ABS_TOL, MAX_NEWTON_ABS_TOL);
         // LCOV_EXCL_STOP
     }
 

--- a/crypt/src/cell/cycle/SimpleWntCellCycleModel.cpp
+++ b/crypt/src/cell/cycle/SimpleWntCellCycleModel.cpp
@@ -33,6 +33,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <algorithm>
+
 #include "SimpleWntCellCycleModel.hpp"
 #include "Exception.hpp"
 #include "StemCellProliferativeType.hpp"
@@ -123,10 +125,7 @@ void SimpleWntCellCycleModel::SetG1Duration()
     }
 
     // Check that the normal random deviate has not returned a small or negative G1 duration
-    if (mG1Duration < mMinimumGapDuration)
-    {
-        mG1Duration = mMinimumGapDuration;
-    }
+    mG1Duration = std::max(mG1Duration, mMinimumGapDuration);
 }
 
 double SimpleWntCellCycleModel::GetWntLevel() const

--- a/crypt/src/cell/cycle/StochasticWntCellCycleModel.cpp
+++ b/crypt/src/cell/cycle/StochasticWntCellCycleModel.cpp
@@ -33,6 +33,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <algorithm>
+
 #include "StochasticWntCellCycleModel.hpp"
 
 StochasticWntCellCycleModel::StochasticWntCellCycleModel(boost::shared_ptr<AbstractCellCycleModelOdeSolver> pOdeSolver)
@@ -92,10 +94,7 @@ void StochasticWntCellCycleModel::GenerateStochasticG2Duration()
     mStochasticG2Duration = p_gen->NormalRandomDeviate(mean, standard_deviation);
 
     // Check that the normal random deviate has not returned a small or negative G2 duration
-    if (mStochasticG2Duration < mMinimumGapDuration)
-    {
-        mStochasticG2Duration = mMinimumGapDuration;
-    }
+    mStochasticG2Duration = std::max(mStochasticG2Duration, mMinimumGapDuration);
 }
 
 void StochasticWntCellCycleModel::InitialiseDaughterCell()

--- a/heart/src/odes/AbstractBackwardEulerCardiacCell.hpp
+++ b/heart/src/odes/AbstractBackwardEulerCardiacCell.hpp
@@ -37,6 +37,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef ABSTRACTBACKWARDEULERCARDIACCELL_HPP_
 #define ABSTRACTBACKWARDEULERCARDIACCELL_HPP_
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 
@@ -228,10 +229,7 @@ OdeSolution AbstractBackwardEulerCardiacCell<SIZE>::Compute(double tStart, doubl
     //     using backward Euler
 
     // Check length of time interval
-    if (tSamp < mDt)
-    {
-        tSamp = mDt;
-    }
+    tSamp = std::max(tSamp, mDt);
     double _n_steps = (tEnd - tStart) / tSamp;
     const unsigned n_steps = (unsigned) floor(_n_steps+0.5);
     assert(fabs(tStart+n_steps*tSamp - tEnd) < 1e-12);
@@ -387,10 +385,7 @@ public:
         //     using backward Euler
 
         // Check length of time interval
-        if (tSamp < mDt)
-        {
-            tSamp = mDt;
-        }
+        tSamp = std::max(tSamp, mDt);
         double _n_steps = (tEnd - tStart) / tSamp;
         const unsigned n_steps = (unsigned) floor(_n_steps+0.5);
         assert(fabs(tStart+n_steps*tSamp - tEnd) < 1e-12);

--- a/heart/src/odes/AbstractCardiacCell.cpp
+++ b/heart/src/odes/AbstractCardiacCell.cpp
@@ -34,6 +34,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #include "AbstractCardiacCell.hpp"
 
+#include <algorithm>
+
 #include <cassert>
 #include <iostream>
 
@@ -74,10 +76,7 @@ void AbstractCardiacCell::SolveAndUpdateState(double tStart, double tEnd)
 
 OdeSolution AbstractCardiacCell::Compute(double tStart, double tEnd, double tSamp)
 {
-    if (tSamp < mDt)
-    {
-        tSamp = mDt;
-    }
+    tSamp = std::max(tSamp, mDt);
     OdeSolution solution = mpOdeSolver->Solve(this, rGetStateVariables(), tStart, tEnd, mDt, tSamp);
 #ifndef NDEBUG
     // Note that tests which rely on this throwing  (e.g. such-and-such a variable is out of range)

--- a/heart/src/odes/AbstractGeneralizedRushLarsenCardiacCell.cpp
+++ b/heart/src/odes/AbstractGeneralizedRushLarsenCardiacCell.cpp
@@ -43,6 +43,8 @@ Science and Engineering Research Council (NSERC) of Canada
 and the MITACS/Mprime Canadian Network of Centres of Excellence.
 */
 
+#include <algorithm>
+
 #include "AbstractGeneralizedRushLarsenCardiacCell.hpp"
 #include <cassert>
 #include <cmath>
@@ -70,10 +72,7 @@ AbstractGeneralizedRushLarsenCardiacCell::~AbstractGeneralizedRushLarsenCardiacC
 OdeSolution AbstractGeneralizedRushLarsenCardiacCell::Compute(double tStart, double tEnd, double tSamp)
 {
     // Check length of time interval
-    if (tSamp < mDt)
-    {
-        tSamp = mDt;
-    }
+    tSamp = std::max(tSamp, mDt);
     const unsigned n_steps = (unsigned) floor((tEnd - tStart)/tSamp + 0.5);
     assert(fabs(tStart+n_steps*tSamp - tEnd) < 1e-12);
     const unsigned n_small_steps = (unsigned) floor(tSamp/mDt+0.5);

--- a/heart/src/odes/AbstractRushLarsenCardiacCell.cpp
+++ b/heart/src/odes/AbstractRushLarsenCardiacCell.cpp
@@ -33,6 +33,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <algorithm>
+
 #include "AbstractRushLarsenCardiacCell.hpp"
 
 #include <cassert>
@@ -62,10 +64,7 @@ OdeSolution AbstractRushLarsenCardiacCell::Compute(double tStart, double tEnd, d
     //     using Rush Larsen method or forward Euler as appropriate
 
     // Check length of time interval
-    if (tSamp < mDt)
-    {
-        tSamp = mDt;
-    }
+    tSamp = std::max(tSamp, mDt);
     const unsigned n_steps = (unsigned) floor((tEnd - tStart)/tSamp + 0.5);
     assert(fabs(tStart+n_steps*tSamp - tEnd) < 1e-12);
     const unsigned n_small_steps = (unsigned) floor(tSamp/mDt+0.5);

--- a/ode/src/solver/RungeKuttaFehlbergIvpOdeSolver.cpp
+++ b/ode/src/solver/RungeKuttaFehlbergIvpOdeSolver.cpp
@@ -234,10 +234,7 @@ void RungeKuttaFehlbergIvpOdeSolver::AdjustStepSize(double& rCurrentStepSize,
         rCurrentStepSize *= delta;
     }
 
-    if (rCurrentStepSize > rMaxTimeStep)
-    {
-        rCurrentStepSize = rMaxTimeStep;
-    }
+    rCurrentStepSize = std::min(rCurrentStepSize, rMaxTimeStep);
 
     if (rCurrentStepSize < rMinTimeStep)
     {

--- a/pde/src/common/AbstractTimeAdaptivityController.hpp
+++ b/pde/src/common/AbstractTimeAdaptivityController.hpp
@@ -36,6 +36,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef ABSTRACTTIMEADAPTIVITYCONTROLLER_HPP_
 #define ABSTRACTTIMEADAPTIVITYCONTROLLER_HPP_
 
+#include <algorithm>
+
 #include "PetscVecTools.hpp"
 
 /**
@@ -92,16 +94,10 @@ public:
      */
     double GetNextTimeStep(double currentTime, Vec currentSolution)
     {
+        // Note that std::clamp returns a reference, so the value being clamped must be
+        // a named local rather than a temporary
         double dt = ComputeTimeStep(currentTime, currentSolution);
-        if (dt < mMinimumTimeStep)
-        {
-            dt = mMinimumTimeStep;
-        }
-        if (dt > mMaximumTimeStep)
-        {
-            dt = mMaximumTimeStep;
-        }
-        return dt;
+        return std::clamp(dt, mMinimumTimeStep, mMaximumTimeStep);
     }
 };
 


### PR DESCRIPTION
Closes #645

Part of the manual-loop cleanup. Branch: `cleanup/std-clamp` (one commit on top of `develop`).

Chaste is built as C++17 (`CMakeLists.txt:37`), so `std::clamp` is available.

**Two-sided clamps → `std::clamp`:**
- `AbstractTimeAdaptivityController::GetNextTimeStep`
- `AbstractNonlinearElasticitySolver::SolveNonSnes` (Newton tolerance)

**One-sided bounds → `std::min` / `std::max`:**
- The `if (tSamp < mDt) { tSamp = mDt; }` guard duplicated across five cardiac cell `Compute` methods in `heart/src/odes` (`AbstractCardiacCell`, `AbstractRushLarsenCardiacCell`, `AbstractGeneralizedRushLarsenCardiacCell`, and twice in `AbstractBackwardEulerCardiacCell`)
- Minimum gap duration checks in `SimpleWntCellCycleModel`, `StochasticWntCellCycleModel`, `StochasticOxygenBasedCellCycleModel`
- The maximum step size cap in `RungeKuttaFehlbergIvpOdeSolver::AdjustStepSize`

The **lower** bound in `AdjustStepSize` is deliberately left as an `if`: it raises an exception rather than clamping, so it is not part of a clamp.

**Preconditions checked:** `std::clamp` is UB if `hi < lo`. Both are already guaranteed — `AbstractTimeAdaptivityController`'s constructor asserts `minimumTimeStep < maximumTimeStep`, and `MIN_NEWTON_ABS_TOL` (1e-10) < `MAX_NEWTON_ABS_TOL` (1e-7).

**One subtlety:** `std::clamp` returns a *reference*, so `GetNextTimeStep` clamps a named local rather than the temporary returned by `ComputeTimeStep`.

**Files:** 10 changed, +29 / -53.

---

### Review notes

- One commit, based on current `develop`. This is one of six sibling PRs from #650; all six were test-merged into `develop` in sequence and **do not conflict** with each other, so they can go in in any order.
- **Not yet compiled.** There was no build tree available where this was prepared, so this needs a CI run before it is trusted. See #650 for the full list of caveats that shaped these changes.
- No test reference data should need regenerating: summation order and floating-point results are unchanged throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
