### PR TITLE
Replace flag-and-break loops with std::any_of, std::none_of and std::equal

### DIFF
--- a/cell_based/src/cell/Cell.hpp
+++ b/cell_based/src/cell/Cell.hpp
@@ -36,6 +36,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef CELL_HPP_
 #define CELL_HPP_
 
+#include <algorithm>
+
 #include <boost/utility.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/enable_shared_from_this.hpp>
@@ -329,22 +331,13 @@ public:
     template<typename CLASS>
     void RemoveCellProperty()
     {
-        bool cell_has_property = false;
+        auto property_iter = std::find_if(mCellPropertyCollection.Begin(), mCellPropertyCollection.End(),
+                                          [](const boost::shared_ptr<AbstractCellProperty>& pProperty)
+                                          { return pProperty->IsType<CLASS>(); });
 
-        for (std::set<boost::shared_ptr<AbstractCellProperty> >::iterator property_iter = mCellPropertyCollection.Begin();
-             property_iter != mCellPropertyCollection.End();
-             ++property_iter)
+        if (property_iter != mCellPropertyCollection.End())
         {
-            if ((*property_iter)->IsType<CLASS>())
-            {
-                cell_has_property = true;
-                (*property_iter)->DecrementCellCount();
-                break;
-            }
-        }
-
-        if (cell_has_property)
-        {
+            (*property_iter)->DecrementCellCount();
             mCellPropertyCollection.RemoveProperty<CLASS>();
         }
     }

--- a/cell_based/src/population/ImmersedBoundaryCellPopulation.cpp
+++ b/cell_based/src/population/ImmersedBoundaryCellPopulation.cpp
@@ -33,6 +33,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <algorithm>
+
 #include "ImmersedBoundaryCellPopulation.hpp"
 
 #include <iomanip>
@@ -990,16 +992,13 @@ bool ImmersedBoundaryCellPopulation<DIM>::IsPdeNodeAssociatedWithNonApoptoticCel
     {
         std::set<unsigned> containing_element_indices = this->GetNode(pdeNodeIndex)->rGetContainingElementIndices();
 
-        for (auto iter = containing_element_indices.begin();
-             iter != containing_element_indices.end();
-             iter++) //LCOV_EXCL_LINE
-        {
-            if (this->GetCellUsingLocationIndex(*iter)->template HasCellProperty<ApoptoticCellProperty>() )
-            {
-                non_apoptotic_cell_present = false;
-                break;
-            }
-        }
+        non_apoptotic_cell_present =
+            std::none_of(containing_element_indices.begin(), containing_element_indices.end(),
+                         [this](unsigned elemIndex)
+                         {
+                             return this->GetCellUsingLocationIndex(elemIndex)
+                                 ->template HasCellProperty<ApoptoticCellProperty>();
+                         });
     }
     else
     {

--- a/cell_based/src/population/VertexBasedCellPopulation.cpp
+++ b/cell_based/src/population/VertexBasedCellPopulation.cpp
@@ -33,6 +33,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <algorithm>
+
 #include "VertexBasedCellPopulation.hpp"
 #include "Warnings.hpp"
 #include "ShortAxisVertexBasedDivisionRule.hpp"
@@ -1068,16 +1070,13 @@ bool VertexBasedCellPopulation<DIM>::IsPdeNodeAssociatedWithNonApoptoticCell(uns
     {
         std::set<unsigned> containing_element_indices = this->GetNode(pdeNodeIndex)->rGetContainingElementIndices();
 
-        for (std::set<unsigned>::iterator iter = containing_element_indices.begin();
-             iter != containing_element_indices.end();
-             iter++)
-        {
-            if (this->GetCellUsingLocationIndex(*iter)->template HasCellProperty<ApoptoticCellProperty>() )
-            {
-                non_apoptotic_cell_present = false;
-                break;
-            }
-        }
+        non_apoptotic_cell_present =
+            std::none_of(containing_element_indices.begin(), containing_element_indices.end(),
+                         [this](unsigned elemIndex)
+                         {
+                             return this->GetCellUsingLocationIndex(elemIndex)
+                                 ->template HasCellProperty<ApoptoticCellProperty>();
+                         });
     }
     else
     {

--- a/cell_based/src/population/division_rules/ExclusionCaBasedDivisionRule.cpp
+++ b/cell_based/src/population/division_rules/ExclusionCaBasedDivisionRule.cpp
@@ -33,14 +33,14 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <algorithm>
+
 #include "ExclusionCaBasedDivisionRule.hpp"
 #include "RandomNumberGenerator.hpp"
 
 template<unsigned SPACE_DIM>
 bool ExclusionCaBasedDivisionRule<SPACE_DIM>::IsRoomToDivide(CellPtr pParentCell, CaBasedCellPopulation<SPACE_DIM>& rCellPopulation)
 {
-    bool is_room = false;
-
     // Get node index corresponding to this cell
     unsigned node_index = rCellPopulation.GetLocationIndexUsingCell(pParentCell);
 
@@ -48,18 +48,9 @@ bool ExclusionCaBasedDivisionRule<SPACE_DIM>::IsRoomToDivide(CellPtr pParentCell
     std::set<unsigned> neighbouring_node_indices = static_cast<PottsMesh<SPACE_DIM>*>(&(rCellPopulation.rGetMesh()))->GetMooreNeighbouringNodeIndices(node_index);
 
     // Iterate through the neighbours to see if there are any available sites
-    for (std::set<unsigned>::iterator neighbour_iter = neighbouring_node_indices.begin();
-         neighbour_iter != neighbouring_node_indices.end();
-         ++neighbour_iter)
-    {
-        if (rCellPopulation.IsSiteAvailable(*neighbour_iter, pParentCell))
-        {
-            is_room = true;
-            break;
-        }
-    }
-
-    return is_room;
+    return std::any_of(neighbouring_node_indices.begin(), neighbouring_node_indices.end(),
+                       [&](unsigned neighbourIndex)
+                       { return rCellPopulation.IsSiteAvailable(neighbourIndex, pParentCell); });
 }
 
 template<unsigned SPACE_DIM>

--- a/global/src/FileFinder.cpp
+++ b/global/src/FileFinder.cpp
@@ -204,15 +204,9 @@ bool FileFinder::IsEmpty() const
     }
     else if (IsDir())
     {
-        fs::directory_iterator end_iter;
-        for (fs::directory_iterator dir_iter(mAbsPath); dir_iter != end_iter; ++dir_iter)
-        {
-            if ((dir_iter->path().filename().string()).substr(0, 1) != ".")
-            {
-                empty = false;
-                break;
-            }
-        }
+        empty = std::none_of(fs::directory_iterator(mAbsPath), fs::directory_iterator(),
+                             [](const fs::directory_entry& rEntry)
+                             { return rEntry.path().filename().string().substr(0, 1) != "."; });
     }
     else
     {
@@ -500,17 +494,10 @@ std::vector<FileFinder> FileFinder::FindMatches(const std::string& rPattern) con
                         // Match against first len chars
                         match = leafname.substr(0, len);
                     }
-                    bool ok = true;
-                    for (std::string::const_iterator it_p = pattern.begin(), it_m = match.begin();
-                         it_p != pattern.end();
-                         ++it_p, ++it_m)
-                    {
-                        if (*it_p != '?' && *it_p != *it_m)
-                        {
-                            ok = false;
-                            break;
-                        }
-                    }
+                    // '?' in the pattern matches any single character
+                    bool ok = std::equal(pattern.begin(), pattern.end(), match.begin(),
+                                         [](char patternChar, char matchChar)
+                                         { return patternChar == '?' || patternChar == matchChar; });
                     if (ok)
                     {
                         results.push_back(FileFinder(our_path / leafname));

--- a/lung/src/airway_generation/MajorAirwaysCentreLinesCleaner.cpp
+++ b/lung/src/airway_generation/MajorAirwaysCentreLinesCleaner.cpp
@@ -33,6 +33,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <algorithm>
+
 #include "MajorAirwaysCentreLinesCleaner.hpp"
 
 
@@ -58,14 +60,11 @@ void  MajorAirwaysCentreLinesCleaner::CleanElementUsingHorsfieldOrder(Element<1,
     std::vector<Element<1,3>* > child_eles = mWalker.GetChildElements(pElement);
 
     // If either of the children of this element are below the order limit delete BOTH of them.
-    bool delete_children = delete_me; //Always delete children if this element is to be deleted.
-    for (unsigned i = 0; i < child_eles.size(); ++i)
-    {
-        if (mWalker.GetElementHorsfieldOrder(child_eles[i]) <= mMaxOrder)
-        {
-            delete_children = true;
-        }
-    }
+    //Always delete children if this element is to be deleted.
+    bool delete_children = delete_me
+                           || std::any_of(child_eles.begin(), child_eles.end(),
+                                          [this](Element<1, 3>* pChild)
+                                          { return mWalker.GetElementHorsfieldOrder(pChild) <= mMaxOrder; });
 
     // Recursively process children
     for (unsigned i = 0; i < child_eles.size(); ++i)

--- a/mesh/src/common/ChastePoint.cpp
+++ b/mesh/src/common/ChastePoint.cpp
@@ -33,6 +33,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <algorithm>
+
 #include "ChastePoint.hpp"
 #include "Exception.hpp"
 
@@ -114,16 +116,7 @@ void ChastePoint<DIM>::SetCoordinate(unsigned i, double value)
 template<unsigned DIM>
 bool ChastePoint<DIM>::IsSamePoint(const ChastePoint<DIM>& rPoint) const
 {
-    bool returned_value = true;
-    for (unsigned dim=0; dim<DIM; dim++)
-    {
-        if (rPoint[dim] != mLocation[dim])
-        {
-            returned_value = false;
-            break;
-        }
-    }
-    return returned_value;
+    return std::equal(std::begin(mLocation), std::end(mLocation), std::begin(rPoint.rGetLocation()));
 }
 
 // Methods of the 0d version

--- a/mesh/src/common/MutableElement.cpp
+++ b/mesh/src/common/MutableElement.cpp
@@ -32,6 +32,8 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
 OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
+#include <algorithm>
+
 #include "MutableElement.hpp"
 #include "RandomNumberGenerator.hpp"
 #include <cassert>
@@ -254,16 +256,8 @@ void MutableElement<ELEMENT_DIM, SPACE_DIM>::RebuildEdges()
 template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
 bool MutableElement<ELEMENT_DIM, SPACE_DIM>::IsElementOnBoundary() const
 {
-    bool is_element_on_boundary = false;
-    for (unsigned i=0; i<this->mNodes.size(); i++)
-    {
-        if (this->GetNode(i)->IsBoundaryNode())
-        {
-            is_element_on_boundary = true;
-            break;
-        }
-    }
-    return is_element_on_boundary;
+    return std::any_of(this->mNodes.begin(), this->mNodes.end(),
+                       [](const Node<SPACE_DIM>* pNode) { return pNode->IsBoundaryNode(); });
 }
 
 template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
@@ -568,16 +562,8 @@ void MutableElement<1, SPACE_DIM>::RebuildEdges(){
 template<unsigned SPACE_DIM>
 bool MutableElement<1, SPACE_DIM>::IsElementOnBoundary() const
 {
-    bool is_element_on_boundary = false;
-    for (unsigned i=0; i<this->mNodes.size(); i++)
-    {
-        if (this->GetNode(i)->IsBoundaryNode())
-        {
-            is_element_on_boundary = true;
-            break;
-        }
-    }
-    return is_element_on_boundary;
+    return std::any_of(this->mNodes.begin(), this->mNodes.end(),
+                       [](const Node<SPACE_DIM>* pNode) { return pNode->IsBoundaryNode(); });
 }
 
 // Explicit instantiation

--- a/mesh/src/utilities/ChasteNodesList.cpp
+++ b/mesh/src/utilities/ChasteNodesList.cpp
@@ -33,6 +33,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <algorithm>
+
 #include "ChasteNodesList.hpp"
 
 template <unsigned SPACE_DIM>
@@ -57,17 +59,9 @@ ChasteNodesList<SPACE_DIM>::~ChasteNodesList()
 template <unsigned SPACE_DIM>
 bool ChasteNodesList<SPACE_DIM>::DoesContain(const ChastePoint<SPACE_DIM>& rPointToCheck) const
 {
-    bool returned_value = false;
-    for (unsigned index = 0; index < mListOfNodes.size(); index++)
-    {
-        if (mListOfNodes[index]->GetPoint().IsSamePoint(rPointToCheck))
-        {
-            returned_value = true;
-            break;
-        }
-    }
-
-    return returned_value;
+    return std::any_of(mListOfNodes.begin(), mListOfNodes.end(),
+                       [&rPointToCheck](const Node<SPACE_DIM>* pNode)
+                       { return pNode->GetPoint().IsSamePoint(rPointToCheck); });
 }
 
 template <unsigned SPACE_DIM>

--- a/mesh/src/vertex/MutableVertexMesh.cpp
+++ b/mesh/src/vertex/MutableVertexMesh.cpp
@@ -33,6 +33,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <algorithm>
+
 #include "MutableVertexMesh.hpp"
 
 #include "LogFile.hpp"
@@ -1092,17 +1094,10 @@ bool MutableVertexMesh<ELEMENT_DIM, SPACE_DIM>::CheckForSwapsFromShortEdges()
                                           elements_of_node_b.begin(), elements_of_node_b.end(),
                                           std::inserter(shared_elements, shared_elements.begin()));
 
-                    bool both_nodes_share_triangular_element = false;
-                    for (std::set<unsigned>::const_iterator it = shared_elements.begin();
-                         it != shared_elements.end();
-                         ++it)
-                    {
-                        if (this->GetElement(*it)->GetNumNodes() <= 3)
-                        {
-                            both_nodes_share_triangular_element = true;
-                            break;
-                        }
-                    }
+                    bool both_nodes_share_triangular_element =
+                        std::any_of(shared_elements.begin(), shared_elements.end(),
+                                    [this](unsigned elemIndex)
+                                    { return this->GetElement(elemIndex)->GetNumNodes() <= 3; });
 
                     // ...and if none are, then perform the required type of swap and halt the search, returning true
                     if (!both_nodes_share_triangular_element)

--- a/mesh/src/vertex/VertexMesh.cpp
+++ b/mesh/src/vertex/VertexMesh.cpp
@@ -33,6 +33,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <algorithm>
+
 #include "VertexMesh.hpp"
 #include "MutableMesh.hpp"
 #include "RandomNumberGenerator.hpp"
@@ -1045,19 +1047,12 @@ VertexMesh<ELEMENT_DIM, SPACE_DIM>* VertexMesh<ELEMENT_DIM, SPACE_DIM>::GetMeshF
 template <unsigned ELEMENT_DIM, unsigned SPACE_DIM>
 bool VertexMesh<ELEMENT_DIM, SPACE_DIM>::IsNearExistingNodes(c_vector<double,SPACE_DIM> newNodeLocation, std::vector<Node<SPACE_DIM> *> nodesToCheck, double minClearance)
 {
-    bool node_near = false;
-
-    for (unsigned i=0; i<nodesToCheck.size(); i++)
-    {
-        double distance = norm_2(mpDelaunayMesh->GetVectorFromAtoB(nodesToCheck[i]->rGetLocation(), newNodeLocation));
-        if (distance < minClearance)
-        {
-            node_near = true;
-            break;
-        }
-    }
-
-    return node_near;
+    return std::any_of(nodesToCheck.begin(), nodesToCheck.end(),
+                       [&](const Node<SPACE_DIM>* pNode)
+                       {
+                           return norm_2(mpDelaunayMesh->GetVectorFromAtoB(pNode->rGetLocation(),
+                                                                          newNodeLocation)) < minClearance;
+                       });
 }
 
 /// \cond Get Doxygen to ignore, since it's confused by these templates


### PR DESCRIPTION
Closes #646

Part of the manual-loop cleanup. Branch: `cleanup/std-any-of` (one commit on top of `develop`).

Twelve loops whose only job was to set a `bool` and `break`, in the same spirit as the `std::none_of` change in `ee4286aa0`.

**`std::any_of`**
- `MutableElement::IsElementOnBoundary` — both the general template and the 1D specialisation, which were byte-identical
- `ChasteNodesList::DoesContain`
- `MutableVertexMesh` — the shared-triangular-element check
- `VertexMesh::IsNearExistingNodes`
- `ExclusionCaBasedDivisionRule::IsRoomToDivide`
- `MajorAirwaysCentreLinesCleaner::CleanElementUsingHorsfieldOrder`

**`std::none_of`**
- `IsPdeNodeAssociatedWithNonApoptoticCell` in both `VertexBasedCellPopulation` and `ImmersedBoundaryCellPopulation` — these were duplicates of each other
- `FileFinder::IsEmpty`

**`std::equal`**
- `ChastePoint::IsSamePoint`
- `FileFinder::FindMatches` — its `?` wildcard comparison is `std::equal` with a predicate

**`std::find_if`**
- `Cell::RemoveCellProperty`, whose loop body has a side effect (`DecrementCellCount`) and so cannot be a plain predicate

**One behavioural note:** `MajorAirwaysCentreLinesCleaner` had **no** `break`, so it evaluated every child. `std::any_of` short-circuits but reaches the same answer, and the `delete_me` seed is preserved as a short-circuiting `||` in front.

`MutableVertexMesh:2425` and similar index-based loops over a fixed count with no underlying container are left alone — there is nothing for an algorithm to iterate.

**Files:** 11 changed, +72 / -141 — the largest net reduction of the six.

---

### Review notes

- One commit, based on current `develop`. This is one of six sibling PRs from #650; all six were test-merged into `develop` in sequence and **do not conflict** with each other, so they can go in in any order.
- **Not yet compiled.** There was no build tree available where this was prepared, so this needs a CI run before it is trusted. See #650 for the full list of caveats that shaped these changes.
- No test reference data should need regenerating: summation order and floating-point results are unchanged throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
