### PR TITLE
Replace summation loops with std::accumulate and std::inner_product

### DIFF
--- a/cell_based/src/simulation/modifiers/ImmersedBoundarySimulationModifier.cpp
+++ b/cell_based/src/simulation/modifiers/ImmersedBoundarySimulationModifier.cpp
@@ -33,6 +33,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <numeric>
+
 #include "ImmersedBoundarySimulationModifier.hpp"
 
 #include <memory>
@@ -463,11 +465,9 @@ void ImmersedBoundarySimulationModifier<DIM>::PropagateFluidSourcesToGrid()
         combined_sources.insert(combined_sources.end(), r_balance_sources.begin(), r_balance_sources.end());
 
         // Find the combined element source strength
-        double cumulative_strength = 0.0;
-        for (unsigned source_idx = 0; source_idx < r_element_sources.size(); source_idx++)
-        {
-            cumulative_strength += r_element_sources[source_idx]->GetStrength();
-        }
+        double cumulative_strength = std::accumulate(r_element_sources.begin(), r_element_sources.end(), 0.0,
+            [](double total, const std::shared_ptr<FluidSource<DIM>>& pSource)
+            { return total + pSource->GetStrength(); });
 
         // Calculate the required balancing strength, and apply it to all balancing sources
         double balance_strength = -1.0 * cumulative_strength / (double)r_balance_sources.size();

--- a/heart/src/odes/single_cell/SteadyStateRunner.cpp
+++ b/heart/src/odes/single_cell/SteadyStateRunner.cpp
@@ -33,6 +33,9 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <functional>
+#include <numeric>
+
 #include "SteadyStateRunner.hpp"
 #include "ZeroStimulus.hpp"
 
@@ -87,11 +90,9 @@ void SteadyStateRunner::RunToSteadyStateImplementation()
         CopyToStdVector(mpModel->rGetStateVariables(), new_state_vars);
 
         // Calculate the change in the norm of the state variables
-        double temp = 0;
-        for (unsigned j = 0; j < old_state_vars.size(); j++)
-        {
-            temp += fabs(new_state_vars[j] - old_state_vars[j]);
-        }
+        double temp = std::inner_product(old_state_vars.begin(), old_state_vars.end(),
+                                         new_state_vars.begin(), 0.0, std::plus<double>(),
+                                         [](double oldVar, double newVar) { return fabs(newVar - oldVar); });
 
         if (temp < 1e-6)
         {

--- a/heart/src/stimulus/MultiStimulus.cpp
+++ b/heart/src/stimulus/MultiStimulus.cpp
@@ -34,6 +34,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 
+#include <numeric>
+
 #include "MultiStimulus.hpp"
 
 void MultiStimulus::AddStimulus(boost::shared_ptr<AbstractStimulusFunction> pStimulus)
@@ -43,14 +45,9 @@ void MultiStimulus::AddStimulus(boost::shared_ptr<AbstractStimulusFunction> pSti
 
 double MultiStimulus::GetStimulus(double time)
 {
-    double total_stimulus = 0.0;
-
-    for (unsigned stimulus_index = 0; stimulus_index < mStimuli.size(); ++stimulus_index)
-    {
-        total_stimulus += mStimuli[stimulus_index]->GetStimulus(time);
-    }
-
-    return total_stimulus;
+    return std::accumulate(mStimuli.begin(), mStimuli.end(), 0.0,
+                           [time](double total, const boost::shared_ptr<AbstractStimulusFunction>& pStimulus)
+                           { return total + pStimulus->GetStimulus(time); });
 }
 
 MultiStimulus::~MultiStimulus()

--- a/lung/src/common/LobePropertiesCalculator.cpp
+++ b/lung/src/common/LobePropertiesCalculator.cpp
@@ -34,6 +34,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 
+#include <numeric>
+
 #include "LobePropertiesCalculator.hpp"
 
 #ifdef CHASTE_VTK
@@ -66,15 +68,9 @@ void LobePropertiesCalculator::AddLobe(vtkSmartPointer<vtkPolyData> pLobeSurface
 
 double LobePropertiesCalculator::GetTotalVolume()
 {
-    double total_volume = 0.0;
-
-    std::map< std::string, std::pair< vtkSmartPointer<vtkPolyData>, LungLocation> >::iterator iter;
-    for (iter = mLobesMap.begin(); iter != mLobesMap.end(); ++iter)
-    {
-        total_volume += GetLobeVolume(iter->second.first);
-    }
-
-    return total_volume;
+    return std::accumulate(mLobesMap.begin(), mLobesMap.end(), 0.0,
+                           [this](double total, const auto& rLobe)
+                           { return total + GetLobeVolume(rLobe.second.first); });
 }
 
 double LobePropertiesCalculator::GetLobeVolume(const std::string& rName)

--- a/mesh/src/common/TetrahedralMesh.cpp
+++ b/mesh/src/common/TetrahedralMesh.cpp
@@ -33,6 +33,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <numeric>
+
 #include "TetrahedralMesh.hpp"
 
 #include <cassert>
@@ -210,11 +212,7 @@ void TetrahedralMesh<ELEMENT_DIM, SPACE_DIM>::ReadNodesPerProcessorFile(const st
         EXCEPTION("Unable to read nodes per processor file " + rNodesPerProcessorFile);
     }
 
-    unsigned sum = 0;
-    for (unsigned i = 0; i < nodes_per_processor_vec.size(); i++)
-    {
-        sum += nodes_per_processor_vec[i];
-    }
+    unsigned sum = std::accumulate(nodes_per_processor_vec.begin(), nodes_per_processor_vec.end(), 0u);
 
     if (sum != this->GetNumNodes())
     {

--- a/mesh/src/utilities/DistributedBoxCollection.cpp
+++ b/mesh/src/utilities/DistributedBoxCollection.cpp
@@ -32,6 +32,8 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
 OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
+#include <numeric>
+
 #include "DistributedBoxCollection.hpp"
 #include "Exception.hpp"
 #include "MathsCustomFunctions.hpp"
@@ -527,16 +529,9 @@ int DistributedBoxCollection<DIM>::LoadBalance(std::vector<int> localDistributio
     /**
      * Calculate change in balance of loads by shifting the left/bottom boundary in either direction
      */
-    int local_load = 0;
-    for (unsigned i=0; i<localDistribution.size(); i++)
-    {
-        local_load += localDistribution[i];
-    }
-    int load_on_left_proc = 0;
-    for (unsigned i=0; i<node_distr_on_left_process.size(); i++)
-    {
-        load_on_left_proc += node_distr_on_left_process[i];
-    }
+    int local_load = std::accumulate(localDistribution.begin(), localDistribution.end(), 0);
+    int load_on_left_proc = std::accumulate(node_distr_on_left_process.begin(),
+                                            node_distr_on_left_process.end(), 0);
 
     if (!PetscTools::AmMaster())
     {

--- a/ode/src/common/CombinedOdeSystem.cpp
+++ b/ode/src/common/CombinedOdeSystem.cpp
@@ -34,6 +34,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 
+#include <numeric>
+
 #include "CombinedOdeSystem.hpp"
 #include "CombinedOdeSystemInformation.hpp"
 
@@ -41,11 +43,9 @@ CombinedOdeSystem::CombinedOdeSystem(std::vector<AbstractOdeSystem*> odeSystems)
     : AbstractOdeSystem(1) // number of state variables will be set properly below
 {
     mOdeSystems = odeSystems;
-    mNumberOfStateVariables = 0;
-    for (unsigned i=0; i<odeSystems.size(); i++)
-    {
-        mNumberOfStateVariables += odeSystems[i]->GetNumberOfStateVariables();
-    }
+    mNumberOfStateVariables = std::accumulate(odeSystems.begin(), odeSystems.end(), 0u,
+        [](unsigned total, const AbstractOdeSystem* pSystem)
+        { return total + pSystem->GetNumberOfStateVariables(); });
     mpSystemInfo = CombinedOdeSystemInformation::Instance(odeSystems);
     ResetToInitialConditions();
 

--- a/ode/src/common/CombinedOdeSystemInformation.cpp
+++ b/ode/src/common/CombinedOdeSystemInformation.cpp
@@ -34,6 +34,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 
+#include <numeric>
+
 #include "CombinedOdeSystemInformation.hpp"
 
 #include <cassert>
@@ -89,11 +91,9 @@ boost::shared_ptr<CombinedOdeSystemInformation> CombinedOdeSystemInformation::In
 CombinedOdeSystemInformation::CombinedOdeSystemInformation(const std::vector<boost::shared_ptr<const AbstractOdeSystemInformation> >& rSubsystemInfo)
 {
     // Figure out our size
-    unsigned total_system_size = 0u;
-    for (unsigned i=0; i<rSubsystemInfo.size(); i++)
-    {
-        total_system_size += rSubsystemInfo[i]->rGetStateVariableNames().size();
-    }
+    unsigned total_system_size = std::accumulate(rSubsystemInfo.begin(), rSubsystemInfo.end(), 0u,
+        [](unsigned total, const boost::shared_ptr<const AbstractOdeSystemInformation>& pInfo)
+        { return total + static_cast<unsigned>(pInfo->rGetStateVariableNames().size()); });
     mVariableNames.reserve(total_system_size);
     mVariableUnits.reserve(total_system_size);
     mInitialConditions.reserve(total_system_size);


### PR DESCRIPTION
Closes #647

Part of the manual-loop cleanup. Branch: `cleanup/std-accumulate` (one commit on top of `develop`).

Eight hand-written summations become a single algorithm call:

- `MultiStimulus::GetStimulus`
- `TetrahedralMesh::ReadNodesPerProcessorFile` — a plain sum, so bare `std::accumulate` with no lambda
- `CombinedOdeSystemInformation` and `CombinedOdeSystem`, both totalling sub-system state variable counts
- `DistributedBoxCollection::LoadBalance` — two integer load sums
- `LobePropertiesCalculator::GetTotalVolume`
- `ImmersedBoundarySimulationModifier` — the cumulative element source strength
- `SteadyStateRunner` — the L1 difference between successive state vectors, which is `std::inner_product` with a custom combine and transform

**Floating point:** summation order is unchanged in every case, so results are bit-identical. No test reference data should need regenerating.

**`std::inner_product` rather than `std::transform_reduce`:** libstdc++ only gained `transform_reduce` in GCC 9, and `inner_product` does exactly the same job here.

**Deliberately skipped.** The centroid accumulations (`AbstractCellPopulation::GetCentroidOfCellPopulation`, `HoneycombMeshGenerator`, `VertexMesh`, `AbstractTetrahedralElement`, `Toroidal2dVertexMesh`) all iterate either a Chaste smart iterator or a bare index range over a mesh. They are blocked on the `iterator_traits` prerequisite issue, and are the main reason that issue is worth doing — roughly 30 further `accumulate` candidates sit behind it.

**Files:** 8 changed, +39 / -52.

---

### Review notes

- One commit, based on current `develop`. This is one of six sibling PRs from #650; all six were test-merged into `develop` in sequence and **do not conflict** with each other, so they can go in in any order.
- **Not yet compiled.** There was no build tree available where this was prepared, so this needs a CI run before it is trusted. See #650 for the full list of caveats that shaped these changes.
- No test reference data should need regenerating: summation order and floating-point results are unchanged throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
