### PR TITLE
Use std::fill, std::copy, std::iota and std::count_if for element-wise loops

### DIFF
--- a/cell_based/src/population/AbstractCellPopulation.cpp
+++ b/cell_based/src/population/AbstractCellPopulation.cpp
@@ -259,11 +259,8 @@ std::vector<unsigned> AbstractCellPopulation<ELEMENT_DIM, SPACE_DIM>::GetCellPro
 template<unsigned ELEMENT_DIM, unsigned SPACE_DIM>
 std::vector<unsigned> AbstractCellPopulation<ELEMENT_DIM, SPACE_DIM>::GetCellCyclePhaseCount()
 {
+    // Note that std::vector value-initialises its elements, so these counts start at zero
     std::vector<unsigned> cell_cycle_phase_count(5);
-    for (unsigned i=0; i<5; i++)
-    {
-        cell_cycle_phase_count[i] = 0;
-    }
 
     /*
      * Note that in parallel with a poor partition a process could end up with zero cells

--- a/cell_based/src/population/CaBasedCellPopulation.cpp
+++ b/cell_based/src/population/CaBasedCellPopulation.cpp
@@ -33,6 +33,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <algorithm>
+
 #include <boost/scoped_array.hpp>
 
 #include "CaBasedCellPopulation.hpp"
@@ -654,10 +656,7 @@ void CaBasedCellPopulation<DIM>::WriteVtkResultsToFile(const std::string& rDirec
     // Create a counter to keep track of how many cells are at a lattice site
     unsigned num_sites = this->mrMesh.GetNumNodes();
     boost::scoped_array<unsigned> number_of_cells_at_site(new unsigned[num_sites]);
-    for (unsigned i=0; i<num_sites; i++)
-    {
-        number_of_cells_at_site[i] = 0;
-    }
+    std::fill_n(number_of_cells_at_site.get(), num_sites, 0u);
 
     // Populate a vector of nodes associated with cell locations, by iterating through the list of cells
     std::vector<Node<DIM>*> nodes;

--- a/cell_based/src/writers/population_writers/CellPopulationAdjacencyMatrixWriter.cpp
+++ b/cell_based/src/writers/population_writers/CellPopulationAdjacencyMatrixWriter.cpp
@@ -74,11 +74,8 @@ void CellPopulationAdjacencyMatrixWriter<ELEMENT_DIM, SPACE_DIM>::VisitAnyPopula
     assert(local_cell_id == num_cells);
 
     // Iterate over cells and calculate the adjacency matrix (stored as a long vector)
+    // Note that std::vector value-initialises its elements, so the matrix starts out zeroed
     std::vector<double> adjacency_matrix(num_cells*num_cells);
-    for (unsigned i=0; i<num_cells*num_cells; i++)
-    {
-        adjacency_matrix[i] = 0;
-    }
 
     for (typename AbstractCellPopulation<SPACE_DIM, SPACE_DIM>::Iterator cell_iter = pCellPopulation->Begin();
          cell_iter != pCellPopulation->End();
@@ -158,11 +155,8 @@ void CellPopulationAdjacencyMatrixWriter<ELEMENT_DIM, SPACE_DIM>::Visit(MeshBase
     assert(local_cell_id == num_cells);
 
     // Iterate over cells and calculate the adjacency matrix (stored as a long vector)
+    // Note that std::vector value-initialises its elements, so the matrix starts out zeroed
     std::vector<double> adjacency_matrix(num_cells*num_cells);
-    for (unsigned i=0; i<num_cells*num_cells; i++)
-    {
-        adjacency_matrix[i] = 0;
-    }
 
     for (typename AbstractCellPopulation<ELEMENT_DIM, SPACE_DIM>::Iterator cell_iter = pCellPopulation->Begin();
          cell_iter != pCellPopulation->End();

--- a/global/src/RandomNumberGenerator.cpp
+++ b/global/src/RandomNumberGenerator.cpp
@@ -33,6 +33,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <numeric>
+
 #include "RandomNumberGenerator.hpp"
 #include "Exception.hpp"
 
@@ -164,10 +166,7 @@ void RandomNumberGenerator::Reseed(unsigned seed)
 void RandomNumberGenerator::Shuffle(unsigned num, std::vector<unsigned>& rValues)
 {
     rValues.resize(num);
-    for (unsigned i = 0; i < num; i++)
-    {
-        rValues[i] = i;
-    }
+    std::iota(rValues.begin(), rValues.end(), 0u);
 
     for (unsigned end = num - 1; end > 0; end--)
     {

--- a/global/src/VectorHelperFunctions.hpp
+++ b/global/src/VectorHelperFunctions.hpp
@@ -473,8 +473,7 @@ inline void CopyFromStdVector(const std::vector<double>& rSrc, N_Vector& rDest)
     if (p_dest == rSrc.data()) return;
 
     // Check dest size
-    long size = NV_LENGTH_S(rDest);
-    assert(size == (long)rSrc.size());
+    assert(NV_LENGTH_S(rDest) == (long)rSrc.size());
 
     // Copy data
     std::copy(rSrc.begin(), rSrc.end(), p_dest);

--- a/global/src/VectorHelperFunctions.hpp
+++ b/global/src/VectorHelperFunctions.hpp
@@ -44,6 +44,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * AbstractParameterisedSystem and some tests.
  */
 
+#include <algorithm>
 #include <cassert>
 #include <vector>
 
@@ -455,10 +456,7 @@ inline void CopyToStdVector(const N_Vector& rSrc, std::vector<double>& rDest)
     long size = NV_LENGTH_S(rSrc);
     rDest.resize(size);
     // Copy data
-    for (long i = 0; i < size; i++)
-    {
-        rDest[i] = p_src[i];
-    }
+    std::copy(p_src, p_src + size, rDest.begin());
 }
 
 /**
@@ -479,10 +477,7 @@ inline void CopyFromStdVector(const std::vector<double>& rSrc, N_Vector& rDest)
     assert(size == (long)rSrc.size());
 
     // Copy data
-    for (long i = 0; i < size; i++)
-    {
-        p_dest[i] = rSrc[i];
-    }
+    std::copy(rSrc.begin(), rSrc.end(), p_dest);
 }
 
 /**

--- a/global/src/parallel/ReplicatableVector.cpp
+++ b/global/src/parallel/ReplicatableVector.cpp
@@ -33,6 +33,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <algorithm>
+
 #include "ReplicatableVector.hpp"
 #include "Exception.hpp"
 #include "PetscTools.hpp"
@@ -189,8 +191,5 @@ void ReplicatableVector::ReplicatePetscVector(Vec vec)
     // Copy into mData
     double* p_replicated;
     VecGetArray(mReplicated, &p_replicated);
-    for (unsigned i=0; i<size; i++)
-    {
-        mpData[i] = p_replicated[i];
-    }
+    std::copy(p_replicated, p_replicated + size, mpData);
 }

--- a/heart/src/solver/electrics/AbstractCorrectionTermAssembler.cpp
+++ b/heart/src/solver/electrics/AbstractCorrectionTermAssembler.cpp
@@ -33,6 +33,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <algorithm>
+
 #include "AbstractCorrectionTermAssembler.hpp"
 #include <typeinfo>
 
@@ -84,10 +86,7 @@ void AbstractCorrectionTermAssembler<ELEMENT_DIM,SPACE_DIM,PROBLEM_DIM>::ResetIn
 {
     // reset ionic current, and state variables
     mIionicInterp = 0;
-    for (unsigned i=0; i<mStateVariablesAtQuadPoint.size(); i++)
-    {
-        mStateVariablesAtQuadPoint[i] = 0;
-    }
+    std::fill(mStateVariablesAtQuadPoint.begin(), mStateVariablesAtQuadPoint.end(), 0.0);
 }
 
 template<unsigned ELEMENT_DIM, unsigned SPACE_DIM, unsigned PROBLEM_DIM>

--- a/heart/src/stimulus/tissue_electrodes/ElectrodesStimulusFactory.cpp
+++ b/heart/src/stimulus/tissue_electrodes/ElectrodesStimulusFactory.cpp
@@ -33,6 +33,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <algorithm>
+
 #include "ElectrodesStimulusFactory.hpp"
 #include "DistributedTetrahedralMesh.hpp"
 #include "HeartConfig.hpp"
@@ -96,20 +98,13 @@ void ElectrodesStimulusFactory<DIM>::CheckForElectrodesIntersection()
         }
     }
     PetscTools::Barrier();
-    for (unsigned node_index = 0; node_index < nodes_in_all_electrodes.size(); node_index++)
+    // A node collected twice belongs to two electrodes. Sorting makes any duplicates
+    // adjacent, which replaces the previous O(n^2) pairwise scan with O(n log n).
+    std::sort(nodes_in_all_electrodes.begin(), nodes_in_all_electrodes.end());
+    if (std::adjacent_find(nodes_in_all_electrodes.begin(), nodes_in_all_electrodes.end())
+        != nodes_in_all_electrodes.end())
     {
-        unsigned number_of_hits = 0;
-        for (unsigned node_to_check = 0; node_to_check < nodes_in_all_electrodes.size(); node_to_check++)
-        {
-            if (nodes_in_all_electrodes[node_index] == nodes_in_all_electrodes[node_to_check] )
-            {
-                number_of_hits++;
-            }
-        }
-        if (number_of_hits>1)
-        {
-            EXCEPTION("Two or more electrodes intersect with each other");
-        }
+        EXCEPTION("Two or more electrodes intersect with each other");
     }
 }
 

--- a/linalg/src/FourthOrderTensor.hpp
+++ b/linalg/src/FourthOrderTensor.hpp
@@ -36,6 +36,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef _FOURTHORDERTENSOR_HPP_
 #define _FOURTHORDERTENSOR_HPP_
 
+#include <algorithm>
 #include <cassert>
 #include <vector>
 
@@ -351,10 +352,7 @@ double& FourthOrderTensor<DIM1,DIM2,DIM3,DIM4>::operator()(unsigned M, unsigned 
 template<unsigned DIM1, unsigned DIM2, unsigned DIM3, unsigned DIM4>
 void FourthOrderTensor<DIM1,DIM2,DIM3,DIM4>::Zero()
 {
-    for (unsigned i=0; i<mData.size(); i++)
-    {
-        mData[i] = 0.0;
-    }
+    std::fill(mData.begin(), mData.end(), 0.0);
 }
 
 #endif //_FOURTHORDERTENSOR_HPP_

--- a/lung/src/airway_generation/MultiLobeAirwayGenerator.cpp
+++ b/lung/src/airway_generation/MultiLobeAirwayGenerator.cpp
@@ -34,6 +34,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 
+#include <algorithm>
+
 #include <map>
 
 #include "MultiLobeAirwayGenerator.hpp"
@@ -98,20 +100,10 @@ void MultiLobeAirwayGenerator::AddLobe(vtkSmartPointer<vtkPolyData> pLobeSurface
 
 unsigned MultiLobeAirwayGenerator::GetNumLobes(LungLocation lungLocation)
 {
-    unsigned lobe_count = 0u;
-
     typedef std::pair<AirwayGenerator*, LungLocation> pair_type;
-    for (std::vector<pair_type>::iterator generators_iter = mLobeGenerators.begin();
-         generators_iter != mLobeGenerators.end();
-         ++generators_iter)
-    {
-        if (generators_iter->second == lungLocation)
-        {
-            lobe_count++;
-        }
-    }
-
-    return lobe_count;
+    return static_cast<unsigned>(std::count_if(mLobeGenerators.begin(), mLobeGenerators.end(),
+                                               [lungLocation](const pair_type& rGenerator)
+                                               { return rGenerator.second == lungLocation; }));
 }
 
 void MultiLobeAirwayGenerator::AssignGrowthApices()

--- a/mesh/src/common/DistributedTetrahedralMesh.cpp
+++ b/mesh/src/common/DistributedTetrahedralMesh.cpp
@@ -1493,10 +1493,9 @@ void DistributedTetrahedralMesh<ELEMENT_DIM, SPACE_DIM>::ParMetisLibraryNodeAndE
         mpi_idx_t = MPI_INT;
     }
     boost::scoped_array<int> int_element_distribution(new int[num_procs+1]);
-    for (unsigned i=0; i<num_procs+1; ++i)
-    {
-        int_element_distribution[i] = element_distribution[i];
-    }
+    // Note the deliberate narrowing from idx_t (64 bit on Windows) to int for the MPI call
+    std::copy(element_distribution.get(), element_distribution.get() + num_procs + 1,
+              int_element_distribution.get());
     MPI_Allgatherv(local_partition.get(), num_local_elements, mpi_idx_t,
                    global_element_partition.get(), element_counts.get(), int_element_distribution.get(), mpi_idx_t, PETSC_COMM_WORLD);
 

--- a/mesh/src/common/NodePartitioner.cpp
+++ b/mesh/src/common/NodePartitioner.cpp
@@ -32,6 +32,8 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
 OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
+#include <numeric>
+
 #include <cassert>
 #include <algorithm>
 
@@ -274,10 +276,7 @@ void NodePartitioner<ELEMENT_DIM, SPACE_DIM>::PetscMatrixPartitioning(AbstractMe
 
     // Once we know the offsets we can compute the permutation vector
     PetscInt* global_range = new PetscInt[num_nodes];
-    for (unsigned i=0; i<num_nodes; i++)
-    {
-        global_range[i] = i;
-    }
+    std::iota(global_range, global_range + num_nodes, 0);
     AOPetscToApplication(ordering, num_nodes, global_range);
 
     rNodePermutation.resize(num_nodes);

--- a/mesh/src/common/NodesOnlyMesh.cpp
+++ b/mesh/src/common/NodesOnlyMesh.cpp
@@ -33,6 +33,8 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <algorithm>
+
 #include <map>
 #include "NodesOnlyMesh.hpp"
 #include "ChasteCuboid.hpp"
@@ -103,10 +105,8 @@ void NodesOnlyMesh<SPACE_DIM>::ConstructNodesWithoutMesh(const std::vector<boost
 {
     // This is not efficient. It should replace the corresponding raw ptr method if SetUpBoxCollection and Chaste Cuboid methods are changed to take shared ptrs.
     std::vector<Node<SPACE_DIM>*> temp_nodes(rNodes.size());
-    for (unsigned idx = 0; idx < rNodes.size(); idx++)
-    {
-        temp_nodes[idx] = rNodes[idx].get();
-    }
+    std::transform(rNodes.begin(), rNodes.end(), temp_nodes.begin(),
+                   [](const boost::shared_ptr<Node<SPACE_DIM> >& pNode) { return pNode.get(); });
 
     ConstructNodesWithoutMesh(temp_nodes, maxInteractionDistance);
 }

--- a/mesh/src/utilities/DistanceMapCalculator.cpp
+++ b/mesh/src/utilities/DistanceMapCalculator.cpp
@@ -78,11 +78,7 @@ void DistanceMapCalculator<ELEMENT_DIM, SPACE_DIM>::ComputeDistanceMap(
         const std::vector<unsigned>& rSourceNodeIndices,
         std::vector<double>& rNodeDistances)
 {
-    rNodeDistances.resize(mNumNodes);
-    for (unsigned index=0; index<mNumNodes; index++)
-    {
-        rNodeDistances[index] = DBL_MAX;
-    }
+    rNodeDistances.assign(mNumNodes, DBL_MAX);
     assert(mActivePriorityNodeIndexQueue.empty());
 
     if (mSingleTarget)

--- a/mesh/src/writer/CmguiDeformedSolutionsWriter.cpp
+++ b/mesh/src/writer/CmguiDeformedSolutionsWriter.cpp
@@ -33,6 +33,9 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
+#include <algorithm>
+#include <iterator>
+
 #include "CmguiDeformedSolutionsWriter.hpp"
 #include "Exception.hpp"
 
@@ -90,10 +93,7 @@ CmguiDeformedSolutionsWriter<DIM>::CmguiDeformedSolutionsWriter(std::string outp
                 // QuadraticBasisFunction::ComputeBasisFunction() to CMGUI ordering
                 // ("psi1 increasing, then psi1 increasing")
                 unsigned reordering[6] = {0,5,1,4,3,2};
-                for (unsigned i=0; i<6; i++)
-                {
-                    this->mReordering[i] = reordering[i];
-                }
+                std::copy(std::begin(reordering), std::end(reordering), this->mReordering.begin());
                 break;
             }
             case 3:
@@ -108,10 +108,7 @@ CmguiDeformedSolutionsWriter<DIM>::CmguiDeformedSolutionsWriter(std::string outp
                 // QuadraticBasisFunction::ComputeBasisFunction() to CMGUI ordering
                 // ("psi1 increasing, then psi2 increasing, then psi3 increasing")
                 unsigned reordering[10] = {0,4,1,6,5,2,7,8,9,3};
-                for (unsigned i=0; i<10; i++)
-                {
-                    this->mReordering[i] = reordering[i];
-                }
+                std::copy(std::begin(reordering), std::end(reordering), this->mReordering.begin());
                 break;
             }
             default:


### PR DESCRIPTION
Closes #648

Part of the manual-loop cleanup. Branch: `cleanup/std-fill-copy-iota` (one commit on top of `develop`).

**`std::iota`**
- `RandomNumberGenerator::Shuffle`'s identity initialisation
- `NodePartitioner`'s `global_range`

**`std::fill` / `std::fill_n` / `assign`**
- `DistanceMapCalculator::ComputeDistanceMap` — resize-then-fill becomes one `assign`
- `FourthOrderTensor::Zero`
- `AbstractCorrectionTermAssembler::ResetInterpolatedQuantities`
- `CaBasedCellPopulation`'s per-site counter — a `scoped_array` from `new[]`, so this one genuinely *does* need zeroing

**Deleted outright — `std::vector` already value-initialises its elements, so these loops were dead code**
- `AbstractCellPopulation::GetCellCyclePhaseCount`
- `CellPopulationAdjacencyMatrixWriter` (both overloads)

**`std::copy`**
- `ReplicatableVector::Replicate`
- `CopyToStdVector` / `CopyFromStdVector` for `N_Vector` in `VectorHelperFunctions`
- `DistributedTetrahedralMesh`'s `idx_t`→`int` conversion for MPI (the narrowing is deliberate and now commented)
- `CmguiDeformedSolutionsWriter`'s two node reordering tables

**`std::transform`**
- `NodesOnlyMesh::ConstructNodesWithoutMesh` — `shared_ptr` to raw pointer

**`std::count_if`**
- `MultiLobeAirwayGenerator::GetNumLobes`

**`std::sort` + `std::adjacent_find` — also an efficiency fix**
- `ElectrodesStimulusFactory::CheckForElectrodesIntersection` was an **O(n²)** pairwise duplicate scan over every node in every electrode; it is now O(n log n). The vector is local and discarded immediately afterwards, so sorting it in place is safe. This is the one change in the whole set with a real performance benefit rather than just readability.

**Files:** 15 changed, +49 / -91.

---

### Review notes

- One commit, based on current `develop`. This is one of six sibling PRs from #650; all six were test-merged into `develop` in sequence and **do not conflict** with each other, so they can go in in any order.
- **Not yet compiled.** There was no build tree available where this was prepared, so this needs a CI run before it is trusted. See #650 for the full list of caveats that shaped these changes.
- No test reference data should need regenerating: summation order and floating-point results are unchanged throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
